### PR TITLE
BUILD-2700 Update gh-action_dogfood_merge version

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: dogfood
-        uses: SonarSource/gh-action_dogfood_merge@master
+        uses: SonarSource/gh-action_dogfood_merge@v1
         with:
           dogfood-branch: 'dogfood-on-peach'
       # Use the output from the `dogfood` step


### PR DESCRIPTION
# BUILD-2700 Update gh-action_dogfood_merge version

## Changes
* Use gh-action_dogfood_merge tag v1 (stable) instead of master 
   That way it no longer relies on master (unsafe) 
   (At the moment they are in sync but for future changes, it is better that way)