### PR TITLE
Add target/ directory to .gitignore to ignore ruling test SonarQube b…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .gradle/
 build/
 
+# ---- Maven / orchestrator 
+target/
+
 # ---- SonarQube analysis
 .scannerwork/
 .sonar/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .gradle/
 build/
 
-# ---- Maven / orchestrator 
+# ---- Orchestrator
 its/ruling/target/
 its/plugin/target/
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 build/
 
 # ---- Maven / orchestrator 
-target/
+its/ruling/target/
+its/plugin/target/
 
 # ---- SonarQube analysis
 .scannerwork/
@@ -38,4 +39,3 @@ Thumbs.db
 Desktop.ini
 
 .java-version
-


### PR DESCRIPTION
In the ITs the required SQ binaries are stored in `target/`. Let's ignore them.