### PR TITLE
[FIX] Remove trailing artifact that messes up build number replacement

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ allprojects {
     // Replaces the version defined in sources, usually x.y-SNAPSHOT, by a version identifying the build.
     if (project.version.toString().endsWith("-SNAPSHOT") && buildNumber != null) {
         val versionSuffix =
-            if (project.version.toString().count { it == '.' } == 1) ".0.$buildNumber" else ".$buildNumber}"
+            if (project.version.toString().count { it == '.' } == 1) ".0.$buildNumber" else ".$buildNumber"
         project.version = project.version.toString().replace("-SNAPSHOT", versionSuffix)
     }
 


### PR DESCRIPTION
Fix an issue where versions of the analyzer with an explicit bug fix number would have an extra `}` character added to them preventing them from being published in a repository and retrieved in later steps of the CI.