### PR TITLE
Fix version number generation for ws scan

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -152,8 +152,7 @@ ws_scan_task:
   whitesource_script:
     - source cirrus-env QA
     - ./gradlew clean build -x test
-    - ./export_ws_variables.sh > ws.env
-    - source ws.env
+    - source ./export_ws_variables.sh
     - source ws_scan.sh
   allow_failures: "true"
   always:

--- a/export_ws_variables.sh
+++ b/export_ws_variables.sh
@@ -2,20 +2,22 @@
 
 set -euox pipefail
 
-get_version() {
- local version_property
- version_property=$(./gradlew properties | grep --extended-regexp "^version: (.*)")
- if [[ -z "${version_property}" ]]; then
-   echo "Could not find property version in project" >&2
-   exit 2
- fi
- local version
- version=$(echo "${version_property}" | tr --delete "[:space:]" | cut --delimiter=":" --fields=2)
- echo "${version%-*}"
+get_project_version() {
+  local version_property
+  version_property=$(./gradlew properties | grep --extended-regexp "^version: (.*)")
+  if [[ -z "${version_property}" ]]; then
+    echo "Could not find property version in project" >&2
+    exit 2
+  fi
+  local version
+  version=$(echo "${version_property}" | tr --delete "[:space:]" | cut --delimiter=":" --fields=2)
+  version="${version/-SNAPSHOT/}"
+  # Because the ws scan script expects a semver-like version (aa.bb.cc.XX), we append the build number to the project version.
+  if [[ "${version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    version="${version}.0"
+  fi
+  version="${version}.${BUILD_NUMBER:-0}"
+  echo "${version}"
 }
 
-main() {
-  echo "export PROJECT_VERSION=$(get_version)"
-}
-
-main "$@"
+export PROJECT_VERSION="$(get_project_version)"

--- a/wss-unified-agent.config
+++ b/wss-unified-agent.config
@@ -5,7 +5,6 @@ resolveAllDependencies=False
 gradle.aggregateModules=True
 gradle.preferredEnvironment=wrapper
 gradle.resolveDependencies=True
-gradle.runPreStep=False
 
 maven.aggregateModules=False
 maven.downloadMissingDependencies=False


### PR DESCRIPTION
The scan script expects a semver-like version number where the bugfix is
trimmed off in the end.
To this end, the build number (or 0 when it is not available) is
appended to the version number.