### PR TITLE
[FIX] Remove trailing artifact that messes up build number replacement

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ allprojects {
     // Replaces the version defined in sources, usually x.y-SNAPSHOT, by a version identifying the build.
     if (project.version.toString().endsWith("-SNAPSHOT") && buildNumber != null) {
         val versionSuffix =
-            if (project.version.toString().count { it == '.' } == 1) ".0.$buildNumber" else ".$buildNumber}"
+            if (project.version.toString().count { it == '.' } == 1) ".0.$buildNumber" else ".$buildNumber"
         project.version = project.version.toString().replace("-SNAPSHOT", versionSuffix)
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.sonarsource.kotlin
-version=2.12.1
+version=2.12.1-SNAPSHOT
 description=Code Analyzer for Kotlin
 projectTitle=Kotlin
 kotlinVersion=1.7.10

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinSensor.kt
@@ -83,15 +83,15 @@ class KotlinSensor(
 
     override fun execute(sensorContext: SensorContext) {
         val sensorDuration = createPerformanceMeasureReport(sensorContext)
-        val contentHashCache = ContentHashCache.of(sensorContext)
         val fileSystem: FileSystem = sensorContext.fileSystem()
         val mainFilePredicate = fileSystem.predicates().and(
             fileSystem.predicates().hasLanguage(language.key),
             fileSystem.predicates().hasType(InputFile.Type.MAIN)
         )
 
-        val filesToAnalyze = fileSystem.inputFiles(mainFilePredicate).let { mainFiles ->
-            if (canSkipUnchangedFiles(sensorContext)) {
+        val filesToAnalyze: Iterable<InputFile> = fileSystem.inputFiles(mainFilePredicate).let { mainFiles ->
+            if (canSkipUnchangedFiles(sensorContext) && sensorContext.runtime().product != SonarProduct.SONARLINT) {
+                val contentHashCache = ContentHashCache.of(sensorContext)
                 LOG.debug("The Kotlin analyzer is running in a context where it can skip unchanged files.")
                 var totalFiles = 0
                 mainFiles

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
@@ -42,7 +42,9 @@ import org.sonar.api.batch.sensor.highlighting.TypeOfText
 import org.sonar.api.batch.sensor.issue.internal.DefaultNoSonarFilter
 import org.sonar.api.config.internal.ConfigurationBridge
 import org.sonar.api.config.internal.MapSettings
+import org.sonar.api.internal.SonarRuntimeImpl
 import org.sonar.api.measures.CoreMetrics
+import org.sonar.api.utils.Version
 import org.sonar.api.utils.log.LoggerLevel
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.DummyReadCache
@@ -593,6 +595,15 @@ internal class KotlinSensorTest : AbstractSensorTest() {
         val checkFactory = checkFactory("S1764")
         sensor(checkFactory).execute(context)
         assertThat(logTester.logs(LoggerLevel.WARN)).contains("Cannot copy key $key from cache as it has already been written")
+    }
+
+    @Test
+    fun `the kotlin sensor does not optimize analysis when running in SonarLint`() {
+        incrementalAnalysisFileSet()
+        context.setCanSkipUnchangedFiles(true)
+        val sonarLintRuntime = SonarRuntimeImpl.forSonarLint(Version.create(7, 0))
+        context.setRuntime(sonarLintRuntime)
+        assertAnalysisIsNotIncremental()
     }
 
     private fun assertAnalysisIsIncremental() {


### PR DESCRIPTION
Fix an issue where versions of the analyzer with an explicit bug fix number would have an extra `}` character added to them preventing them from being published in a repository and retrieved in later steps of the CI.