### PR TITLE
SONARKT-68 Fixing S5324 FNs

### DIFF
--- a/kotlin-checks-test-sources/src/main/kotlin/checks/ExternalAndroidStorageAccessCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/ExternalAndroidStorageAccessCheckSample.kt
@@ -14,7 +14,7 @@ class ExternalAndroidStorageAccessCheckSample {
         env.getDownloadCacheDirectory() // ok
     }
 
-    fun contextNoncompliant(ctx: Context) {
+    fun contextNoncompliant(ctx: Context, cc: ContextChild) {
         ctx.getExternalFilesDir("") // Noncompliant
         ctx.getExternalFilesDirs("") // Noncompliant
         ctx.externalCacheDir // Noncompliant
@@ -28,6 +28,19 @@ class ExternalAndroidStorageAccessCheckSample {
         ctx.getObbDir() // Noncompliant
         ctx.obbDirs // Noncompliant
         ctx.getObbDirs() // Noncompliant
+
+        cc.getExternalFilesDir("") // Noncompliant
+        cc.getExternalFilesDirs("") // Noncompliant
+        cc.externalCacheDir // Noncompliant
+        cc.getExternalCacheDir() // Noncompliant
+        cc.externalCacheDirs // Noncompliant
+        cc.getExternalCacheDirs() // Noncompliant
+        cc.externalMediaDirs // Noncompliant
+        cc.getExternalMediaDirs() // Noncompliant
+        cc.obbDir // Noncompliant
+        cc.getObbDir() // Noncompliant
+        cc.obbDirs // Noncompliant
+        cc.getObbDirs() // Noncompliant
     }
 
     fun contextCompliant(ctx: Context) {
@@ -35,3 +48,5 @@ class ExternalAndroidStorageAccessCheckSample {
         ctx.getCompliantDir()
     }
 }
+
+class ContextChild: Context()

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/checks/ExternalAndroidStorageAccessCheck.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/checks/ExternalAndroidStorageAccessCheck.kt
@@ -15,13 +15,13 @@ import org.sonarsource.kotlin.plugin.KotlinFileContext
 private const val MESSAGE = "Make sure accessing the Android external storage is safe here."
 
 private val HOTSPOT_FUNS = listOf(
-    FunMatcher(qualifier = "android.os.Environment") {
+    FunMatcher(definingSupertype = "android.os.Environment") {
         withNames(
             "getExternalStorageDirectory",
             "getExternalStoragePublicDirectory"
         )
     },
-    FunMatcher(qualifier = "android.content.Context") {
+    FunMatcher(definingSupertype = "android.content.Context") {
         withNames(
             "getExternalFilesDir",
             "getExternalFilesDirs",


### PR DESCRIPTION
Matching also on super types when calling methods that access Android external storage to avoid FNs when the method called actually belongs to a subtype of Context or Environment