### PR TITLE
Add missing -SNAPSHOT key to version number 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.sonarsource.kotlin
-version=2.12.1
+version=2.12.1-SNAPSHOT
 description=Code Analyzer for Kotlin
 projectTitle=Kotlin
 kotlinVersion=1.7.10


### PR DESCRIPTION
Fix a bug where artifacts would be published without version number making it impossible to distinguish between build artifacts.

This would result in ITs in the CI the pipeline failing because the tests would run against mismatched versions of the kotlin analyzer.