### PR TITLE
SONARKT-15 Introduce Kotlin source version property

### DIFF
--- a/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
@@ -2,8 +2,7 @@ package checks
 
 @Deprecated("Some text")
 enum class MyEnumClass(val value: String) {
-    ENTRY1(""), // Noncompliant
-//        ^
+    ENTRY1(""), // Compliant (FN?) since Kotlin 1.7, where the compiler doesn't seem to find this anymore.
 }
 
 class Example : DeprecatedCode() // Noncompliant {{Deprecated code should not be used.}}
@@ -12,14 +11,14 @@ class Example : DeprecatedCode() // Noncompliant {{Deprecated code should not be
     @DeprecatedAnnotation() // Noncompliant
 //   ^^^^^^^^^^^^^^^^^^^^
 class DeprecatedCodeUsedCheckSample {
-    
+
     fun usesDeprecated(kStr: DeprecatedString): String { // Noncompliant
 //                           ^^^^^^^^^^^^^^^^
-        
+
         //Noncompliant@+1
         val d = DeprecatedCode("") // Noncompliant
 //              ^^^^^^^^^^^^^^
-        
+
         d.prop // Noncompliant
 //        ^^^^
 
@@ -33,11 +32,11 @@ class DeprecatedCodeUsedCheckSample {
 
         deprecatedFunction() // Noncompliant
 //      ^^^^^^^^^^^^^^^^^^
-        
+
         return kStr - "" // Noncompliant
-//             ^^^^^^^^^        
+//             ^^^^^^^^^
     }
-    
+
 }
 
 @Deprecated("")

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/converter/KotlinCodeVerifier.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/converter/KotlinCodeVerifier.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiErrorElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
 import org.jetbrains.kotlin.psi.KtCollectionLiteralExpression
@@ -97,7 +98,7 @@ class KotlinCodeVerifier {
         return if (words < 2 || isKDoc(content)) {
             false
         } else {
-            val environment = Environment(emptyList())
+            val environment = Environment(emptyList(), LanguageVersion.LATEST_STABLE)
             try {
                 val wrappedContent = "fun function () { $content }"
 

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/converter/KotlinCoreEnvironmentTools.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/converter/KotlinCoreEnvironmentTools.kt
@@ -44,9 +44,9 @@ import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
 import java.io.File
 
-class Environment(val classpath: List<String>) {
+class Environment(val classpath: List<String>, kotlinLanguageVersion: LanguageVersion, javaLanguageVersion: JvmTarget = JvmTarget.JVM_1_8) {
     val disposable = Disposer.newDisposable()
-    val configuration = compilerConfiguration(classpath, LanguageVersion.KOTLIN_1_5, JvmTarget.JVM_1_8)
+    val configuration = compilerConfiguration(classpath, kotlinLanguageVersion, javaLanguageVersion)
     val env = kotlinCoreEnvironment(configuration, disposable)
     val ktPsiFactory: KtPsiFactory = KtPsiFactory(env.project, false)
 }

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/api/ApiExtensionsKtTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/api/ApiExtensionsKtTest.kt
@@ -22,6 +22,7 @@ package org.sonarsource.kotlin.api
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -261,7 +262,7 @@ class ApiExtensionsKtDetermineTypeTest {
 
 private fun parse(code: String) = kotlinTreeOf(
     code,
-    Environment(listOf("build/classes/kotlin/main")),
+    Environment(listOf("build/classes/kotlin/main"), LanguageVersion.LATEST_STABLE),
     TestInputFileBuilder("moduleKey", "src/org/foo/kotlin.kt")
         .setCharset(StandardCharsets.UTF_8)
         .initMetadata(code)

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/api/FunMatcherTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/api/FunMatcherTest.kt
@@ -20,6 +20,7 @@
 package org.sonarsource.kotlin.api
 
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
@@ -37,7 +38,7 @@ import java.nio.file.Paths
 
 class FunMatcherTest {
 
-    val environment = Environment(listOf("../kotlin-checks-test-sources/build/classes/kotlin/main"))
+    val environment = Environment(listOf("../kotlin-checks-test-sources/build/classes/kotlin/main"), LanguageVersion.LATEST_STABLE)
     val path = Paths.get("../kotlin-checks-test-sources/src/main/kotlin/sample/functions.kt")
     val content = String(Files.readAllBytes(path))
     val inputFile = TestInputFileBuilder("moduleKey",  "src/org/foo/kotlin.kt")

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/api/regex/TextRangeTrackerTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/api/regex/TextRangeTrackerTest.kt
@@ -21,6 +21,7 @@ package org.sonarsource.kotlin.api.regex
 
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.ObjectAssert
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.junit.jupiter.api.Test
@@ -93,7 +94,7 @@ internal class TextRangeTrackerTest {
             val x = 
             $regex
         """.trimIndent(),
-            environment = Environment(emptyList()),
+            environment = Environment(emptyList(), LanguageVersion.LATEST_STABLE),
             inputFile = DummyInputFile()
         )
 

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/converter/KotlinASTTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/converter/KotlinASTTest.kt
@@ -20,6 +20,7 @@
 package org.sonarsource.kotlin.converter
 
 import org.assertj.core.api.Assertions
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.psi.KtFile
 import org.junit.jupiter.api.Test
 import org.sonarsource.kotlin.dev.AstPrinter
@@ -30,7 +31,7 @@ import java.nio.file.Path
 import java.util.stream.Collectors
 import kotlin.io.path.readText
 
-private val environment = Environment(emptyList())
+private val environment = Environment(emptyList(), LanguageVersion.LATEST_STABLE)
 
 fun main() {
     fix_all_cls_files_test_automatically()

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/converter/KotlinSyntaxStructureTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/converter/KotlinSyntaxStructureTest.kt
@@ -23,6 +23,7 @@ import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.resolve.BindingContextUtils
 import org.jetbrains.kotlin.utils.KotlinExceptionWithAttachments
 import org.junit.jupiter.api.AfterEach
@@ -51,7 +52,7 @@ internal class KotlinSyntaxStructureTest {
         every { BindingContextUtils.getRecordedTypeInfo(any(), any()) } throws expectedException
 
         val content = path.readText()
-        val environment = Environment(System.getProperty("java.class.path").split(":"))
+        val environment = Environment(System.getProperty("java.class.path").split(":"), LanguageVersion.LATEST_STABLE)
         val inputFile = TestInputFileBuilder("moduleKey", path.toString())
             .setCharset(StandardCharsets.UTF_8)
             .initMetadata(content).build()
@@ -68,7 +69,7 @@ internal class KotlinSyntaxStructureTest {
     fun `ensure ktfile name is properly set`() {
         val path = Path.of("src/test/resources/api/sample/SimpleClass.kt")
         val content = path.readText()
-        val environment = Environment(listOf("../kotlin-checks-test-sources/build/classes/kotlin/main"))
+        val environment = Environment(listOf("../kotlin-checks-test-sources/build/classes/kotlin/main"), LanguageVersion.LATEST_STABLE)
 
         val inputFile = TestInputFileBuilder("moduleKey", path.toString())
             .setCharset(StandardCharsets.UTF_8)

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/converter/KotlinTreeTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/converter/KotlinTreeTest.kt
@@ -22,6 +22,7 @@ package org.sonarsource.kotlin.converter
 import java.nio.file.Files
 import java.nio.file.Path
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.junit.jupiter.api.Test
@@ -33,9 +34,9 @@ class KotlinTreeTest {
 
   @Test
   fun testCreateKotlinTree() {
-    val environment = Environment(listOf("../kotlin-checks-test-sources/build/classes/kotlin/main"))
+    val environment = Environment(listOf("../kotlin-checks-test-sources/build/classes/kotlin/main"), LanguageVersion.LATEST_STABLE)
     val path = Path.of("../kotlin-checks-test-sources/src/main/kotlin/sample/functions.kt")
-    val content = String(Files.readAllBytes(path))   
+    val content = String(Files.readAllBytes(path))
     val inputFile = TestInputFileBuilder("moduleKey",  "src/org/foo/kotlin.kt")
       .setCharset(StandardCharsets.UTF_8)
       .initMetadata(content)

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/dev/AstPrinterTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/dev/AstPrinterTest.kt
@@ -21,6 +21,7 @@ package org.sonarsource.kotlin.dev
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.util.Files
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.sonarsource.kotlin.converter.Environment
@@ -30,7 +31,7 @@ import kotlin.io.path.readText
 private val INPUT_FILE = Path.of("src", "test", "resources", "ast-printing", "TestFileToPrintAstFor.kt").toAbsolutePath()
 private val EXPECTED_DOT_OUTPUT = Path.of("src", "test", "resources", "ast-printing", "TestFileToPrintAstFor.dot")
 private val EXPECTED_TXT_OUTPUT = Path.of("src", "test", "resources", "ast-printing", "TestFileToPrintAstFor.txt")
-private val INPUT_KT = Environment(emptyList()).ktPsiFactory.createFile(INPUT_FILE.readText())
+private val INPUT_KT = Environment(emptyList(), LanguageVersion.LATEST_STABLE).ktPsiFactory.createFile(INPUT_FILE.readText())
 
 class AstPrinterTest {
 

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/CopyPasteDetectorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/CopyPasteDetectorTest.kt
@@ -21,6 +21,7 @@ package org.sonarsource.kotlin.plugin
 
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.ObjectAssert
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder
@@ -62,7 +63,7 @@ class CopyPasteDetectorTest {
             .setContents(content)
             .build()
 
-        val root = kotlinTreeOf(content, Environment(emptyList()), inputFile)
+        val root = kotlinTreeOf(content, Environment(emptyList(), LanguageVersion.LATEST_STABLE), inputFile)
         val ctx = InputFileContextImpl(sensorContext, inputFile, false)
         CopyPasteDetector().scan(ctx, root)
 

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/CyclomaticComplexityVisitorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/CyclomaticComplexityVisitorTest.kt
@@ -22,6 +22,7 @@ package org.sonarsource.kotlin.plugin
 import org.assertj.core.api.Assertions
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtLoopExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -141,7 +142,7 @@ internal class CyclomaticComplexityVisitorTest {
     }
 
     private fun getComplexityTrees(content: String): List<PsiElement> {
-        val env = Environment(emptyList())
+        val env = Environment(emptyList(), LanguageVersion.LATEST_STABLE)
         val ktFile = env.ktPsiFactory.createFile(content)
         val cyclomaticComplexityVisitor = CyclomaticComplexityVisitor()
         ktFile.accept(cyclomaticComplexityVisitor)

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/IssueSuppressionVisitorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/IssueSuppressionVisitorTest.kt
@@ -19,6 +19,7 @@
  */
 package org.sonarsource.kotlin.plugin
 
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.junit.jupiter.api.Test
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder
 import org.sonarsource.analyzer.commons.checks.verifier.SingleFileVerifier
@@ -58,7 +59,7 @@ class IssueSuppressionVisitorTest {
         scanFile(path, false, BadClassNameCheck(), BadFunctionNameCheck(), VariableAndParameterNameCheck(), UnusedLocalVariableCheck())
 
     private fun scanFile(path: Path, suppress: Boolean, check: AbstractCheck, vararg checks: AbstractCheck): SingleFileVerifier {
-        val env = Environment(DEFAULT_KOTLIN_CLASSPATH)
+        val env = Environment(DEFAULT_KOTLIN_CLASSPATH, LanguageVersion.LATEST_STABLE)
         val verifier = SingleFileVerifier.create(path, StandardCharsets.UTF_8)
         val testFileContent = String(Files.readAllBytes(path), StandardCharsets.UTF_8)
         val inputFile = TestInputFileBuilder("moduleKey",  "src/org/foo/kotlin.kt")

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinPluginTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinPluginTest.kt
@@ -20,6 +20,7 @@
 package org.sonarsource.kotlin.plugin
 
 import org.assertj.core.api.Assertions
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.junit.jupiter.api.Test
 import org.sonar.api.SonarEdition
 import org.sonar.api.SonarQubeSide
@@ -48,18 +49,18 @@ internal class KotlinPluginTest {
         kotlinPlugin.define(context)
         Assertions.assertThat(context.extensions).hasSize(4)
     }
-    
+
     @Test
     fun test_android_context() {
-        val environment = Environment(listOf("../kotlin-checks-test-sources/build/classes/java/main"))
-        
+        val environment = Environment(listOf("../kotlin-checks-test-sources/build/classes/java/main"), LanguageVersion.LATEST_STABLE)
+
         Assertions.assertThat(isInAndroidContext(environment)).isTrue
     }
-    
+
     @Test
     fun test_non_android_context() {
-        val environment = Environment(listOf("../kotlin-checks-test-sources/build/classes/kotlin/main"))
-        
+        val environment = Environment(listOf("../kotlin-checks-test-sources/build/classes/kotlin/main"), LanguageVersion.LATEST_STABLE)
+
         Assertions.assertThat(isInAndroidContext(environment)).isFalse
     }
 }

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
@@ -346,7 +346,7 @@ internal class KotlinSensorTest : AbstractSensorTest() {
     }
 
     @Test
-    fun `setting the kotlin version analyzer property to an invalid value results in log message and teh default version to be used`() {
+    fun `setting the kotlin version analyzer property to an invalid value results in log message and the default version to be used`() {
         logTester.setLevel(LoggerLevel.DEBUG)
 
         val sensorContext = mockk<SensorContext> {
@@ -362,6 +362,26 @@ internal class KotlinSensorTest : AbstractSensorTest() {
         assertThat(environment.configuration.languageVersionSettings.languageVersion).isSameAs(expectedKotlinVersion)
         assertThat(logTester.logs(LoggerLevel.WARN))
             .containsExactly("Failed to find Kotlin version 'foo'. Defaulting to ${expectedKotlinVersion.versionString}")
+        assertThat(logTester.logs(LoggerLevel.DEBUG))
+            .containsExactly("Using Kotlin ${expectedKotlinVersion.versionString} to parse source code")
+    }
+
+    @Test
+    fun `setting the kotlin version analyzer property to whitespaces only results in the default version to be used`() {
+        logTester.setLevel(LoggerLevel.DEBUG)
+
+        val sensorContext = mockk<SensorContext> {
+            every { config() } returns ConfigurationBridge(MapSettings().apply {
+                setProperty("sonar.kotlin.source.version", "  ")
+            })
+        }
+
+        val environment = environment(sensorContext)
+
+        val expectedKotlinVersion = LanguageVersion.KOTLIN_1_5
+
+        assertThat(environment.configuration.languageVersionSettings.languageVersion).isSameAs(expectedKotlinVersion)
+        assertThat(logTester.logs(LoggerLevel.WARN)).isEmpty()
         assertThat(logTester.logs(LoggerLevel.DEBUG))
             .containsExactly("Using Kotlin ${expectedKotlinVersion.versionString} to parse source code")
     }

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
@@ -26,41 +26,27 @@ import io.mockk.spyk
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
-import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.jetbrains.kotlin.cli.jvm.compiler.NoScopeRecordCliBindingTrace
-import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
-import org.jetbrains.kotlin.com.intellij.openapi.Disposable
-import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.config.CommonConfigurationKeys
-import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
-import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.sonar.api.batch.rule.CheckFactory
+import org.sonar.api.batch.sensor.SensorContext
 import org.sonar.api.batch.sensor.highlighting.TypeOfText
 import org.sonar.api.batch.sensor.issue.internal.DefaultNoSonarFilter
+import org.sonar.api.config.internal.ConfigurationBridge
 import org.sonar.api.config.internal.MapSettings
 import org.sonar.api.measures.CoreMetrics
 import org.sonar.api.utils.log.LoggerLevel
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.AbstractCheck
 import org.sonarsource.kotlin.converter.Environment
-import org.sonarsource.kotlin.converter.compilerConfiguration
 import org.sonarsource.kotlin.testing.AbstractSensorTest
 import org.sonarsource.kotlin.testing.assertTextRange
 import java.io.IOException
-import java.util.Optional
 import kotlin.time.ExperimentalTime
 
 @ExperimentalTime
@@ -189,7 +175,8 @@ internal class KotlinSensorTest : AbstractSensorTest() {
 
     @Test
     fun `Ensure compiler crashes during BindingContext generation don't crash engine`() {
-        val inputFile = createInputFile("file1.kt", """
+        val inputFile = createInputFile(
+            "file1.kt", """
         abstract class MyClass {
             abstract fun <P1> foo(): (P1) -> Unknown<String>
         
@@ -197,11 +184,12 @@ internal class KotlinSensorTest : AbstractSensorTest() {
                 println(foo<String>())
             }
         }
-        """.trimIndent())
+        """.trimIndent()
+        )
         context.fileSystem().add(inputFile)
 
         mockkStatic("org.sonarsource.kotlin.plugin.KotlinSensorKt")
-        every { environment(any()) } returns Environment(listOf("file1.kt"))
+        every { environment(any()) } returns Environment(listOf("file1.kt"), LanguageVersion.LATEST_STABLE)
 
         val checkFactory = checkFactory("S1764")
         assertDoesNotThrow { sensor(checkFactory).execute(context) }
@@ -317,6 +305,65 @@ internal class KotlinSensorTest : AbstractSensorTest() {
         assertDoesNotThrow { sensor.execute(context) }
         assertThat(logTester.logs(LoggerLevel.ERROR))
             .containsExactly("Cannot analyse 'file1.kt' with 'KtChecksVisitor': This is a test message")
+    }
+
+    @Test
+    fun `not setting the kotlin version analyzer property results in Environment with the default Kotlin version`() {
+        logTester.setLevel(LoggerLevel.DEBUG)
+
+        val sensorContext = mockk<SensorContext> {
+            every { config() } returns ConfigurationBridge(MapSettings())
+        }
+
+        val environment = environment(sensorContext)
+
+        val expectedKotlinVersion = LanguageVersion.KOTLIN_1_5
+
+        assertThat(environment.configuration.languageVersionSettings.languageVersion).isSameAs(expectedKotlinVersion)
+        assertThat(logTester.logs(LoggerLevel.WARN)).isEmpty()
+        assertThat(logTester.logs(LoggerLevel.DEBUG))
+            .containsExactly("Using Kotlin ${expectedKotlinVersion.versionString} to parse source code")
+    }
+
+    @Test
+    fun `setting the kotlin version analyzer property to a valid value is reflected in the Environment`() {
+        logTester.setLevel(LoggerLevel.DEBUG)
+
+        val sensorContext = mockk<SensorContext> {
+            every { config() } returns ConfigurationBridge(MapSettings().apply {
+                setProperty("sonar.kotlin.source.version", "1.3")
+            })
+        }
+
+        val environment = environment(sensorContext)
+
+        val expectedKotlinVersion = LanguageVersion.KOTLIN_1_3
+
+        assertThat(environment.configuration.languageVersionSettings.languageVersion).isSameAs(expectedKotlinVersion)
+        assertThat(logTester.logs(LoggerLevel.WARN)).isEmpty()
+        assertThat(logTester.logs(LoggerLevel.DEBUG))
+            .containsExactly("Using Kotlin ${expectedKotlinVersion.versionString} to parse source code")
+    }
+
+    @Test
+    fun `setting the kotlin version analyzer property to an invalid value results in log message and teh default version to be used`() {
+        logTester.setLevel(LoggerLevel.DEBUG)
+
+        val sensorContext = mockk<SensorContext> {
+            every { config() } returns ConfigurationBridge(MapSettings().apply {
+                setProperty("sonar.kotlin.source.version", "foo")
+            })
+        }
+
+        val environment = environment(sensorContext)
+
+        val expectedKotlinVersion = LanguageVersion.KOTLIN_1_5
+
+        assertThat(environment.configuration.languageVersionSettings.languageVersion).isSameAs(expectedKotlinVersion)
+        assertThat(logTester.logs(LoggerLevel.WARN))
+            .containsExactly("Failed to find Kotlin version 'foo'. Defaulting to ${expectedKotlinVersion.versionString}")
+        assertThat(logTester.logs(LoggerLevel.DEBUG))
+            .containsExactly("Using Kotlin ${expectedKotlinVersion.versionString} to parse source code")
     }
 
     private fun sensor(checkFactory: CheckFactory): KotlinSensor {

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/MetricVisitorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/MetricVisitorTest.kt
@@ -20,6 +20,7 @@
 package org.sonarsource.kotlin.plugin
 
 import org.assertj.core.api.Assertions
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -41,7 +42,7 @@ import kotlin.io.path.createTempFile
 import kotlin.io.path.name
 
 internal class MetricVisitorTest {
-    private val environment = Environment(emptyList())
+    private val environment = Environment(emptyList(), LanguageVersion.LATEST_STABLE)
     private lateinit var mockNoSonarFilter: NoSonarFilter
     private lateinit var visitor: MetricVisitor
     private lateinit var sensorContext: SensorContextTester

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/StatementsVisitorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/StatementsVisitorTest.kt
@@ -20,6 +20,7 @@
 package org.sonarsource.kotlin.plugin
 
 import org.assertj.core.api.Assertions
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.junit.jupiter.api.Test
 import org.sonarsource.kotlin.converter.Environment
 
@@ -59,7 +60,7 @@ internal class StatementsVisitorTest {
 }
 
 private fun statements(content: String): Int {
-    val ktFile = Environment(emptyList()).ktPsiFactory.createFile(content)
+    val ktFile = Environment(emptyList(), LanguageVersion.LATEST_STABLE).ktPsiFactory.createFile(content)
     val statementsVisitor = StatementsVisitor()
     ktFile.accept(statementsVisitor)
     return statementsVisitor.statements

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/verifier/KotlinVerifier.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/verifier/KotlinVerifier.kt
@@ -21,6 +21,7 @@ package org.sonarsource.kotlin.verifier
 
 import io.mockk.InternalPlatformDsl.toStr
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.sonar.api.batch.fs.InputFile
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder
 import org.sonarsource.analyzer.commons.checks.verifier.SingleFileVerifier
@@ -52,7 +53,7 @@ class KotlinVerifier(private val check: AbstractCheck) {
     var isAndroid = false
 
     fun verify() {
-        val environment = Environment(classpath + deps)
+        val environment = Environment(classpath + deps, LanguageVersion.LATEST_STABLE)
         val converter = { content: String ->
             val inputFile = TestInputFileBuilder("moduleKey", "src/org/foo/kotlin.kt")
                 .setCharset(StandardCharsets.UTF_8)
@@ -65,7 +66,7 @@ class KotlinVerifier(private val check: AbstractCheck) {
     }
 
     fun verifyNoIssue() {
-        val environment = Environment(classpath + deps)
+        val environment = Environment(classpath + deps, LanguageVersion.LATEST_STABLE)
         val converter = { content: String ->
             val inputFile = TestInputFileBuilder("moduleKey", "src/org/foo/kotlin.kt")
                 .setCharset(StandardCharsets.UTF_8)

--- a/utils-kotlin/src/main/kotlin/org/sonarsource/kotlin/ast/AstPrinter.kt
+++ b/utils-kotlin/src/main/kotlin/org/sonarsource/kotlin/ast/AstPrinter.kt
@@ -1,5 +1,6 @@
 package org.sonarsource.kotlin.ast
 
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.sonarsource.kotlin.converter.Environment
 import org.sonarsource.kotlin.dev.AstPrinter
 import java.nio.file.Path
@@ -14,7 +15,7 @@ fun main(vararg args: String) {
 
     val mode = args[0].lowercase()
     val inputFile = resolveDir(args[1])
-    val environment = Environment(emptyList())
+    val environment = Environment(emptyList(), LanguageVersion.LATEST_STABLE)
 
     val ktFile by lazy { environment.ktPsiFactory.createFile(inputFile.readText()) }
 


### PR DESCRIPTION
Introduce property that users can set to specify the Kotlin source code version they would like to scan their code with.