### PR TITLE
Fix link to linter versions in README

### DIFF
--- a/utils-kotlin/README.md
+++ b/utils-kotlin/README.md
@@ -8,14 +8,14 @@ third-party linters.
 
 To re-generate detekt's [`rules.json`](../sonar-kotlin-plugin/src/main/resources/org/sonar/l10n/kotlin/rules/detekt/rules.json):
 
-1. Update `detektVersion` property in [`build.gradle.kts`](build.gradle.kts)
+1. Update `detektVersion` property in [`gradle.properties`](../gradle.properties)
 1. Run `./gradlew utils-kotlin:updateDetektRules` from the project's root directory
 
 ### ktlint
 
 To re-generate ktlint's [`rules.json`](../sonar-kotlin-plugin/src/main/resources/org/sonar/l10n/kotlin/rules/ktlint/rules.json):
 
-1. Update `ktlintVersion` property in [`build.gradle.kts`](build.gradle.kts)
+1. Update `ktlintVersion` property in [`gradle.properties`](../gradle.properties)
 1. Run `./gradlew utils-kotlin:updateKtlintRules` from the project's root directory
 
 ### Android Lint


### PR DESCRIPTION
Just fixing links to the linter versions.