### PR TITLE
Upgrade to Kotlin 1.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ group=org.sonarsource.kotlin
 version=2.16-SNAPSHOT
 description=Code Analyzer for Kotlin
 projectTitle=Kotlin
-kotlinVersion=1.8.20
+kotlinVersion=1.9.0
 org.gradle.jvmargs=-Xmx4096M

--- a/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S100.json
+++ b/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S100.json
@@ -1,17 +1,17 @@
 {
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/test/java/com/example/android/observability/UserViewModelTest.kt':[
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/test/java/com/example/android/observability/UserViewModelTest.kt": [
 55,
 66,
-78,
+78
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/RepoDaoTest.kt':[
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/RepoDaoTest.kt": [
 81,
-88,
+88
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/repository/RepoRepositoryTest.kt':[
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/repository/RepoRepositoryTest.kt": [
 146,
 154,
 181,
-221,
-],
+221
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S1066.json
+++ b/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S1066.json
@@ -1,5 +1,5 @@
 {
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/RedditActivity.kt':[
-130,
-],
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/RedditActivity.kt": [
+130
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S108.json
+++ b/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S108.json
@@ -1,8 +1,8 @@
 {
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/RepoDaoTest.kt':[
-50,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/RepoDaoTest.kt": [
+50
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/AutoClearedValueTest.kt':[
-56,
-],
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/AutoClearedValueTest.kt": [
+56
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S1128.json
+++ b/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S1128.json
@@ -1,9 +1,9 @@
 {
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/Leaderboard.kt':[
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/Leaderboard.kt": [
 21,
-22,
+22
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/MainActivity.kt':[
-26,
-],
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/MainActivity.kt": [
+26
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S1151.json
+++ b/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S1151.json
@@ -1,5 +1,5 @@
 {
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/FetchNextSearchPageTask.kt':[
-57,
-],
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/FetchNextSearchPageTask.kt": [
+57
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S117.json
+++ b/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S117.json
@@ -1,5 +1,5 @@
 {
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/vo/RedditPost.kt':[
-41,
-],
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/vo/RedditPost.kt": [
+41
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S1186.json
+++ b/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S1186.json
@@ -1,13 +1,13 @@
 {
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppInjector.kt':[
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppInjector.kt": [
 43,
 47,
 51,
 55,
 59,
-63,
+63
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/NetworkBoundResource.kt':[
-108,
-],
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/NetworkBoundResource.kt": [
+108
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S126.json
+++ b/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S126.json
@@ -1,8 +1,8 @@
 {
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/EspressoTestUtil.kt':[
-58,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/EspressoTestUtil.kt": [
+58
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/PostsAdapter.kt':[
-89,
-],
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/PostsAdapter.kt": [
+89
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S1451.json
+++ b/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S1451.json
@@ -1,419 +1,419 @@
 {
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/androidTest/java/com/example/android/observability/persistence/UserDaoTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/androidTest/java/com/example/android/observability/persistence/UserDaoTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/Injection.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/Injection.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/persistence/User.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/persistence/User.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/persistence/UserDao.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/persistence/UserDao.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/persistence/UsersDatabase.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/persistence/UsersDatabase.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/ui/UserActivity.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/ui/UserActivity.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/ui/UserViewModel.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/ui/UserViewModel.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/ui/ViewModelFactory.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/ui/ViewModelFactory.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/test/java/com/example/android/observability/MockitoKotlinHelpers.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/test/java/com/example/android/observability/MockitoKotlinHelpers.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/test/java/com/example/android/observability/UserViewModelTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/BasicRxJavaSampleKotlin/app/src/test/java/com/example/android/observability/UserViewModelTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/TestApp.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/TestApp.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/DbTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/DbTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/RepoDaoTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/RepoDaoTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/UserDaoTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/UserDaoTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/repo/RepoFragmentTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/repo/RepoFragmentTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/search/SearchFragmentTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/search/SearchFragmentTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/user/UserFragmentTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/user/UserFragmentTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/AutoClearedValueTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/AutoClearedValueTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/CountingAppExecutorsRule.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/CountingAppExecutorsRule.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/EspressoTestUtil.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/EspressoTestUtil.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/GithubTestRunner.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/GithubTestRunner.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/NavDirectionsMatcher.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/NavDirectionsMatcher.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/RecyclerViewMatcher.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/RecyclerViewMatcher.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/TaskExecutorWithIdlingResourceRule.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/TaskExecutorWithIdlingResourceRule.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/ViewModelUtil.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/ViewModelUtil.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/debug/java/com/android/example/github/testing/OpenForTesting.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/debug/java/com/android/example/github/testing/OpenForTesting.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/debug/java/com/android/example/github/testing/SingleFragmentActivity.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/debug/java/com/android/example/github/testing/SingleFragmentActivity.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/AppExecutors.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/AppExecutors.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/GithubApp.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/GithubApp.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/MainActivity.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/MainActivity.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/api/ApiResponse.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/api/ApiResponse.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/api/GithubService.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/api/GithubService.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/api/RepoSearchResponse.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/api/RepoSearchResponse.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/binding/BindingAdapters.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/binding/BindingAdapters.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/binding/FragmentBindingAdapters.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/binding/FragmentBindingAdapters.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/binding/FragmentDataBindingComponent.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/binding/FragmentDataBindingComponent.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/db/GithubDb.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/db/GithubDb.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/db/GithubTypeConverters.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/db/GithubTypeConverters.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/db/RepoDao.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/db/RepoDao.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/db/UserDao.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/db/UserDao.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppComponent.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppComponent.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppInjector.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppInjector.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppModule.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppModule.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/FragmentBuildersModule.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/FragmentBuildersModule.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/Injectable.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/Injectable.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/MainActivityModule.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/MainActivityModule.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/ViewModelKey.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/ViewModelKey.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/ViewModelModule.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/ViewModelModule.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/FetchNextSearchPageTask.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/FetchNextSearchPageTask.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/NetworkBoundResource.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/NetworkBoundResource.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/RepoRepository.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/RepoRepository.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/UserRepository.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/UserRepository.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/common/DataBoundListAdapter.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/common/DataBoundListAdapter.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/common/DataBoundViewHolder.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/common/DataBoundViewHolder.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/common/RepoListAdapter.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/common/RepoListAdapter.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/common/RetryCallback.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/common/RetryCallback.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/repo/ContributorAdapter.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/repo/ContributorAdapter.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/repo/RepoFragment.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/repo/RepoFragment.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/repo/RepoViewModel.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/repo/RepoViewModel.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/search/SearchFragment.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/search/SearchFragment.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/search/SearchViewModel.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/search/SearchViewModel.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/user/UserFragment.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/user/UserFragment.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/user/UserViewModel.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/user/UserViewModel.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/util/AbsentLiveData.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/util/AbsentLiveData.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/util/AutoClearedValue.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/util/AutoClearedValue.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/util/LiveDataCallAdapter.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/util/LiveDataCallAdapter.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/util/LiveDataCallAdapterFactory.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/util/LiveDataCallAdapterFactory.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/util/RateLimiter.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/util/RateLimiter.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/viewmodel/GithubViewModelFactory.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/viewmodel/GithubViewModelFactory.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/vo/Contributor.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/vo/Contributor.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/vo/Repo.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/vo/Repo.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/vo/RepoSearchResult.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/vo/RepoSearchResult.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/vo/Resource.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/vo/Resource.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/vo/Status.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/vo/Status.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/vo/User.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/vo/User.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/release/java/com/android/example/github/testing/OpenForTesting.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/release/java/com/android/example/github/testing/OpenForTesting.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test-common/java/com/android/example/github/util/CountingAppExecutors.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test-common/java/com/android/example/github/util/CountingAppExecutors.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test-common/java/com/android/example/github/util/LiveDataTestUtil.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test-common/java/com/android/example/github/util/LiveDataTestUtil.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test-common/java/com/android/example/github/util/MockitoExt.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test-common/java/com/android/example/github/util/MockitoExt.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test-common/java/com/android/example/github/util/TestUtil.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test-common/java/com/android/example/github/util/TestUtil.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/api/ApiResponseTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/api/ApiResponseTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/api/GithubServiceTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/api/GithubServiceTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/repository/FetchNextSearchPageTaskTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/repository/FetchNextSearchPageTaskTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/repository/NetworkBoundResourceTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/repository/NetworkBoundResourceTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/repository/RepoRepositoryTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/repository/RepoRepositoryTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/repository/UserRepositoryTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/repository/UserRepositoryTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/ui/repo/RepoViewModelTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/ui/repo/RepoViewModelTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/ui/search/NextPageHandlerTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/ui/search/NextPageHandlerTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/ui/search/SearchViewModelTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/ui/search/SearchViewModelTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/ui/user/UserViewModelTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/ui/user/UserViewModelTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/util/ApiUtil.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/util/ApiUtil.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/util/InstantAppExecutors.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/test/java/com/android/example/github/util/InstantAppExecutors.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/GameOver.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/GameOver.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/InGame.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/InGame.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/Leaderboard.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/Leaderboard.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/MainActivity.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/MainActivity.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/Match.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/Match.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/Register.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/Register.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/ResultsWinner.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/ResultsWinner.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/TitleScreen.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/TitleScreen.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/UserProfile.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/UserProfile.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/Cheese.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/Cheese.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/CheeseAdapter.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/CheeseAdapter.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/CheeseDao.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/CheeseDao.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/CheeseDb.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/CheeseDb.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/CheeseViewHolder.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/CheeseViewHolder.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/CheeseViewModel.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/CheeseViewModel.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/Executors.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/Executors.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/MainActivity.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingSample/app/src/main/java/paging/android/example/com/pagingsample/MainActivity.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/androidTest/java/com/android/example/paging/pagingwithnetwork/reddit/ui/RedditActivityTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/androidTest/java/com/android/example/paging/pagingwithnetwork/reddit/ui/RedditActivityTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/MainActivity.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/MainActivity.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/RedditAppGlideModule.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/RedditAppGlideModule.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ServiceLocator.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ServiceLocator.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/api/RedditApi.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/api/RedditApi.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/db/RedditDb.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/db/RedditDb.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/db/RedditPostDao.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/db/RedditPostDao.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/Listing.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/Listing.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/NetworkState.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/NetworkState.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/RedditPostRepository.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/RedditPostRepository.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inDb/DbRedditPostRepository.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inDb/DbRedditPostRepository.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inDb/SubredditBoundaryCallback.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inDb/SubredditBoundaryCallback.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/byItem/InMemoryByItemRepository.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/byItem/InMemoryByItemRepository.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/byItem/ItemKeyedSubredditDataSource.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/byItem/ItemKeyedSubredditDataSource.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/byItem/SubRedditDataSourceFactory.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/byItem/SubRedditDataSourceFactory.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/byPage/InMemoryByPageKeyRepository.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/byPage/InMemoryByPageKeyRepository.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/byPage/PageKeyedSubredditDataSource.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/byPage/PageKeyedSubredditDataSource.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/byPage/SubRedditDataSourceFactory.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/byPage/SubRedditDataSourceFactory.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/NetworkStateItemViewHolder.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/NetworkStateItemViewHolder.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/PostsAdapter.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/PostsAdapter.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/RedditActivity.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/RedditActivity.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/RedditPostViewHolder.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/RedditPostViewHolder.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/SubRedditViewModel.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/SubRedditViewModel.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/util/PagingRequestHelperExt.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/util/PagingRequestHelperExt.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/vo/RedditPost.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/vo/RedditPost.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/test-common/java/com/android/example/paging/pagingwithnetwork/repository/FakeRedditApi.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/test-common/java/com/android/example/paging/pagingwithnetwork/repository/FakeRedditApi.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/test-common/java/com/android/example/paging/pagingwithnetwork/repository/PostFactory.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/test-common/java/com/android/example/paging/pagingwithnetwork/repository/PostFactory.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/test/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/InMemoryRepositoryTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/test/java/com/android/example/paging/pagingwithnetwork/reddit/repository/inMemory/InMemoryRepositoryTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/WorkManagerSample/app/src/androidTest/java/com/example/background/ImageOperationsTest.kt':[
-0,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/WorkManagerSample/app/src/androidTest/java/com/example/background/ImageOperationsTest.kt": [
+0
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/WorkManagerSample/app/src/androidTest/java/com/example/background/TestLifeCycleOwner.kt':[
-0,
-],
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/WorkManagerSample/app/src/androidTest/java/com/example/background/TestLifeCycleOwner.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S5612.json
+++ b/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S5612.json
@@ -1,5 +1,5 @@
 {
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/NetworkBoundResource.kt':[
-73,
-],
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/NetworkBoundResource.kt": [
+73
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S6517.json
+++ b/its/ruling/src/test/resources/expected/kotlin/android-architecture-components/kotlin-S6517.json
@@ -1,11 +1,11 @@
 {
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppComponent.kt':[
-33,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppComponent.kt": [
+33
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/common/RetryCallback.kt':[
-22,
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/common/RetryCallback.kt": [
+22
 ],
-'kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/RedditPostRepository.kt':[
-26,
-],
+"kotlin-android-architecture-components-project:sources/kotlin/android-architecture-components/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/repository/RedditPostRepository.kt": [
+26
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S100.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S100.json
@@ -1,5 +1,5 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt": [
 90,
 96,
 115,
@@ -36,20 +36,20 @@
 600,
 612,
 621,
-627,
+627
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt": [
 95,
 116,
-140,
+140
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/model/ExchangeRateModelTest.kt':[
-27,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/model/ExchangeRateModelTest.kt": [
+27
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/BlacklistKotlinClosureTest.kt':[
-31,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/BlacklistKotlinClosureTest.kt": [
+31
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt": [
 66,
 71,
 78,
@@ -57,15 +57,15 @@
 140,
 156,
 164,
-182,
+182
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/FlowsExecutionModeRpcTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/FlowsExecutionModeRpcTest.kt": [
 27,
 63,
 76,
-90,
+90
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt": [
 68,
 101,
 128,
@@ -82,9 +82,9 @@
 442,
 497,
 534,
-575,
+575
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt": [
 100,
 115,
 129,
@@ -93,87 +93,87 @@
 157,
 179,
 202,
-228,
+228
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt": [
 76,
 92,
 102,
 147,
 156,
-192,
+192
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt": [
 109,
 145,
-169,
+169
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCFailureTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCFailureTests.kt": [
 50,
 56,
-70,
+70
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt": [
 81,
 123,
-153,
+153
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTests.kt": [
 49,
 60,
 70,
 80,
 94,
-108,
+108
 ],
-'kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt": [
 49,
-77,
+77
 ],
-'kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt": [
 22,
 58,
-80,
+80
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt": [
 268,
-286,
+286
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt": [
 221,
-232,
+232
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/smoke-test/kotlin/net/corda/core/NodeVersioningTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/smoke-test/kotlin/net/corda/core/NodeVersioningTest.kt": [
 46,
-52,
+52
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/smoke-test/kotlin/net/corda/core/cordapp/CordappSmokeTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/smoke-test/kotlin/net/corda/core/cordapp/CordappSmokeTest.kt": [
 42,
-63,
+63
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/UtilsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/UtilsTest.kt": [
 12,
 20,
 30,
 40,
-51,
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/concurrent/ConcurrencyUtilsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/concurrent/ConcurrencyUtilsTest.kt": [
 25,
 43,
 61,
 78,
 90,
-106,
+106
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/AmountTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/AmountTests.kt": [
 19,
 25,
 63,
 88,
-119,
+119
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/ContractsDSLTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/ContractsDSLTests.kt": [
 45,
 52,
 58,
@@ -186,17 +186,17 @@
 144,
 153,
 162,
-171,
+171
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/PrivacySaltTest.kt':[
-8,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/PrivacySaltTest.kt": [
+8
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/StructuresTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/StructuresTests.kt": [
 20,
 49,
-62,
+62
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt": [
 52,
 58,
 67,
@@ -211,9 +211,9 @@
 226,
 292,
 316,
-370,
+370
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt": [
 37,
 71,
 126,
@@ -247,12 +247,12 @@
 747,
 788,
 815,
-856,
+856
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/EdDSATests.kt':[
-20,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/EdDSATests.kt": [
+20
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt": [
 90,
 95,
 100,
@@ -272,54 +272,54 @@
 241,
 248,
 256,
-279,
+279
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/SignedDataTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/SignedDataTest.kt": [
 26,
-36,
+36
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/TransactionSignatureTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/TransactionSignatureTest.kt": [
 24,
 42,
 50,
-97,
+97
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/X509NameConstraintsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/X509NameConstraintsTest.kt": [
 53,
-88,
+88
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt':[
-52,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt": [
+52
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt": [
 103,
 124,
 136,
-148,
+148
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt": [
 66,
 127,
-198,
+198
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/FastThreadLocalTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/FastThreadLocalTest.kt": [
 56,
 66,
 76,
 86,
 117,
-124,
+124
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt": [
 46,
-62,
+62
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/ReceiveAllFlowTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/ReceiveAllFlowTests.kt": [
 24,
 59,
-71,
+71
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt": [
 10,
 21,
 32,
@@ -327,26 +327,26 @@
 50,
 57,
 64,
-71,
+71
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/PartyAndCertificateTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/PartyAndCertificateTest.kt": [
 25,
 31,
-42,
+42
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/AbstractAttachmentTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/AbstractAttachmentTest.kt": [
 61,
 70,
 78,
 88,
 96,
-108,
+108
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/CertRoleTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/CertRoleTests.kt": [
 10,
-17,
+17
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/InternalUtilsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/InternalUtilsTest.kt": [
 14,
 21,
 29,
@@ -355,9 +355,9 @@
 54,
 60,
 73,
-84,
+84
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/LegalNameValidatorTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/LegalNameValidatorTest.kt": [
 9,
 17,
 24,
@@ -366,24 +366,24 @@
 73,
 96,
 109,
-120,
+120
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/PathUtilsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/PathUtilsTest.kt": [
 14,
 21,
 28,
 35,
 43,
-52,
+52
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt": [
 56,
 70,
 79,
 93,
-113,
+113
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/ToggleFieldTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/ToggleFieldTest.kt": [
 56,
 71,
 84,
@@ -392,15 +392,15 @@
 120,
 143,
 173,
-194,
+194
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/X509EdDSAEngineTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/X509EdDSAEngineTest.kt": [
 55,
 77,
 99,
-120,
+120
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/concurrent/CordaFutureImplTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/concurrent/CordaFutureImplTest.kt": [
 19,
 32,
 46,
@@ -410,34 +410,34 @@
 134,
 139,
 148,
-163,
+163
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/node/VaultUpdateTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/node/VaultUpdateTests.kt": [
 45,
 52,
 59,
 67,
 75,
 83,
-91,
+91
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/AttachmentSerializationTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/AttachmentSerializationTest.kt": [
 174,
 181,
 189,
-198,
+198
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/CommandsSerializationTests.kt':[
-16,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/CommandsSerializationTests.kt": [
+16
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/CompatibleTransactionTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/CompatibleTransactionTests.kt": [
 66,
 126,
 195,
 289,
-408,
+408
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/LedgerTransactionQueryTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/LedgerTransactionQueryTests.kt": [
 92,
 102,
 112,
@@ -457,29 +457,29 @@
 274,
 283,
 292,
-301,
+301
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/TransactionEncumbranceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/TransactionEncumbranceTests.kt": [
 74,
 88,
 109,
 130,
 149,
 162,
-176,
+176
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/TransactionTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/TransactionTests.kt": [
 47,
 81,
 112,
 138,
 153,
-179,
+179
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/ByteArraysTest.kt':[
-13,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/ByteArraysTest.kt": [
+13
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/EncodingUtilsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/EncodingUtilsTest.kt": [
 19,
 26,
 33,
@@ -487,26 +487,26 @@
 49,
 56,
 65,
-91,
+91
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/KotlinUtilsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/KotlinUtilsTest.kt": [
 36,
 44,
 54,
 62,
-73,
+73
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/NetworkHostAndPortTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/NetworkHostAndPortTest.kt": [
 12,
 21,
 32,
-43,
+43
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/NonEmptySetTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/NonEmptySetTest.kt": [
 45,
-55,
+55
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt": [
 48,
 65,
 72,
@@ -514,55 +514,55 @@
 135,
 170,
 208,
-243,
+243
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt':[
-26,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt": [
+26
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/CustomVaultQueryTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/CustomVaultQueryTest.kt": [
 55,
-71,
+71
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/ExampleConfigTest.kt':[
-29,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/ExampleConfigTest.kt": [
+29
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt':[
-43,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt": [
+43
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt':[
-50,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt": [
+50
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt':[
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt": [
 161,
 182,
 201,
 234,
-276,
+276
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/tests/StepsProviderTests.kt':[
-13,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/tests/StepsProviderTests.kt": [
+13
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/monitoring/MonitoringTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/monitoring/MonitoringTests.kt": [
 11,
 18,
 25,
 35,
 45,
-55,
+55
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/network/NetworkTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/network/NetworkTests.kt": [
 13,
-28,
+28
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/process/CommandTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/process/CommandTests.kt": [
 10,
 16,
-22,
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/service/PostreSQLServiceTests.kt':[
-12,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/service/PostreSQLServiceTests.kt": [
+12
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/corda-utils/src/test/kotlin/io/cryptoblk/core/StatusTransitionsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/corda-utils/src/test/kotlin/io/cryptoblk/core/StatusTransitionsTest.kt": [
 106,
 138,
 151,
@@ -574,35 +574,35 @@
 231,
 245,
 278,
-291,
+291
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/ContractFunctions.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/ContractFunctions.kt": [
 13,
-27,
+27
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt": [
 206,
 245,
 262,
 278,
-318,
+318
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Caplet.kt':[
-125,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Caplet.kt": [
+125
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/ContractDefinition.kt':[
-102,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/ContractDefinition.kt": [
+102
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Examples.kt':[
-121,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Examples.kt": [
+121
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXFwdTimeOption.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXFwdTimeOption.kt": [
 52,
 71,
 100,
-129,
+129
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXSwap.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXSwap.kt": [
 43,
 80,
 97,
@@ -611,65 +611,65 @@
 132,
 144,
 156,
-168,
+168
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/IRS.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/IRS.kt": [
 149,
 188,
-205,
+205
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/RollOutTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/RollOutTests.kt": [
 124,
 129,
 134,
-139,
+139
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Swaption.kt':[
-77,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Swaption.kt": [
+77
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/ZeroCouponBond.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/ZeroCouponBond.kt": [
 50,
 79,
-90,
+90
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/compat/CashExceptionSerialisationTest.kt':[
-18,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/compat/CashExceptionSerialisationTest.kt": [
+18
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/flows/CashConfigDataFlowTest.kt':[
-13,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/flows/CashConfigDataFlowTest.kt": [
+13
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/flows/CashSelectionTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/flows/CashSelectionTest.kt": [
 25,
 47,
 75,
-107,
+107
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/Currencies.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/Currencies.kt": [
 33,
 34,
 35,
 47,
-48,
+48
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/CommercialPaper.kt':[
-94,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/CommercialPaper.kt": [
+94
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt": [
 801,
-802,
+802
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/CurrenciesTests.kt':[
-9,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/CurrenciesTests.kt": [
+9
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/CommercialPaperTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/CommercialPaperTests.kt": [
 115,
 188,
 200,
 212,
 224,
-237,
+237
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/FinanceTypesTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/FinanceTypesTest.kt": [
 13,
 19,
 27,
@@ -683,9 +683,9 @@
 95,
 102,
 109,
-129,
+129
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt": [
 163,
 222,
 278,
@@ -696,9 +696,9 @@
 750,
 757,
 763,
-776,
+776
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt": [
 147,
 248,
 265,
@@ -723,14 +723,14 @@
 918,
 932,
 940,
-948,
+948
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt": [
 28,
 41,
-59,
+59
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/math/InterpolatorsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/math/InterpolatorsTest.kt": [
 11,
 19,
 25,
@@ -738,35 +738,35 @@
 42,
 50,
 56,
-63,
+63
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashExitFlowTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashExitFlowTests.kt": [
 45,
-58,
+58
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashIssueFlowTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashIssueFlowTests.kt": [
 39,
-50,
+50
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt": [
 46,
 85,
-97,
+97
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt": [
 68,
-79,
+79
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/SignedNodeInfoTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/SignedNodeInfoTest.kt": [
 32,
 39,
 47,
 58,
 71,
 81,
-91,
+91
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/config/ConfigParsingTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/config/ConfigParsingTest.kt": [
 51,
 106,
 114,
@@ -780,9 +780,9 @@
 196,
 204,
 211,
-216,
+216
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt": [
 59,
 76,
 86,
@@ -793,9 +793,9 @@
 217,
 322,
 337,
-353,
+353
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapperTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapperTest.kt": [
 14,
 20,
 27,
@@ -808,206 +808,206 @@
 93,
 103,
 110,
-119,
+119
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NodeInfoFilesCopierTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NodeInfoFilesCopierTest.kt": [
 52,
 73,
-91,
+91
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt": [
 101,
 106,
 121,
 141,
 154,
 170,
-190,
+190
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/BootTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/BootTests.kt": [
 27,
-38,
+38
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/CordappConfigFileProviderTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/CordappConfigFileProviderTests.kt": [
 28,
 34,
 41,
-50,
+50
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/CordappScanningDriverTest.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/CordappScanningDriverTest.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt": [
 20,
-29,
+29
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt": [
 50,
 80,
-94,
+94
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeStartAndStopTest.kt':[
-11,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeStartAndStopTest.kt": [
+11
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeStartupPerformanceTests.kt':[
-15,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeStartupPerformanceTests.kt": [
+15
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeUnloadHandlerTests.kt':[
-23,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeUnloadHandlerTests.kt": [
+23
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt':[
-49,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt": [
+49
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt": [
 97,
 129,
 150,
 171,
 192,
 218,
-244,
+244
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt": [
 53,
 86,
 108,
 186,
 239,
 265,
-311,
+311
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt':[
-35,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt": [
+35
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt": [
+54
+],
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt": [
 54,
+86
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt':[
-54,
-86,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/RpcFlowsDrainingModeTest.kt": [
+25
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/RpcFlowsDrainingModeTest.kt':[
-25,
-],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/persistence/NodeStatePersistenceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/persistence/NodeStatePersistenceTests.kt": [
 37,
-66,
+66
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt": [
 99,
 115,
-127,
+127
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt": [
 122,
 164,
 185,
-200,
+200
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/BFTSMaRtTests.kt':[
-37,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/BFTSMaRtTests.kt": [
+37
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt": [
 32,
-65,
+65
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/distributed/DistributedServiceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/distributed/DistributedServiceTests.kt": [
 84,
 122,
-129,
+129
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt':[
-88,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt": [
+88
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt": [
 89,
 136,
 154,
 172,
 194,
-219,
+219
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt": [
 58,
 73,
 80,
 94,
-110,
+110
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt": [
 47,
 57,
 80,
 90,
 99,
-109,
+109
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt": [
 31,
 45,
 61,
-75,
+75
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt": [
 34,
 72,
 101,
-117,
+117
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt':[
-20,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt": [
+20
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt':[
-82,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt": [
+82
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsNodeTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsNodeTest.kt": [
 41,
 46,
 54,
 62,
 70,
 78,
-86,
+86
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsRPCTest.kt':[
-15,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsRPCTest.kt": [
+15
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt": [
 69,
 75,
 81,
 86,
-92,
+92
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMQSecurityTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMQSecurityTest.kt": [
 18,
 23,
 29,
 35,
 41,
 47,
-52,
+52
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt": [
 40,
 48,
-74,
+74
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/RPCMQSecurityTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/RPCMQSecurityTest.kt": [
 19,
 24,
 30,
 36,
 42,
 48,
-53,
+53
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt": [
 405,
 410,
-488,
+488
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt": [
 103,
 159,
 247,
@@ -1019,9 +1019,9 @@
 316,
 331,
 340,
-373,
+373
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/NodeArgsParserTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/NodeArgsParserTest.kt": [
 34,
 52,
 60,
@@ -1038,80 +1038,80 @@
 157,
 163,
 169,
-175,
+175
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/SerialFilterTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/SerialFilterTests.kt": [
 12,
-20,
+20
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/AbstractNodeTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/AbstractNodeTests.kt": [
 33,
-44,
+44
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt": [
 94,
 105,
 111,
-118,
+118
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/NetworkParametersTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/NetworkParametersTest.kt": [
 43,
 54,
-66,
+66
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt": [
 60,
-72,
+72
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappLoaderTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappLoaderTest.kt": [
 41,
 48,
 67,
 83,
 90,
-99,
+99
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappProviderImplTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappProviderImplTests.kt": [
 37,
 46,
 52,
 64,
-75,
+75
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/TypesafeCordappConfigTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/TypesafeCordappConfigTests.kt": [
 10,
 24,
 32,
-41,
+41
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/security/PasswordTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/security/PasswordTest.kt": [
 27,
-87,
+87
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/InMemoryMessagingTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/InMemoryMessagingTests.kt": [
 30,
-87,
+87
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt": [
 106,
 161,
 219,
 330,
 434,
 512,
-521,
+521
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/modes/draining/ScheduledFlowsDrainingModeTest.kt':[
-70,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/modes/draining/ScheduledFlowsDrainingModeTest.kt": [
+70
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/serialization/kryo/KryoStreamsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/serialization/kryo/KryoStreamsTest.kt": [
 28,
 37,
 47,
 67,
-89,
+89
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/serialization/kryo/KryoTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/serialization/kryo/KryoTests.kt": [
 78,
 86,
 94,
@@ -1132,16 +1132,16 @@
 320,
 333,
 341,
-350,
+350
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt": [
 57,
 65,
 81,
 95,
-129,
+129
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/RPCSecurityManagerTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/RPCSecurityManagerTest.kt": [
 23,
 30,
 39,
@@ -1152,15 +1152,15 @@
 81,
 92,
 105,
-118,
+118
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/ServiceHubConcurrentUsageTest.kt':[
-35,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/ServiceHubConcurrentUsageTest.kt": [
+35
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/ConfigOperatorTests.kt':[
-11,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/ConfigOperatorTests.kt": [
+11
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt": [
 28,
 37,
 44,
@@ -1176,9 +1176,9 @@
 154,
 165,
 181,
-190,
+190
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt": [
 190,
 195,
 200,
@@ -1190,17 +1190,17 @@
 265,
 297,
 313,
-353,
+353
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepositoryTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepositoryTest.kt": [
 21,
-43,
+43
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt": [
 118,
-141,
+141
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/identity/InMemoryIdentityServiceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/identity/InMemoryIdentityServiceTests.kt": [
 43,
 61,
 70,
@@ -1210,9 +1210,9 @@
 120,
 142,
 186,
-198,
+198
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/identity/PersistentIdentityServiceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/identity/PersistentIdentityServiceTests.kt": [
 72,
 90,
 98,
@@ -1223,12 +1223,12 @@
 169,
 195,
 238,
-250,
+250
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/keys/KMSUtilsTests.kt':[
-17,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/keys/KMSUtilsTests.kt": [
+17
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt": [
 92,
 100,
 109,
@@ -1236,22 +1236,22 @@
 128,
 139,
 157,
-174,
+174
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapCacheTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapCacheTest.kt": [
 29,
 71,
 96,
-112,
+112
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt": [
 53,
 74,
 87,
 95,
-100,
+100
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt": [
 79,
 115,
 156,
@@ -1260,28 +1260,28 @@
 215,
 232,
 255,
-289,
+289
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt": [
 55,
 71,
-81,
+81
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt": [
 70,
 99,
 126,
-160,
+160
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt": [
 63,
 78,
 96,
 114,
 136,
-157,
+157
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt": [
 58,
 66,
 77,
@@ -1290,9 +1290,9 @@
 113,
 124,
 139,
-148,
+148
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt": [
 157,
 169,
 189,
@@ -1318,40 +1318,40 @@
 729,
 788,
 840,
-896,
+896
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentStorageTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentStorageTest.kt": [
 59,
 83,
 117,
 138,
 186,
 199,
-225,
+225
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/TransactionCallbackTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/TransactionCallbackTest.kt": [
 20,
-32,
+32
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt": [
 52,
 62,
 67,
-78,
+78
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/schema/HibernateObserverTests.kt':[
-52,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/schema/HibernateObserverTests.kt": [
+52
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/schema/NodeSchemaServiceTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/schema/NodeSchemaServiceTest.kt": [
 34,
 43,
 55,
 72,
 81,
 93,
-108,
+108
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt": [
 103,
 123,
 141,
@@ -1381,9 +1381,9 @@
 669,
 677,
 692,
-704,
+704
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImplTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImplTest.kt": [
 42,
 47,
 53,
@@ -1391,42 +1391,42 @@
 63,
 69,
 75,
-81,
+81
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt": [
 55,
 61,
 69,
 85,
-91,
+91
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/BFTSMaRtConfigTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/BFTSMaRtConfigTests.kt": [
 11,
 22,
-30,
+30
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/MaxTransactionSizeTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/MaxTransactionSizeTests.kt": [
 53,
-76,
+76
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt':[
-51,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt": [
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/PathManagerTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/PathManagerTests.kt": [
 14,
-24,
+24
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/PersistentUniquenessProviderTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/PersistentUniquenessProviderTests.kt": [
 51,
-61,
+61
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLogTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLogTests.kt": [
 61,
 81,
 101,
-118,
+118
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt": [
 63,
 80,
 101,
@@ -1439,9 +1439,9 @@
 257,
 268,
 279,
-290,
+290
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt": [
 131,
 144,
 169,
@@ -1460,12 +1460,12 @@
 548,
 592,
 689,
-712,
+712
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt':[
-44,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt": [
+44
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt": [
 233,
 247,
 261,
@@ -1563,31 +1563,31 @@
 2022,
 2063,
 2104,
-2146,
+2146
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt": [
 155,
 158,
 161,
-164,
+164
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt": [
 114,
 162,
 252,
 273,
 313,
-351,
+351
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/AddressUtilsTests.kt':[
-10,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/AddressUtilsTests.kt": [
+10
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/AffinityExecutorTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/AffinityExecutorTests.kt": [
 21,
 35,
-57,
+57
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ClockUtilsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ClockUtilsTest.kt": [
 46,
 51,
 56,
@@ -1600,9 +1600,9 @@
 112,
 123,
 145,
-167,
+167
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt": [
 35,
 64,
 95,
@@ -1612,18 +1612,18 @@
 222,
 262,
 285,
-307,
+307
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/PersistentMapTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/PersistentMapTests.kt": [
 32,
 48,
 64,
 82,
 100,
 126,
-142,
+142
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/TLSAuthenticationTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/TLSAuthenticationTests.kt": [
 72,
 88,
 104,
@@ -1633,26 +1633,26 @@
 166,
 182,
 197,
-223,
+223
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt": [
 72,
 111,
 119,
 129,
 140,
-153,
+153
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt':[
-20,
+"kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt": [
+20
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaCordformTest.kt':[
-10,
+"kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaCordformTest.kt": [
+10
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt':[
-26,
+"kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt": [
+26
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/NodeInterestRatesTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/NodeInterestRatesTest.kt": [
 83,
 94,
 104,
@@ -1662,14 +1662,14 @@
 152,
 166,
 180,
-199,
+199
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt": [
 73,
 99,
-114,
+114
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt": [
 256,
 310,
 334,
@@ -1684,32 +1684,32 @@
 539,
 552,
 574,
-599,
+599
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt':[
-52,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt": [
+52
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/system-test/kotlin/net/corda/irs/IRSDemoDockerTest.kt':[
-42,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/system-test/kotlin/net/corda/irs/IRSDemoDockerTest.kt": [
+42
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/test/kotlin/net/corda/netmap/simulation/IRSSimulationTest.kt':[
-10,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/test/kotlin/net/corda/netmap/simulation/IRSSimulationTest.kt": [
+10
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt':[
-47,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt": [
+47
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt':[
-28,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt": [
+28
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/TransactionGraphSearchTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/TransactionGraphSearchTests.kt": [
 68,
 78,
-88,
+88
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationOutput.kt':[
-66,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationOutput.kt": [
+66
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/AttachmentsClassLoaderTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/AttachmentsClassLoaderTests.kt": [
 86,
 113,
 125,
@@ -1723,16 +1723,16 @@
 276,
 302,
 335,
-357,
+357
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/ContractAttachmentSerializerTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/ContractAttachmentSerializerTest.kt": [
 38,
 51,
 67,
 80,
-93,
+93
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt": [
 121,
 126,
 131,
@@ -1765,45 +1765,45 @@
 342,
 354,
 363,
-373,
+373
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/ListsSerializationTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/ListsSerializationTest.kt": [
 41,
 48,
 67,
 85,
-103,
+103
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/MapsSerializationTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/MapsSerializationTest.kt": [
 33,
 38,
 43,
 53,
 68,
-76,
+76
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/PrivateKeySerializationTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/PrivateKeySerializationTest.kt": [
 34,
-40,
+40
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/SerializationTokenTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/SerializationTokenTest.kt": [
 47,
 61,
 71,
 79,
 88,
 94,
-120,
+120
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/SetsSerializationTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/SetsSerializationTest.kt": [
 28,
 35,
-54,
+54
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/CorDappSerializerTests.kt':[
-44,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/CorDappSerializerTests.kt": [
+44
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedTypeTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedTypeTests.kt": [
 18,
 23,
 28,
@@ -1820,15 +1820,15 @@
 83,
 88,
 93,
-98,
+98
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolvabilityTests.kt':[
-591,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolvabilityTests.kt": [
+591
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/OverridePKSerializerTest.kt':[
-60,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/OverridePKSerializerTest.kt": [
+60
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt": [
 324,
 330,
 336,
@@ -1914,9 +1914,9 @@
 1171,
 1187,
 1238,
-1248,
+1248
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTest.kt": [
 92,
 104,
 149,
@@ -1935,9 +1935,9 @@
 396,
 417,
 434,
-462,
+462
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt": [
 56,
 65,
 81,
@@ -1948,72 +1948,72 @@
 147,
 160,
 170,
-180,
+180
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/FlowStackSnapshotTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/FlowStackSnapshotTest.kt": [
 228,
 243,
 258,
 274,
 288,
-305,
+305
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/MockNetworkIntegrationTests.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/MockNetworkIntegrationTests.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/internal/InternalMockNetworkIntegrationTests.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/internal/InternalMockNetworkIntegrationTests.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/internal/ProcessUtilitiesTests.kt':[
-30,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/internal/ProcessUtilitiesTests.kt": [
+30
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/InternalMockNetworkTests.kt':[
-9,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/InternalMockNetworkTests.kt": [
+9
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/LedgerDSLInterpreter.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/LedgerDSLInterpreter.kt": [
 80,
 98,
 108,
-115,
+115
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt": [
 141,
 143,
 269,
 275,
-281,
+281
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TransactionDSLInterpreter.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TransactionDSLInterpreter.kt": [
 70,
-76,
+76
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/test/kotlin/net/corda/testing/TestIdentityTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/test/kotlin/net/corda/testing/TestIdentityTests.kt": [
 12,
-20,
+20
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/test/kotlin/net/corda/testing/internal/RigorousMockTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/test/kotlin/net/corda/testing/internal/RigorousMockTest.kt": [
 34,
 44,
 62,
 80,
 101,
-114,
+114
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/LoggingTestSuite.kt':[
-27,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/LoggingTestSuite.kt": [
+27
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/JVMConfigTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/JVMConfigTest.kt": [
 14,
 19,
 24,
 29,
-36,
+36
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt": [
 25,
-54,
+54
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt": [
 19,
 27,
 35,
@@ -2027,57 +2027,57 @@
 111,
 120,
 129,
-138,
+138
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/pty/ZeroFilterTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/pty/ZeroFilterTest.kt": [
 28,
 36,
 42,
-51,
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/test/kotlin/net/corda/explorer/model/SettingsModelTest.kt':[
-18,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/test/kotlin/net/corda/explorer/model/SettingsModelTest.kt": [
+18
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/test/kotlin/net/corda/explorer/views/GuiUtilitiesKtTest.kt':[
-10,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/test/kotlin/net/corda/explorer/views/GuiUtilitiesKtTest.kt": [
+10
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt": [
 42,
 58,
 74,
 103,
 129,
 141,
-184,
+184
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/SSHServerTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/SSHServerTest.kt": [
 33,
 54,
 73,
 96,
-126,
+126
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt':[
-123,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt": [
+123
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt':[
-55,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt": [
+55
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/CustomTypeJsonParsingTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/CustomTypeJsonParsingTests.kt": [
 35,
 44,
 53,
 59,
-67,
+67
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/StandaloneShellArgsParserTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/StandaloneShellArgsParserTest.kt": [
 16,
 54,
 78,
 116,
-150,
+150
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/integration-test/kotlin/net/corda/webserver/WebserverDriverTests.kt':[
-30,
-],
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/integration-test/kotlin/net/corda/webserver/WebserverDriverTests.kt": [
+30
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S101.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S101.json
@@ -1,19 +1,19 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentryTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentryTests.kt": [
 200,
-220,
+220
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/GenericsTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/GenericsTests.kt": [
 277,
-512,
+512
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt": [
 142,
 144,
 146,
-148,
+148
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt':[
-14,
-],
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt": [
+14
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S103.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S103.json
@@ -1,274 +1,274 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt':[
-152,
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt": [
+152
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt':[
-127,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt": [
+127
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt": [
 25,
 31,
 37,
 43,
-49,
+49
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/ContractAttachment.kt':[
-13,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/ContractAttachment.kt": [
+13
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt':[
-44,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt": [
+44
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/AbstractStateReplacementFlow.kt':[
-47,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/AbstractStateReplacementFlow.kt": [
+47
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt':[
-68,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt": [
+68
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt": [
 157,
 164,
 176,
-177,
+177
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt':[
-244,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt": [
+244
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt": [
 25,
 86,
 191,
 194,
 229,
 230,
-335,
+335
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt':[
-76,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt": [
+76
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt':[
-114,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt": [
+114
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt": [
 40,
 46,
-216,
+216
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/ContractsDSLTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/ContractsDSLTests.kt": [
 67,
 72,
 73,
 115,
 120,
-121,
+121
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt':[
-650,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt": [
+650
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/CompatibleTransactionTests.kt':[
-520,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/CompatibleTransactionTests.kt": [
+520
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/quasar-hook/src/main/kotlin/net/corda/quasarhook/QuasarInstrumentationHook.kt':[
-170,
+"kotlin-corda-project:sources/kotlin/corda/experimental/quasar-hook/src/main/kotlin/net/corda/quasarhook/QuasarInstrumentationHook.kt": [
+170
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Perceivable.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Perceivable.kt": [
 162,
 163,
 165,
 169,
 170,
 172,
-173,
+173
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt':[
-136,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt": [
+136
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt": [
 291,
 297,
 303,
 308,
-311,
+311
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt':[
-223,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt": [
+223
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt':[
-235,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt": [
+235
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt':[
-124,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt": [
+124
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt':[
-33,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt": [
+33
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt':[
-31,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt": [
+31
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/schemas/CommercialPaperSchemaV1.kt':[
-27,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/schemas/CommercialPaperSchemaV1.kt": [
+27
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/utils/StateSummingUtilities.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/utils/StateSummingUtilities.kt": [
 53,
-56,
+56
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/FinanceTypesTest.kt':[
-49,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/FinanceTypesTest.kt": [
+49
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt": [
 613,
-624,
+624
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCashSchemaV2.kt':[
-29,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCashSchemaV2.kt": [
+29
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCommercialPaperSchemaV1.kt':[
-25,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCommercialPaperSchemaV1.kt": [
+25
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCommercialPaperSchemaV2.kt':[
-44,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCommercialPaperSchemaV2.kt": [
+44
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/RPCApi.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/RPCApi.kt": [
 236,
-324,
+324
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt':[
-81,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt": [
+81
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPServer.kt':[
-116,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPServer.kt": [
+116
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt':[
-63,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt": [
+63
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt':[
-347,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt": [
+347
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/persistence/NodeStatePersistenceTests.kt':[
-73,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/persistence/NodeStatePersistenceTests.kt": [
+73
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt':[
-51,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt": [
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/NodeArgsParser.kt':[
-57,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/NodeArgsParser.kt": [
+57
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt": [
 199,
-880,
+880
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt": [
 60,
 63,
 66,
-69,
+69
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/Node.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/Node.kt": [
 197,
 202,
 228,
 230,
-395,
+395
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt':[
-357,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt": [
+357
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt':[
-138,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt": [
+138
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt": [
 54,
-55,
+55
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/ExceptionSerialisingRpcOpsProxy.kt':[
-82,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/ExceptionSerialisingRpcOpsProxy.kt": [
+82
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt':[
-58,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt": [
+58
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt':[
-255,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt": [
+255
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt':[
-119,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt": [
+119
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/InternalRPCMessagingClient.kt':[
-19,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/InternalRPCMessagingClient.kt": [
+19
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt": [
 109,
-118,
+118
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt": [
 129,
 207,
-386,
+386
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt':[
-185,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt": [
+185
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/ArtemisRpcBroker.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/ArtemisRpcBroker.kt": [
 36,
 40,
-66,
+66
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt": [
 20,
-127,
+127
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/MetricInterceptor.kt':[
-11,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/MetricInterceptor.kt": [
+11
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt':[
-130,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt": [
+130
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt": [
 306,
-479,
+479
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt':[
-97,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt": [
+97
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/modes/draining/ScheduledFlowsDrainingModeTest.kt':[
-106,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/modes/draining/ScheduledFlowsDrainingModeTest.kt": [
+106
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt':[
-187,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt": [
+187
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt": [
 128,
-162,
+162
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt':[
-95,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt": [
+95
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLogTests.kt':[
-151,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLogTests.kt": [
+151
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt':[
-87,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt": [
+87
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt':[
-202,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt": [
+202
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaClientApi.kt':[
-41,
+"kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaClientApi.kt": [
+41
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRS.kt':[
-554,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRS.kt": [
+554
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt':[
-397,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt": [
+397
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt':[
-37,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt": [
+37
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/AnalyticsEngine.kt':[
-69,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/AnalyticsEngine.kt": [
+69
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingCcpExample.kt':[
-192,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingCcpExample.kt": [
+192
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingExample.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingExample.kt": [
 203,
 210,
 308,
@@ -300,73 +300,73 @@
 396,
 401,
 403,
-405,
+405
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TransactionGraphSearch.kt':[
-66,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TransactionGraphSearch.kt": [
+66
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/LocalDateTimeSerializer.kt':[
-12,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/LocalDateTimeSerializer.kt": [
+12
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/OffsetDateTimeSerializer.kt':[
-12,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/OffsetDateTimeSerializer.kt": [
+12
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PrivateKeySerializer.kt':[
-18,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PrivateKeySerializer.kt": [
+18
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PublicKeySerializer.kt':[
-14,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PublicKeySerializer.kt": [
+14
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ThrowableSerializer.kt':[
-86,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ThrowableSerializer.kt": [
+86
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ZonedDateTimeSerializer.kt':[
-14,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ZonedDateTimeSerializer.kt": [
+14
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/AttachmentsClassLoaderTests.kt':[
-60,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/AttachmentsClassLoaderTests.kt": [
+60
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt": [
 119,
 205,
 344,
 356,
-375,
+375
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeMapTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeMapTests.kt": [
 95,
-106,
+106
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt": [
 84,
 221,
-270,
+270
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/UnsafeCertificatesFactory.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/UnsafeCertificatesFactory.kt": [
 158,
-208,
+208
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/MockCordappProvider.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/MockCordappProvider.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyDealStateSchemaV1.kt':[
-25,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyDealStateSchemaV1.kt": [
+25
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyLinearStateSchemaV2.kt':[
-21,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyLinearStateSchemaV2.kt": [
+21
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/services/MockAttachmentStorage.kt':[
-71,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/services/MockAttachmentStorage.kt": [
+71
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt": [
 155,
 212,
-214,
+214
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt':[
-260,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt": [
+260
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/NotaryTest.kt':[
-31,
-],
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/NotaryTest.kt": [
+31
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S104.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S104.json
@@ -1,11 +1,11 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt':[
-0,
-],
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S105.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S105.json
@@ -1,8 +1,8 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/RPCSecurityManagerImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/RPCSecurityManagerImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt':[
-0,
-],
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1066.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1066.json
@@ -1,24 +1,24 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt':[
-222,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt": [
+222
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt": [
 120,
-282,
+282
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt':[
-248,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt": [
+248
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/IdentityServiceUtil.kt':[
-13,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/IdentityServiceUtil.kt": [
+13
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/FiberDeserializationCheckingInterceptor.kt':[
-32,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/FiberDeserializationCheckingInterceptor.kt": [
+32
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TransactionGraphSearch.kt':[
-44,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TransactionGraphSearch.kt": [
+44
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt':[
-194,
-],
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt": [
+194
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1067.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1067.json
@@ -1,30 +1,30 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/CordaException.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/CordaException.kt": [
 53,
-99,
+99
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/internal/SerializationEnvironment.kt':[
-48,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/internal/SerializationEnvironment.kt": [
+48
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/avalanche/src/main/kotlin/net/corda/avalanche/Main.kt':[
-176,
+"kotlin-corda-project:sources/kotlin/corda/experimental/avalanche/src/main/kotlin/net/corda/avalanche/Main.kt": [
+176
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt':[
-213,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt": [
+213
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt':[
-253,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt": [
+253
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/CordaClassResolver.kt':[
-66,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/CordaClassResolver.kt": [
+66
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRtConfig.kt':[
-95,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRtConfig.kt": [
+95
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AddressUtils.kt':[
-24,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AddressUtils.kt": [
+24
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/FlowStackSnapshot.kt':[
-112,
-],
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/FlowStackSnapshot.kt": [
+112
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S107.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S107.json
@@ -1,54 +1,54 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt':[
-405,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt": [
+405
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt": [
 151,
 199,
 235,
-263,
+263
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt':[
-652,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt": [
+652
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt':[
-146,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt": [
+146
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/ArtemisRpcBroker.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/ArtemisRpcBroker.kt": [
 36,
-40,
+40
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt':[
-124,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt": [
+124
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRS.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRS.kt": [
 198,
 370,
-450,
+450
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt": [
 364,
-394,
+394
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt": [
 201,
 767,
-1114,
+1114
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt": [
 103,
-304,
+304
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt':[
-10,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt": [
+10
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt':[
-78,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt": [
+78
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt':[
-149,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt": [
+149
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/identicon/IdenticonRenderer.kt':[
-152,
-],
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/identicon/IdenticonRenderer.kt": [
+152
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S108.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S108.json
@@ -1,42 +1,42 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AssociatedList.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AssociatedList.kt": [
 29,
-31,
+31
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt": [
 411,
 421,
-597,
+597
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt':[
-467,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt": [
+467
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/Eventually.kt':[
-17,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/Eventually.kt": [
+17
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt':[
-82,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt": [
+82
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt':[
-750,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt": [
+750
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/PersistentMap.kt':[
-47,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/PersistentMap.kt": [
+47
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/TransactionCallbackTest.kt':[
-43,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/TransactionCallbackTest.kt": [
+43
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ClockUtilsTest.kt':[
-139,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ClockUtilsTest.kt": [
+139
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt": [
 87,
-119,
+119
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt':[
-257,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt": [
+257
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/web/WebServer.kt':[
-103,
-],
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/web/WebServer.kt": [
+103
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1110.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1110.json
@@ -1,5 +1,5 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt':[
-106,
-],
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt": [
+106
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1125.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1125.json
@@ -1,14 +1,14 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt": [
 42,
 43,
 56,
-57,
+57
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/UniqueIdentifier.kt':[
-35,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/UniqueIdentifier.kt": [
+35
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt':[
-304,
-],
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt": [
+304
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1128.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1128.json
@@ -1,88 +1,88 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/BlacklistKotlinClosureTest.kt':[
-4,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/BlacklistKotlinClosureTest.kt": [
+4
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/UntrustworthyData.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/UntrustworthyData.kt": [
 5,
 6,
-7,
+7
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt": [
 43,
-44,
+44
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt": [
 38,
-39,
+39
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt':[
-9,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt": [
+9
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt':[
-11,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt": [
+11
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt": [
 54,
-55,
+55
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt':[
-23,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt": [
+23
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt':[
-3,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt": [
+3
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt':[
-27,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt": [
+27
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt':[
-11,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt": [
+11
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/AbstractNodeTests.kt':[
-10,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/AbstractNodeTests.kt": [
+10
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepositoryTest.kt':[
-9,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepositoryTest.kt": [
+9
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt": [
 28,
-29,
+29
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt": [
 10,
+11
+],
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt": [
+10
+],
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt": [
 11,
+12
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt':[
-10,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt": [
+31
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt':[
-11,
-12,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt": [
+26
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt':[
-31,
-],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt':[
-26,
-],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt": [
 4,
-5,
+5
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt": [
 11,
-12,
+12
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/SerializationTestHelpers.kt':[
-6,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/SerializationTestHelpers.kt": [
+6
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt": [
 23,
-24,
+24
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt':[
-3,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt": [
+3
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/SSHServerTest.kt':[
-25,
-],
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/SSHServerTest.kt": [
+25
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1134.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1134.json
@@ -1,11 +1,11 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt':[
-280,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt": [
+280
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/test/kotlin/net/corda/netmap/simulation/IRSSimulationTest.kt':[
-11,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/test/kotlin/net/corda/netmap/simulation/IRSSimulationTest.kt": [
+11
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/RigorousMock.kt':[
-69,
-],
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/RigorousMock.kt": [
+69
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1135.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1135.json
@@ -1,291 +1,291 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt':[
-218,
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt": [
+218
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt": [
 114,
-257,
+257
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt": [
 364,
-365,
+365
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt':[
-101,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt": [
+101
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ExchangeRateModel.kt':[
-40,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ExchangeRateModel.kt": [
+40
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/Models.kt':[
-9,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/Models.kt": [
+9
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NodeMonitorModel.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NodeMonitorModel.kt": [
 90,
 130,
-131,
+131
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AggregatedList.kt':[
-33,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AggregatedList.kt": [
+33
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/FlattenedList.kt':[
-65,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/FlattenedList.kt": [
+65
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ObservableUtilities.kt':[
-122,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ObservableUtilities.kt": [
+122
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/LeftOuterJoinedMapTest.kt':[
-28,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/LeftOuterJoinedMapTest.kt": [
+28
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt':[
-55,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt": [
+55
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt": [
 29,
-179,
+179
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt':[
-156,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt": [
+156
 ],
-'kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/main/kotlin/net/corda/confidential/IdentitySyncFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/main/kotlin/net/corda/confidential/IdentitySyncFlow.kt": [
 22,
-65,
+65
 ],
-'kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt':[
-80,
+"kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt": [
+80
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/Utils.kt':[
-12,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/Utils.kt": [
+12
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt':[
-120,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt": [
+120
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Amount.kt':[
-41,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Amount.kt": [
+41
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Structures.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Structures.kt": [
 191,
 208,
-230,
+230
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/TransactionState.kt':[
-26,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/TransactionState.kt": [
+26
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt": [
 59,
 70,
-155,
+155
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt':[
-25,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt": [
+25
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt": [
 139,
 156,
 741,
 931,
-1009,
+1009
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt": [
 75,
 95,
-186,
+186
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/DigitalSignature.kt':[
-9,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/DigitalSignature.kt": [
+9
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt':[
-35,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt": [
+35
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/AbstractStateReplacementFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/AbstractStateReplacementFlow.kt": [
 162,
 182,
-183,
+183
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt": [
 63,
 77,
-219,
+219
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt':[
-76,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt": [
+76
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowInitiator.kt':[
-43,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowInitiator.kt": [
+43
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt": [
 356,
 369,
-382,
+382
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowLogicRef.kt':[
-60,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowLogicRef.kt": [
+60
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/InitiatingFlow.kt':[
-27,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/InitiatingFlow.kt": [
+27
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/NotaryChangeFlow.kt':[
-40,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/NotaryChangeFlow.kt": [
+40
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/NotaryError.kt':[
-64,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/NotaryError.kt": [
+64
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt':[
-52,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt": [
+52
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/StartableByRPC.kt':[
-12,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/StartableByRPC.kt": [
+12
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt':[
-41,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt": [
+41
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/CertRole.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/CertRole.kt": [
 25,
-38,
+38
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/DigitalSignatureWithCert.kt':[
-12,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/DigitalSignatureWithCert.kt": [
+12
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt": [
 77,
-88,
+88
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt": [
 182,
-432,
+432
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/LazyStickyPool.kt':[
-13,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/LazyStickyPool.kt": [
+13
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/LegalNameValidator.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/LegalNameValidator.kt": [
 89,
-100,
+100
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt": [
 18,
 84,
 126,
 131,
 160,
-181,
+181
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappImpl.kt':[
-31,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappImpl.kt": [
+31
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/NotaryUtils.kt':[
-23,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/NotaryUtils.kt": [
+23
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/TrustedAuthorityNotaryService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/TrustedAuthorityNotaryService.kt": [
 38,
-60,
+60
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt": [
 192,
 200,
 232,
 246,
-313,
+313
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/AppServiceHub.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/AppServiceHub.kt": [
 19,
-26,
+26
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/NodeInfo.kt':[
-27,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/NodeInfo.kt": [
+27
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt':[
-59,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt": [
+59
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/CordaService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/CordaService.kt": [
 18,
-19,
+19
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt':[
-82,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt": [
+82
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/CordaSerializable.kt':[
-17,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/CordaSerializable.kt": [
+17
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/CordaSerializationTransformRename.kt':[
-18,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/CordaSerializationTransformRename.kt": [
+18
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt": [
 21,
 22,
 177,
 195,
 216,
 224,
-240,
+240
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt": [
 26,
-148,
+148
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt':[
-82,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt": [
+82
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt": [
 78,
 136,
 185,
-190,
+190
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt':[
-125,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt": [
+125
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt':[
-103,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt": [
+103
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt": [
+72
+],
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/EncodingUtils.kt": [
 72,
+73
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/EncodingUtils.kt':[
-72,
-73,
-],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt": [
 201,
 276,
-277,
+277
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt':[
-83,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt": [
+83
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt": [
 147,
-157,
+157
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomVaultQuery.kt':[
-132,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomVaultQuery.kt": [
+132
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/mocknetwork/TutorialMockNetwork.kt':[
-72,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/mocknetwork/TutorialMockNetwork.kt": [
+72
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/kryo-hook/src/main/kotlin/net/corda/kryohook/KryoHook.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/kryo-hook/src/main/kotlin/net/corda/kryohook/KryoHook.kt": [
 112,
-120,
+120
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/quasar-hook/src/main/kotlin/net/corda/quasarhook/QuasarInstrumentationHook.kt':[
-170,
+"kotlin-corda-project:sources/kotlin/corda/experimental/quasar-hook/src/main/kotlin/net/corda/quasarhook/QuasarInstrumentationHook.kt": [
+170
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Arrangement.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Arrangement.kt": [
 27,
 28,
 43,
-44,
+44
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Perceivable.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Perceivable.kt": [
 158,
 162,
 165,
 169,
 172,
-177,
+177
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt": [
 35,
 89,
 106,
@@ -293,139 +293,139 @@
 115,
 120,
 203,
-212,
+212
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Util.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Util.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/compat/CompatibilityTest.kt':[
-15,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/compat/CompatibilityTest.kt": [
+15
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/CommercialPaper.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/CommercialPaper.kt": [
 47,
 152,
-157,
+157
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt": [
 183,
 195,
 220,
 259,
 321,
 401,
-426,
+426
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt':[
-197,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt": [
+197
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt": [
 431,
-668,
+668
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/OnLedgerAsset.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/OnLedgerAsset.kt": [
 117,
 121,
-264,
+264
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt": [
 50,
 108,
 145,
-155,
+155
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashConfigDataFlow.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashConfigDataFlow.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt':[
-70,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt": [
+70
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt':[
-55,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt": [
+55
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt": [
 25,
 26,
-27,
+27
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt": [
 38,
 61,
-152,
+152
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/CommercialPaperTests.kt':[
-37,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/CommercialPaperTests.kt": [
+37
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt':[
-79,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt": [
+79
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/DummyFungibleContract.kt':[
-147,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/DummyFungibleContract.kt": [
+147
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt':[
-49,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt": [
+49
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingClient.kt':[
-36,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingClient.kt": [
+36
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingComponent.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingComponent.kt": [
 32,
-38,
+38
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt": [
 27,
-28,
+28
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/KeyStoreConfigHelpers.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/KeyStoreConfigHelpers.kt": [
 17,
 60,
-108,
+108
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/SignedNodeInfo.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/SignedNodeInfo.kt": [
 18,
-24,
+24
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt':[
-37,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt": [
+37
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/SSLConfiguration.kt':[
-12,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/SSLConfiguration.kt": [
+12
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt": [
 44,
-444,
+444
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt": [
 49,
-277,
+277
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkMap.kt':[
-61,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkMap.kt": [
+61
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/HibernateConfiguration.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/HibernateConfiguration.kt": [
 54,
-61,
+61
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt": [
 70,
-412,
+412
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPClient.kt':[
-169,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPClient.kt": [
+169
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPServer.kt':[
-115,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPServer.kt": [
+115
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/distributed/DistributedServiceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/distributed/DistributedServiceTests.kt": [
 82,
-119,
+119
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt':[
-115,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt": [
+115
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt':[
-24,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt": [
+24
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt": [
 111,
 204,
 425,
@@ -436,164 +436,164 @@
 808,
 836,
 843,
-850,
+850
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt':[
-77,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt": [
+77
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt':[
-45,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt": [
+45
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/Node.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/Node.kt": [
 110,
-254,
+254
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt':[
-200,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt": [
+200
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeUniqueIdProvider.kt':[
-11,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeUniqueIdProvider.kt": [
+11
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt':[
-154,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt": [
+154
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt':[
-62,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt": [
+62
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/CordaClassResolver.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/CordaClassResolver.kt": [
 109,
-121,
+121
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/DefaultKryoCustomizer.kt':[
-82,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/DefaultKryoCustomizer.kt": [
+82
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt": [
 148,
-300,
+300
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoSerializationScheme.kt':[
-51,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoSerializationScheme.kt": [
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt": [
 14,
 16,
 31,
-42,
+42
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/AuditService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/AuditService.kt": [
 49,
 132,
-136,
+136
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt':[
-178,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt": [
+178
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt": [
 70,
-73,
+73
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt": [
 49,
-185,
+185
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt':[
-293,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt": [
+293
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/ScheduledActivityObserver.kt':[
-26,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/ScheduledActivityObserver.kt": [
+26
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt": [
 25,
-89,
+89
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt": [
 39,
-185,
+185
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/E2ETestKeyManagementService.kt':[
-77,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/E2ETestKeyManagementService.kt": [
+77
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt": [
 70,
 98,
-108,
+108
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt": [
 36,
 37,
-86,
+86
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt':[
-142,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt": [
+142
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt':[
-192,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt": [
+192
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt": [
 433,
-444,
+444
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt": [
 150,
-179,
+179
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt": [
 44,
 51,
-125,
+125
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt": [
 51,
 92,
-245,
+245
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt": [
 286,
-293,
+293
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/schema/HibernateObserver.kt':[
-27,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/schema/HibernateObserver.kt": [
+27
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt':[
-31,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt": [
+31
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt':[
-149,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt": [
+149
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt':[
-153,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt": [
+153
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImpl.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImpl.kt": [
 28,
 34,
 62,
-91,
+91
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt": [
 281,
 283,
-300,
+300
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt": [
 229,
 476,
-737,
+737
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt':[
-25,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt": [
+25
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt": [
 32,
-33,
+33
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt':[
-29,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt": [
+29
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt": [
 87,
-107,
+107
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRt.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRt.kt": [
 50,
 51,
 53,
@@ -604,103 +604,103 @@
 139,
 149,
 169,
-273,
+273
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt':[
-83,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt": [
+83
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLog.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLog.kt": [
 62,
 63,
-161,
+161
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftUniquenessProvider.kt':[
-139,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftUniquenessProvider.kt": [
+139
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt':[
-290,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt": [
+290
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt": [
 44,
 427,
-475,
+475
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt':[
-34,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt": [
+34
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AffinityExecutor.kt':[
-33,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AffinityExecutor.kt": [
+33
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt": [
 66,
-308,
+308
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/NonInvalidatingCache.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/NonInvalidatingCache.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/NonInvalidatingUnboundCache.kt':[
-27,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/NonInvalidatingUnboundCache.kt": [
+27
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/ObjectDiffer.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/ObjectDiffer.kt": [
 72,
-99,
+99
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/HTTPNetworkRegistrationService.kt':[
-24,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/HTTPNetworkRegistrationService.kt": [
+24
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt": [
 30,
-45,
+45
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappProviderImplTests.kt':[
-18,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappProviderImplTests.kt": [
+18
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt':[
-142,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt": [
+142
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/serialization/kryo/KryoTests.kt':[
-202,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/serialization/kryo/KryoTests.kt": [
+202
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt':[
-186,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt": [
+186
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/identity/InMemoryIdentityServiceTests.kt':[
-106,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/identity/InMemoryIdentityServiceTests.kt": [
+106
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapCacheTest.kt':[
-56,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapCacheTest.kt": [
+56
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt": [
 95,
 105,
 132,
 143,
-203,
+203
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/schema/NodeSchemaServiceTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/schema/NodeSchemaServiceTest.kt": [
 94,
-102,
+102
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt':[
-40,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt": [
+40
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt':[
-545,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt": [
+545
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt':[
-43,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt": [
+43
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaClientApi.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaClientApi.kt": [
 20,
-33,
+33
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt": [
 92,
 122,
 167,
-195,
+195
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRS.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRS.kt": [
 102,
 152,
 171,
@@ -710,82 +710,82 @@
 532,
 618,
 670,
-671,
+671
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRSUtils.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRSUtils.kt": [
 17,
-89,
+89
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt':[
-49,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt": [
+49
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt": [
 40,
-51,
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt": [
 89,
-100,
+100
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/utilities/OracleUtils.kt':[
-18,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/utilities/OracleUtils.kt": [
+18
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt": [
 108,
 111,
 196,
-199,
+199
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt':[
-40,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt": [
+40
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/main/kotlin/net/corda/irs/web/IrsDemoWebApplication.kt':[
-37,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/main/kotlin/net/corda/irs/web/IrsDemoWebApplication.kt": [
+37
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/main/kotlin/net/corda/irs/web/api/InterestSwapRestAPI.kt':[
-26,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/main/kotlin/net/corda/irs/web/api/InterestSwapRestAPI.kt": [
+26
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/demo/IrsDemoClientApi.kt':[
-24,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/demo/IrsDemoClientApi.kt": [
+24
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt':[
-33,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt": [
+33
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserView.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserView.kt": [
 257,
-303,
+303
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserViewModel.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserViewModel.kt": [
 166,
-202,
+202
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt": [
 127,
-161,
+161
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/Simulation.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/Simulation.kt": [
 58,
-75,
+75
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/test/kotlin/net/corda/netmap/simulation/IRSSimulationTest.kt':[
-8,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/test/kotlin/net/corda/netmap/simulation/IRSSimulationTest.kt": [
+8
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/IRSState.kt':[
-17,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/IRSState.kt": [
+17
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/SwapData.kt':[
-71,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/SwapData.kt": [
+71
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/AnalyticsEngine.kt':[
-140,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/AnalyticsEngine.kt": [
+140
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/OGUtils.kt':[
-7,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/OGUtils.kt": [
+7
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/IRSTradeFlow.kt':[
-23,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/IRSTradeFlow.kt": [
+23
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt": [
 81,
 141,
 142,
@@ -793,81 +793,81 @@
 187,
 258,
 259,
-276,
+276
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApi.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApi.kt": [
 31,
 40,
 101,
 219,
 234,
 256,
-263,
+263
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApiUtils.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApiUtils.kt": [
 151,
-166,
+166
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/SwapDataView.kt':[
-53,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/SwapDataView.kt": [
+53
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt':[
-56,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt": [
+56
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/BuyerFlow.kt':[
-57,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/BuyerFlow.kt": [
+57
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/CommercialPaperIssueFlow.kt':[
-48,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/CommercialPaperIssueFlow.kt": [
+48
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/AllButBlacklisted.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/AllButBlacklisted.kt": [
 59,
 72,
 82,
 107,
-133,
+133
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/AttachmentsClassLoader.kt':[
-87,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/AttachmentsClassLoader.kt": [
+87
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ClassWhitelists.kt':[
-45,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ClassWhitelists.kt": [
+45
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/SerializationScheme.kt':[
-94,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/SerializationScheme.kt": [
+94
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt':[
-41,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt": [
+41
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CollectionSerializer.kt':[
-92,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CollectionSerializer.kt": [
+92
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt": [
 60,
-62,
+62
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Envelope.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Envelope.kt": [
 14,
-15,
+15
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializer.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializer.kt": [
 70,
-199,
+199
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/FingerPrinter.kt':[
-158,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/FingerPrinter.kt": [
+158
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/MapSerializer.kt':[
-101,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/MapSerializer.kt": [
+101
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertySerializers.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertySerializers.kt": [
 35,
-77,
+77
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt':[
-430,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt": [
+430
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt": [
 30,
 31,
 32,
@@ -881,173 +881,173 @@
 40,
 143,
 308,
-313,
+313
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformTypes.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformTypes.kt": [
 21,
-22,
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PublicKeySerializer.kt':[
-19,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PublicKeySerializer.kt": [
+19
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ThrowableSerializer.kt':[
-48,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ThrowableSerializer.kt": [
+48
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt": [
 102,
 103,
 104,
 105,
-106,
+106
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt": [
 294,
-443,
+443
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt':[
-261,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt": [
+261
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt':[
-142,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt": [
+142
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt": [
 73,
-124,
+124
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt": [
 123,
 183,
 348,
 493,
 524,
 701,
-756,
+756
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt':[
-32,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt": [
+32
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeConfig.kt':[
-31,
+"kotlin-corda-project:sources/kotlin/corda/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeConfig.kt": [
+31
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeProcess.kt':[
-48,
+"kotlin-corda-project:sources/kotlin/corda/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeProcess.kt": [
+48
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt':[
-15,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt": [
+15
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt':[
-153,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt": [
+153
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/LedgerDSLInterpreter.kt':[
-87,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/LedgerDSLInterpreter.kt": [
+87
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalSerializationTestHelpers.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalSerializationTestHelpers.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt": [
 118,
-125,
+125
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt':[
-183,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt": [
+183
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/explorer/Explorer.kt':[
-86,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/explorer/Explorer.kt": [
+86
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt':[
-100,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt": [
+100
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt':[
-245,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt": [
+245
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt':[
-67,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt": [
+67
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt':[
-100,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt": [
+100
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/AmountFormatter.kt':[
-13,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/AmountFormatter.kt": [
+13
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/NumberFormatter.kt':[
-4,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/NumberFormatter.kt": [
+4
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/identicon/IdenticonRenderer.kt':[
-120,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/identicon/IdenticonRenderer.kt": [
+120
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/CordaViewModel.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/CordaViewModel.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/GuiUtilities.kt':[
-92,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/GuiUtilities.kt": [
+92
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/LoginView.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/LoginView.kt": [
 41,
-51,
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/Network.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/Network.kt": [
 101,
 116,
 181,
-207,
+207
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/SearchField.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/SearchField.kt": [
 23,
-64,
+64
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/Settings.kt':[
-47,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/Settings.kt": [
+47
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt": [
 226,
 227,
 301,
-314,
+314
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/CashViewer.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/CashViewer.kt": [
 130,
 213,
 227,
 237,
 272,
-277,
+277
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt": [
 189,
-209,
+209
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/Disruption.kt':[
-29,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/Disruption.kt": [
+29
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt": [
 35,
 182,
-196,
+196
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/Main.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/Main.kt": [
 23,
 91,
-120,
+120
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/NodeConnection.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/NodeConnection.kt": [
 26,
 42,
-55,
+55
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt": [
 73,
-260,
+260
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/NotaryTest.kt':[
-34,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/NotaryTest.kt": [
+34
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt':[
-226,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt": [
+226
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/FlowWatchPrintingSubscriber.kt':[
-68,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/FlowWatchPrintingSubscriber.kt": [
+68
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt": [
 67,
 68,
 69,
@@ -1060,28 +1060,28 @@
 76,
 237,
 315,
-370,
+370
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt':[
-204,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt": [
+204
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/WebServerConfig.kt':[
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/WebServerConfig.kt": [
 33,
-35,
+35
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/api/Query.kt':[
-13,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/api/Query.kt": [
+13
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt':[
-58,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt": [
+58
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt':[
-24,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt": [
+24
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/CorDappInfoServlet.kt':[
-16,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/CorDappInfoServlet.kt": [
+16
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/ResponseFilter.kt':[
-19,
-],
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/ResponseFilter.kt": [
+19
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1143.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1143.json
@@ -1,5 +1,5 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt':[
-290,
-],
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt": [
+290
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1144.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1144.json
@@ -1,12 +1,12 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/DatabaseConnection.kt':[
-44,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/DatabaseConnection.kt": [
+44
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt": [
 765,
-769,
+769
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedType.kt':[
-24,
-],
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedType.kt": [
+24
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1151.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1151.json
@@ -1,55 +1,55 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AssociatedList.kt':[
-33,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AssociatedList.kt": [
+33
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt": [
 299,
-315,
+315
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt':[
-82,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt": [
+82
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/PrettyPrint.kt':[
-99,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/PrettyPrint.kt": [
+99
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt": [
 191,
-256,
+256
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt':[
-300,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt": [
+300
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt": [
 605,
-624,
+624
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DeliverSessionMessageTransition.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DeliverSessionMessageTransition.kt": [
+58
+],
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt": [
+155
+],
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt": [
+279
+],
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt": [
+790
+],
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt": [
 58,
+144
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt':[
-155,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/FingerPrinter.kt": [
+140
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt':[
-279,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/LoginView.kt": [
+39
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt':[
-790,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt": [
+292
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt':[
-58,
-144,
-],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/FingerPrinter.kt':[
-140,
-],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/LoginView.kt':[
-39,
-],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt':[
-292,
-],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt": [
 162,
-189,
-],
+189
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S117.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S117.json
@@ -1,18 +1,18 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt": [
 62,
 77,
-149,
+149
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt": [
 104,
 105,
 106,
 107,
 108,
-109,
+109
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt": [
 299,
 300,
 301,
@@ -22,66 +22,66 @@
 325,
 326,
 327,
-328,
+328
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt": [
 109,
 164,
 219,
 274,
-329,
+329
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt':[
-104,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt": [
+104
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Literal.kt':[
-142,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Literal.kt": [
+142
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt':[
-56,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt": [
+56
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt':[
-93,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt": [
+93
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt": [
 291,
-305,
+305
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/ScheduledActivityObserver.kt':[
-15,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/ScheduledActivityObserver.kt": [
+15
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt':[
-142,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt": [
+142
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/schema/HibernateObserverTests.kt':[
-70,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/schema/HibernateObserverTests.kt": [
+70
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImplTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImplTest.kt": [
 17,
-20,
+20
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt": [
 150,
 156,
 267,
-273,
+273
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApi.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApi.kt": [
 124,
 125,
 213,
-213,
+213
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/SwapDataView.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/SwapDataView.kt": [
 24,
 25,
-31,
+31
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/CorDappSerializerTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/CorDappSerializerTests.kt": [
 20,
-32,
+32
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolveTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolveTests.kt": [
 179,
 180,
 181,
@@ -99,15 +99,15 @@
 211,
 213,
 214,
-215,
+215
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTests.kt": [
 83,
 84,
 111,
-112,
+112
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolvabilityTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolvabilityTests.kt": [
 43,
 44,
 64,
@@ -131,14 +131,14 @@
 343,
 345,
 346,
-594,
+594
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/GenericsTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/GenericsTests.kt": [
 141,
 142,
-143,
+143
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/PrivatePropertyTests.kt':[
-211,
-],
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/PrivatePropertyTests.kt": [
+211
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1172.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1172.json
@@ -1,64 +1,64 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/tearoffs/TutorialTearOffs.kt':[
-14,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/tearoffs/TutorialTearOffs.kt": [
+14
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/process/CommandTests.kt':[
-24,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/process/CommandTests.kt": [
+24
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt':[
-38,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt": [
+38
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt':[
-34,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt": [
+34
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt':[
-143,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt": [
+143
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt": [
 151,
-166,
+166
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt':[
-63,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt": [
+63
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/RoundTripObservableSerializerTests.kt':[
-51,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/RoundTripObservableSerializerTests.kt": [
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/Main.kt':[
-14,
+"kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/Main.kt": [
+14
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/Main.kt':[
-14,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/Main.kt": [
+14
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt':[
-17,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt": [
+17
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/Clean.kt':[
-5,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/Clean.kt": [
+5
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/CustomNotaryCordform.kt':[
-12,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/CustomNotaryCordform.kt": [
+12
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/Notarise.kt':[
-17,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/Notarise.kt": [
+17
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt':[
-16,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt": [
+16
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt':[
-14,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt": [
+14
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingExample.kt':[
-54,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingExample.kt": [
+54
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/Main.kt':[
-15,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/Main.kt": [
+15
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/Main.kt':[
-20,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/Main.kt": [
+20
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/SettingsModel.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/SettingsModel.kt": [
 52,
-63,
-],
+63
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1186.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1186.json
@@ -1,130 +1,130 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt':[
-64,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt": [
+64
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/Utils.kt':[
-40,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/Utils.kt": [
+40
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt':[
-254,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt": [
+254
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/node/VaultUpdateTests.kt':[
-24,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/node/VaultUpdateTests.kt": [
+24
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt':[
-41,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt": [
+41
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/LaunchSpaceshipFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/LaunchSpaceshipFlow.kt": [
 22,
-67,
+67
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/Service.kt':[
-62,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/Service.kt": [
+62
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/tests/StepsProviderTests.kt':[
-29,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/tests/StepsProviderTests.kt": [
+29
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt": [
 232,
 233,
-234,
+234
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt':[
-40,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt": [
+40
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt": [
 961,
-963,
+963
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/PropagatingFlowHospital.kt':[
-24,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/PropagatingFlowHospital.kt": [
+24
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt':[
-72,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt": [
+72
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt':[
-164,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt": [
+164
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/SimpleNotaryService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/SimpleNotaryService.kt": [
 15,
-16,
+16
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryService.kt": [
 15,
-16,
+16
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt':[
-208,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt": [
+208
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/testutils/TestObservableContext.kt':[
-17,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/testutils/TestObservableContext.kt": [
+17
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt':[
-188,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt": [
+188
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt':[
-138,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt": [
+138
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt':[
-74,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt": [
+74
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/IrsDemoWebApplicationTests.kt':[
-17,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/IrsDemoWebApplicationTests.kt": [
+17
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt':[
-88,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt": [
+88
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/CustomNotaryCordform.kt':[
-48,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/CustomNotaryCordform.kt": [
+48
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt": [
 33,
-34,
+34
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt':[
-81,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt": [
+81
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt':[
-54,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt": [
+54
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/DummyIssueAndMove.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/DummyIssueAndMove.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPPrimitiveSerializer.kt':[
-19,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPPrimitiveSerializer.kt": [
+19
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CorDappCustomSerializer.kt':[
-66,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CorDappCustomSerializer.kt": [
+66
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt':[
-104,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt": [
+104
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertySerializer.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertySerializer.kt": [
 101,
-128,
+128
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformTypes.kt':[
-31,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformTypes.kt": [
+31
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt": [
 87,
 90,
-99,
+99
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt": [
 665,
-679,
+679
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt':[
-446,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt": [
+446
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyDealContract.kt':[
-17,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyDealContract.kt": [
+17
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/ConnectionManager.kt':[
-43,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/ConnectionManager.kt": [
+43
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/services/WebServerPluginRegistry.kt':[
-29,
-],
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/services/WebServerPluginRegistry.kt": [
+29
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1192.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1192.json
@@ -1,107 +1,107 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTests.kt": [
 54,
-85,
+85
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeSignature.kt':[
-33,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeSignature.kt": [
+33
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/CertRole.kt':[
-56,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/CertRole.kt": [
+56
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/ContractsDSLTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/ContractsDSLTests.kt": [
 39,
-40,
+40
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/StructuresTests.kt':[
-51,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/StructuresTests.kt": [
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/TransactionVerificationExceptionSerialisationTests.kt':[
-61,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/TransactionVerificationExceptionSerialisationTests.kt": [
+61
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt": [
 492,
 667,
-692,
+692
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt':[
-66,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt": [
+66
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/X509NameConstraintsTest.kt':[
-54,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/X509NameConstraintsTest.kt": [
+54
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt": [
 14,
-15,
+15
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/AbstractAttachmentTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/AbstractAttachmentTest.kt": [
 34,
 34,
 34,
-63,
+63
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/LegalNameValidatorTest.kt':[
-56,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/LegalNameValidatorTest.kt": [
+56
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/TransactionEncumbranceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/TransactionEncumbranceTests.kt": [
 80,
-92,
+92
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/NetworkHostAndPortTest.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/NetworkHostAndPortTest.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt':[
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt": [
 135,
 206,
-222,
+222
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt": [
 48,
 48,
 52,
 71,
 213,
 214,
-220,
+220
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Caplet.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Caplet.kt": [
 27,
 27,
 27,
-100,
+100
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/ContractDefinition.kt':[
-28,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/ContractDefinition.kt": [
+28
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Examples.kt':[
-14,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Examples.kt": [
+14
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXFwdTimeOption.kt':[
-84,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXFwdTimeOption.kt": [
+84
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXSwap.kt':[
-139,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXSwap.kt": [
+139
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/IRS.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/IRS.kt": [
 37,
 37,
 40,
 43,
 47,
 58,
-163,
+163
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/RollOutTests.kt':[
-17,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/RollOutTests.kt": [
+17
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/flows/CashSelectionTest.kt':[
-26,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/flows/CashSelectionTest.kt": [
+26
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt": [
 134,
-791,
+791
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt": [
 83,
 99,
 100,
@@ -109,160 +109,160 @@
 102,
 118,
 511,
-601,
+601
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt": [
 53,
-112,
+112
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NodeInfoFilesCopier.kt':[
-51,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NodeInfoFilesCopier.kt": [
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt':[
-131,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt": [
+131
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt':[
-147,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt": [
+147
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt':[
-366,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt": [
+366
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt": [
 40,
-43,
+43
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt": [
 102,
-147,
+147
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/TypesafeCordappConfig.kt':[
-20,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/TypesafeCordappConfig.kt": [
+20
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/NodeArgsParserTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/NodeArgsParserTest.kt": [
 37,
 54,
 69,
 112,
-136,
+136
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/InMemoryMessagingTests.kt':[
-52,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/InMemoryMessagingTests.kt": [
+52
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt": [
 140,
-347,
+347
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/RPCSecurityManagerTest.kt':[
-97,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/RPCSecurityManagerTest.kt": [
+97
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt": [
 82,
 102,
 103,
-134,
+134
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt':[
-130,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt": [
+130
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt": [
 85,
-183,
+183
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentStorageTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentStorageTest.kt": [
 68,
 69,
 71,
-72,
+72
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt':[
-54,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt": [
+54
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt": [
 56,
 71,
 71,
-185,
+185
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImplTest.kt':[
-48,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImplTest.kt": [
+48
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/BFTSMaRtConfigTests.kt':[
-34,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/BFTSMaRtConfigTests.kt": [
+34
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt':[
-2076,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt": [
+2076
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ClockUtilsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ClockUtilsTest.kt": [
 47,
-73,
+73
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/NodeInterestRatesTest.kt':[
-85,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/NodeInterestRatesTest.kt": [
+85
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt':[
-78,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt": [
+78
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt": [
 241,
 418,
 422,
 439,
 690,
-703,
+703
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt':[
-68,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt": [
+68
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt':[
-37,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt": [
+37
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt':[
-307,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt": [
+307
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/AttachmentsClassLoaderTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/AttachmentsClassLoaderTests.kt": [
 128,
 129,
 141,
-142,
+142
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/CorDappSerializerTests.kt':[
-77,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/CorDappSerializerTests.kt": [
+77
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/OverridePKSerializerTest.kt':[
-29,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/OverridePKSerializerTest.kt": [
+29
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt": [
 325,
-1296,
+1296
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTest.kt": [
 29,
-179,
+179
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/EnumClassTests.kt':[
-14,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/EnumClassTests.kt": [
+14
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt':[
-226,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt": [
+226
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/JVMConfigTest.kt':[
-30,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/JVMConfigTest.kt": [
+30
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt": [
 15,
-16,
+16
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt": [
 79,
-82,
+82
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/CustomTypeJsonParsingTests.kt':[
-36,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/CustomTypeJsonParsingTests.kt": [
+36
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/StandaloneShellArgsParserTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/StandaloneShellArgsParserTest.kt": [
 18,
 19,
 26,
-29,
-],
+29
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S122.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S122.json
@@ -1,23 +1,23 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt':[
-217,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt": [
+217
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt':[
-45,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt": [
+45
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserView.kt':[
-227,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserView.kt": [
+227
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserViewModel.kt':[
-217,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserViewModel.kt": [
+217
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/AMQPSchemaExtensions.kt':[
-145,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/AMQPSchemaExtensions.kt": [
+145
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/AttachmentsClassLoaderTests.kt':[
-99,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/AttachmentsClassLoaderTests.kt": [
+99
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt": [
 115,
 153,
 168,
@@ -30,14 +30,14 @@
 436,
 437,
 510,
-513,
+513
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/GenericsTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/GenericsTests.kt": [
 154,
 161,
-168,
+168
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt':[
-283,
-],
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt": [
+283
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S125.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S125.json
@@ -1,52 +1,52 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/CompatibleTransactionTests.kt':[
-443,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/CompatibleTransactionTests.kt": [
+443
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Perceivable.kt':[
-51,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Perceivable.kt": [
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Util.kt':[
-84,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Util.kt": [
+84
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/Node.kt':[
-202,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/Node.kt": [
+202
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/TLSAuthenticationTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/TLSAuthenticationTests.kt": [
 297,
 324,
-329,
+329
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRSUtils.kt':[
-91,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRSUtils.kt": [
+91
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingCcpExample.kt':[
-124,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingCcpExample.kt": [
+124
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingExample.kt':[
-94,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingExample.kt": [
+94
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/SwapExample.kt':[
-82,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/SwapExample.kt": [
+82
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt':[
-229,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt": [
+229
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolvabilityTests.kt':[
-434,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolvabilityTests.kt": [
+434
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolveTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolveTests.kt": [
 44,
 72,
-112,
+112
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolvabilityTests.kt':[
-268,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolvabilityTests.kt": [
+268
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/GenericsTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/GenericsTests.kt": [
 263,
 378,
 401,
 425,
-493,
-],
+493
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S126.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S126.json
@@ -1,53 +1,53 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/MapValuesList.kt':[
-48,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/MapValuesList.kt": [
+48
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ObservableUtilities.kt':[
-201,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ObservableUtilities.kt": [
+201
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/PartialMerkleTree.kt':[
-183,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/PartialMerkleTree.kt": [
+183
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/process/Command.kt':[
-95,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/process/Command.kt": [
+95
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt':[
-753,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt": [
+753
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt": [
 308,
-379,
+379
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/JolokiaSlf4jAdapter.kt':[
-19,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/JolokiaSlf4jAdapter.kt": [
+19
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt':[
-187,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt": [
+187
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/IdentityServiceUtil.kt':[
-13,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/IdentityServiceUtil.kt": [
+13
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/ObjectDiffer.kt':[
-140,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/ObjectDiffer.kt": [
+140
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt':[
-234,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt": [
+234
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt": [
 102,
 240,
-286,
+286
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedType.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedType.kt": [
 70,
-80,
+80
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializer.kt':[
-95,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializer.kt": [
+95
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt": [
 45,
 178,
-186,
-],
+186
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1313.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1313.json
@@ -1,23 +1,23 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt':[
-124,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt": [
+124
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt':[
-24,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt": [
+24
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/X509EdDSAEngineTest.kt':[
-47,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/X509EdDSAEngineTest.kt": [
+47
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/NetworkHostAndPortTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/NetworkHostAndPortTest.kt": [
 35,
 35,
 46,
-46,
+46
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt':[
-110,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt": [
+110
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/AddressUtilsTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/AddressUtilsTests.kt": [
 18,
 19,
 20,
@@ -27,6 +27,6 @@
 25,
 26,
 27,
-29,
-],
+29
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S134.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S134.json
@@ -1,85 +1,85 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AggregatedList.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AggregatedList.kt": [
 83,
-89,
+89
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ConcatenatedList.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ConcatenatedList.kt": [
 98,
 107,
 139,
 157,
 167,
 184,
-205,
+205
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/FlattenedList.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/FlattenedList.kt": [
 70,
-90,
+90
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/MappedList.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/MappedList.kt": [
 47,
-55,
+55
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ReplayedList.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ReplayedList.kt": [
 43,
-51,
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt": [
 309,
-332,
+332
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Amount.kt':[
-165,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Amount.kt": [
+165
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt':[
-91,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt": [
+91
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/kryo-hook/src/main/kotlin/net/corda/kryohook/KryoHook.kt':[
-83,
+"kotlin-corda-project:sources/kotlin/corda/experimental/kryo-hook/src/main/kotlin/net/corda/kryohook/KryoHook.kt": [
+83
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt':[
-257,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt": [
+257
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt':[
-161,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt": [
+161
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt": [
 137,
-371,
+371
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/Node.kt':[
-262,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/Node.kt": [
+262
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt':[
-269,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt": [
+269
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/ObjectDiffer.kt':[
-101,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/ObjectDiffer.kt": [
+101
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt':[
-158,
+"kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt": [
+158
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedType.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedType.kt": [
 88,
-100,
+100
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/FingerPrinter.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/FingerPrinter.kt": [
 110,
-141,
+141
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt": [
 46,
 177,
 185,
-194,
+194
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt':[
-134,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt": [
+134
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt':[
-280,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt": [
+280
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt':[
-286,
-],
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt": [
+286
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S138.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S138.json
@@ -1,11 +1,11 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/EdDSATests.kt':[
-20,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/EdDSATests.kt": [
+20
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt':[
-89,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt": [
+89
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt':[
-56,
-],
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt": [
+56
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1451.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1451.json
@@ -1,3527 +1,3527 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/JacksonUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/JacksonUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/test/kotlin/net/corda/client/jackson/StringToMethodCallParserTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/test/kotlin/net/corda/client/jackson/StringToMethodCallParserTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ContractStateModel.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ContractStateModel.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ExchangeRateModel.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ExchangeRateModel.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/Models.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/Models.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ModelsUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ModelsUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NetworkIdentityModel.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NetworkIdentityModel.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NodeMonitorModel.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NodeMonitorModel.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/TrackedDelegate.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/TrackedDelegate.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/TransactionDataModel.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/model/TransactionDataModel.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AggregatedList.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AggregatedList.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AmountBindings.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AmountBindings.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AssociatedList.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AssociatedList.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ChosenList.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ChosenList.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ConcatenatedList.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ConcatenatedList.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/FlattenedList.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/FlattenedList.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/LeftOuterJoinedMap.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/LeftOuterJoinedMap.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/MapValuesList.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/MapValuesList.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/MappedList.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/MappedList.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ObservableFold.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ObservableFold.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ObservableUtilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ObservableUtilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ReadOnlyBackedObservableMapBase.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ReadOnlyBackedObservableMapBase.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ReplayedList.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ReplayedList.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/model/ExchangeRateModelTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/model/ExchangeRateModelTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/AggregatedListTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/AggregatedListTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/AssociatedListTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/AssociatedListTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/ConcatenatedListTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/ConcatenatedListTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/FlattenedListTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/FlattenedListTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/LeftOuterJoinedMapTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/LeftOuterJoinedMapTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/MappedListTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/MappedListTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/ReplayedListTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/ReplayedListTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/ReplayedMap.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/test/kotlin/net/corda/client/jfx/utils/ReplayedMap.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/mock/src/main/kotlin/net/corda/client/mock/EventGenerator.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/mock/src/main/kotlin/net/corda/client/mock/EventGenerator.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/mock/src/main/kotlin/net/corda/client/mock/Generator.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/mock/src/main/kotlin/net/corda/client/mock/Generator.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/mock/src/main/kotlin/net/corda/client/mock/Generators.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/mock/src/main/kotlin/net/corda/client/mock/Generators.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/BlacklistKotlinClosureTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/BlacklistKotlinClosureTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/FlowsExecutionModeRpcTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/FlowsExecutionModeRpcTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/PermissionException.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/PermissionException.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/RPCConnection.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/RPCConnection.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/RPCException.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/RPCException.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/RPCSinceVersion.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/RPCSinceVersion.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/Utils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/Utils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/CordaRPCClientUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/CordaRPCClientUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/serialization/amqp/AMQPClientSerializationScheme.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/serialization/amqp/AMQPClientSerializationScheme.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/serialization/amqp/RpcClientCordaFutureSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/serialization/amqp/RpcClientCordaFutureSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/serialization/amqp/RpcClientObservableSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/serialization/amqp/RpcClientObservableSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/AbstractRPCTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/AbstractRPCTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/Measure.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/Measure.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCFailureTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCFailureTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RepeatingBytesInputStream.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RepeatingBytesInputStream.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/main/kotlin/net/corda/confidential/IdentitySyncFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/main/kotlin/net/corda/confidential/IdentitySyncFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/ClientRelevantError.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/ClientRelevantError.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/CordaException.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/CordaException.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/CordaInternal.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/CordaInternal.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/CordaOID.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/CordaOID.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/DoNotImplement.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/DoNotImplement.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/Utils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/Utils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/concurrent/ConcurrencyUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/concurrent/ConcurrencyUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/concurrent/CordaFuture.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/concurrent/CordaFuture.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/context/Trace.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/context/Trace.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Amount.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Amount.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Attachment.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Attachment.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/ComponentGroupEnum.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/ComponentGroupEnum.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/ContractAttachment.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/ContractAttachment.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/ContractState.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/ContractState.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/FungibleAsset.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/FungibleAsset.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Structures.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Structures.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/TimeWindow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/TimeWindow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/TransactionState.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/TransactionState.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/UniqueIdentifier.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/UniqueIdentifier.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/cordapp/ConfigException.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/cordapp/ConfigException.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/cordapp/Cordapp.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/cordapp/Cordapp.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/cordapp/CordappConfig.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/cordapp/CordappConfig.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/cordapp/CordappContext.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/cordapp/CordappContext.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/cordapp/CordappProvider.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/cordapp/CordappProvider.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeKeyFactory.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeKeyFactory.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeSignature.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeSignature.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeSignaturesWithKeys.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeSignaturesWithKeys.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/DigitalSignature.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/DigitalSignature.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/MerkleTree.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/MerkleTree.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/NullKeys.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/NullKeys.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/PartialMerkleTree.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/PartialMerkleTree.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/SignableData.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/SignableData.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/SignatureMetadata.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/SignatureMetadata.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/SignatureScheme.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/SignatureScheme.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/SignedData.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/SignedData.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/TransactionSignature.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/TransactionSignature.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/AbstractStateReplacementFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/AbstractStateReplacementFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowException.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowException.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowInitiator.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowInitiator.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowLogicRef.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowLogicRef.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowSession.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowSession.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowStackSnapshot.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowStackSnapshot.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/InitiatedBy.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/InitiatedBy.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/InitiatingFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/InitiatingFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/NotaryChangeFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/NotaryChangeFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/NotaryError.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/NotaryError.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/NotaryWireFormat.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/NotaryWireFormat.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/SchedulableFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/SchedulableFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/SendTransactionFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/StartableByRPC.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/StartableByRPC.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/StartableByService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/StartableByService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/StateMachineRunId.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/StateMachineRunId.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/AbstractParty.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/AbstractParty.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/AnonymousParty.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/AnonymousParty.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/IdentityUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/IdentityUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/Party.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/Party.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/PartyAndCertificate.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/identity/PartyAndCertificate.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/AttachmentWithContext.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/AttachmentWithContext.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/CertRole.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/CertRole.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/ContractUpgradeUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/ContractUpgradeUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/DigitalSignatureWithCert.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/DigitalSignatureWithCert.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/Emoji.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/Emoji.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/FlowAsyncOperation.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/FlowAsyncOperation.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/FlowIORequest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/FlowIORequest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/LazyPool.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/LazyPool.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/LazyStickyPool.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/LazyStickyPool.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/LegalNameValidator.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/LegalNameValidator.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/LifeCycle.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/LifeCycle.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/PathUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/PathUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/ProgressTracker.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/ProgressTracker.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/ThreadBox.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/ThreadBox.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/ToggleField.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/ToggleField.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/X509EdDSAEngine.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/X509EdDSAEngine.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/concurrent/CordaFutureImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/concurrent/CordaFutureImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/NotaryService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/NotaryService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/NotaryUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/NotaryUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/TrustedAuthorityNotaryService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/TrustedAuthorityNotaryService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/UniquenessProvider.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/UniquenessProvider.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/ClientRpcSslOptions.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/ClientRpcSslOptions.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/FlowHandle.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/FlowHandle.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/Messaging.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/Messaging.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/RPCOps.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/RPCOps.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/RPCReturnsObservables.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/messaging/RPCReturnsObservables.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/AppServiceHub.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/AppServiceHub.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/NodeInfo.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/NodeInfo.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/AttachmentStorage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/AttachmentStorage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/ContractUpgradeService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/ContractUpgradeService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/CordaService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/CordaService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/KeyManagementService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/KeyManagementService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/PartyInfo.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/PartyInfo.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/TimeWindowChecker.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/TimeWindowChecker.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/TransactionStorage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/TransactionStorage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/TransactionVerifierService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/TransactionVerifierService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/schemas/CommonSchema.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/schemas/CommonSchema.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/schemas/PersistentTypes.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/schemas/PersistentTypes.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/ConstructorForDeserialization.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/ConstructorForDeserialization.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/CordaSerializable.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/CordaSerializable.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/CordaSerializationTransformEnumDefault.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/CordaSerializationTransformEnumDefault.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/CordaSerializationTransformRename.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/CordaSerializationTransformRename.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/DeprecatedConstructorForDeserialization.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/DeprecatedConstructorForDeserialization.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/MissingAttachmentsException.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/MissingAttachmentsException.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/SerializationCustomSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/SerializationCustomSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/SerializationToken.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/SerializationToken.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/SerializationWhitelist.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/SerializationWhitelist.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/internal/SerializationEnvironment.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/internal/SerializationEnvironment.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/BaseTransaction.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/BaseTransaction.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/BaseTransactions.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/ByteArrays.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/ByteArrays.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/EncodingUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/EncodingUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/Id.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/Id.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/NetworkHostAndPort.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/NetworkHostAndPort.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/NonEmptySet.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/NonEmptySet.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/Try.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/Try.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/UntrustworthyData.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/UntrustworthyData.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/UuidGenerator.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/UuidGenerator.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/smoke-test/kotlin/net/corda/core/NodeVersioningTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/smoke-test/kotlin/net/corda/core/NodeVersioningTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/smoke-test/kotlin/net/corda/core/cordapp/CordappSmokeTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/smoke-test/kotlin/net/corda/core/cordapp/CordappSmokeTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/UtilsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/UtilsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/concurrent/ConcurrencyUtilsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/concurrent/ConcurrencyUtilsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/AmountTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/AmountTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/ContractsDSLTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/ContractsDSLTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/PrivacySaltTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/PrivacySaltTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/StructuresTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/StructuresTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/TimeWindowTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/TimeWindowTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/TransactionVerificationExceptionSerialisationTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/contracts/TransactionVerificationExceptionSerialisationTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/Base58Test.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/Base58Test.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/EdDSATests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/EdDSATests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/SignedDataTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/SignedDataTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/TransactionSignatureTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/TransactionSignatureTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/X509NameConstraintsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/X509NameConstraintsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/FastThreadLocalTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/FastThreadLocalTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/FlowTestsUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/FlowTestsUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/ReceiveAllFlowTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/ReceiveAllFlowTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/TestDataVendingFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/TestDataVendingFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/PartyAndCertificateTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/PartyAndCertificateTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/PartyTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/PartyTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/AbstractAttachmentTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/AbstractAttachmentTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/CertRoleTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/CertRoleTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/InternalUtilsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/InternalUtilsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/LegalNameValidatorTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/LegalNameValidatorTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/PathUtilsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/PathUtilsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/ToggleFieldTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/ToggleFieldTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/X509EdDSAEngineTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/X509EdDSAEngineTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/concurrent/CordaFutureImplTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/concurrent/CordaFutureImplTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/node/VaultUpdateTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/node/VaultUpdateTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/node/services/VaultEnumTypesTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/node/services/VaultEnumTypesTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/AttachmentSerializationTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/AttachmentSerializationTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/CommandsSerializationTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/CommandsSerializationTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/NotaryExceptionSerializationTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/NotaryExceptionSerializationTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/CompatibleTransactionTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/CompatibleTransactionTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/LedgerTransactionQueryTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/LedgerTransactionQueryTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/TransactionEncumbranceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/TransactionEncumbranceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/TransactionTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/TransactionTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/ByteArraysTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/ByteArraysTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/EmbeddedExpressionsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/EmbeddedExpressionsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/EncodingUtilsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/EncodingUtilsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/KotlinUtilsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/KotlinUtilsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/NetworkHostAndPortTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/NetworkHostAndPortTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/NonEmptySetTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/NonEmptySetTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomVaultQuery.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomVaultQuery.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/LaunchSpaceshipFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/LaunchSpaceshipFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/contract/TutorialContract.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/contract/TutorialContract.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/flowstatemachines/TutorialFlowStateMachines.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/flowstatemachines/TutorialFlowStateMachines.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/helloworld/flow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/helloworld/flow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/helloworld/state.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/helloworld/state.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/helloworld/templateContract.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/helloworld/templateContract.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/mocknetwork/TutorialMockNetwork.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/mocknetwork/TutorialMockNetwork.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/tearoffs/TutorialTearOffs.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/tearoffs/TutorialTearOffs.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/twoparty/contract.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/twoparty/contract.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/twoparty/flow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/twoparty/flow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/twoparty/flowResponder.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/twoparty/flowResponder.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/twoparty/state.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/twoparty/state.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/CustomVaultQueryTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/CustomVaultQueryTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/ExampleConfigTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/ExampleConfigTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/avalanche/src/main/kotlin/net/corda/avalanche/Main.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/avalanche/src/main/kotlin/net/corda/avalanche/Main.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/avalanche/src/main/kotlin/net/corda/avalanche/Parameters.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/avalanche/src/main/kotlin/net/corda/avalanche/Parameters.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/Utilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/Utilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/DatabaseConfigurationTemplate.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/DatabaseConfigurationTemplate.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/DatabaseConnection.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/DatabaseConnection.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/DatabaseSettings.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/DatabaseSettings.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/DatabaseType.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/DatabaseType.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/configuration/H2ConfigurationTemplate.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/configuration/H2ConfigurationTemplate.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/configuration/PostgresConfigurationTemplate.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/database/configuration/PostgresConfigurationTemplate.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/file/FileUtilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/file/FileUtilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/file/LogSource.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/file/LogSource.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/monitoring/ConjunctiveWatch.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/monitoring/ConjunctiveWatch.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/monitoring/DisjunctiveWatch.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/monitoring/DisjunctiveWatch.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/monitoring/PatternWatch.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/monitoring/PatternWatch.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/monitoring/Watch.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/monitoring/Watch.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/network/Network.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/network/Network.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/Distribution.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/Distribution.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/Node.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/Node.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/Configuration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/Configuration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/ConfigurationTemplate.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/ConfigurationTemplate.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/CordappConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/CordappConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/CurrencyConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/CurrencyConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/DatabaseConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/DatabaseConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/NetworkInterface.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/NetworkInterface.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/NotaryConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/NotaryConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/NotaryType.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/NotaryType.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/UserConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/UserConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/process/Command.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/process/Command.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/process/JarCommand.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/process/JarCommand.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/process/output/OutputListener.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/process/output/OutputListener.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/ContainerService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/ContainerService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/Service.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/Service.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/ServiceInitiator.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/ServiceInitiator.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/ServiceSettings.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/ServiceSettings.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/database/H2Service.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/database/H2Service.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/database/PostgreSQLService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/service/database/PostgreSQLService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/ssh/MonitoringSSHClient.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/ssh/MonitoringSSHClient.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/ssh/SSHClient.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/ssh/SSHClient.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/Scenarios.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/Scenarios.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/ScenarioRunner.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/ScenarioRunner.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/ScenarioState.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/ScenarioState.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/StepsContainer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/StepsContainer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/api/StepsBlock.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/api/StepsBlock.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/api/StepsProvider.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/api/StepsProvider.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/helpers/Cash.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/helpers/Cash.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/helpers/Database.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/helpers/Database.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/helpers/Ssh.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/helpers/Ssh.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/helpers/Startup.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/helpers/Startup.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/helpers/Substeps.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/helpers/Substeps.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/helpers/Vault.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/helpers/Vault.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/CashSteps.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/CashSteps.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/ConfigurationSteps.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/ConfigurationSteps.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/DatabaseSteps.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/DatabaseSteps.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/NetworkSteps.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/NetworkSteps.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/RpcSteps.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/RpcSteps.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/SshSteps.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/SshSteps.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/StartupSteps.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/StartupSteps.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/VaultSteps.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/steps/VaultSteps.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/tests/StepsProviderTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/scenario/kotlin/net/corda/behave/scenarios/tests/StepsProviderTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/monitoring/MonitoringTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/monitoring/MonitoringTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/network/NetworkTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/network/NetworkTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/process/CommandTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/process/CommandTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/service/PostreSQLServiceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/test/kotlin/net/corda/behave/service/PostreSQLServiceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/corda-utils/src/main/kotlin/io/cryptoblk/core/StatusTransitions.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/corda-utils/src/main/kotlin/io/cryptoblk/core/StatusTransitions.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/corda-utils/src/main/kotlin/io/cryptoblk/core/Utils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/corda-utils/src/main/kotlin/io/cryptoblk/core/Utils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/corda-utils/src/test/kotlin/io/cryptoblk/core/StatusTransitionsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/corda-utils/src/test/kotlin/io/cryptoblk/core/StatusTransitionsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/kryo-hook/src/main/kotlin/net/corda/kryohook/KryoHook.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/kryo-hook/src/main/kotlin/net/corda/kryohook/KryoHook.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/quasar-hook/src/main/kotlin/net/corda/quasarhook/QuasarInstrumentationHook.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/quasar-hook/src/main/kotlin/net/corda/quasarhook/QuasarInstrumentationHook.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Arrangement.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Arrangement.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/ContractFunctions.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/ContractFunctions.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Literal.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Literal.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Perceivable.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Perceivable.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/PrettyPrint.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/PrettyPrint.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Util.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Util.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Caplet.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Caplet.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/ContractDefinition.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/ContractDefinition.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Examples.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Examples.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXFwdTimeOption.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXFwdTimeOption.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXSwap.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXSwap.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/IRS.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/IRS.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/RollOutTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/RollOutTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Swaption.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Swaption.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/ZeroCouponBond.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/ZeroCouponBond.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/isolated/src/main/kotlin/net/corda/finance/contracts/isolated/AnotherDummyContract.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/isolated/src/main/kotlin/net/corda/finance/contracts/isolated/AnotherDummyContract.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/isolated/src/main/kotlin/net/corda/finance/contracts/isolated/IsolatedDummyFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/isolated/src/main/kotlin/net/corda/finance/contracts/isolated/IsolatedDummyFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/isolated/src/main/kotlin/net/corda/nodeapi/DummyContractBackdoor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/isolated/src/main/kotlin/net/corda/nodeapi/DummyContractBackdoor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/compat/CashExceptionSerialisationTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/compat/CashExceptionSerialisationTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/compat/CompatibilityTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/compat/CompatibilityTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/flows/CashConfigDataFlowTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/flows/CashConfigDataFlowTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/flows/CashSelectionTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/integration-test/kotlin/net/corda/finance/flows/CashSelectionTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/Currencies.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/Currencies.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/CommercialPaper.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/CommercialPaper.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/GetBalances.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/GetBalances.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/OnLedgerAsset.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/OnLedgerAsset.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/math/Interpolators.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/math/Interpolators.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/AbstractCashFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/AbstractCashFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashConfigDataFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashConfigDataFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashIssueAndPaymentFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashIssueAndPaymentFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/plugin/FinanceJSONSupport.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/plugin/FinanceJSONSupport.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/schemas/CashSchemaV1.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/schemas/CashSchemaV1.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/schemas/CommercialPaperSchemaV1.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/schemas/CommercialPaperSchemaV1.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/utils/PhysicalLocationStructures.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/utils/PhysicalLocationStructures.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/utils/StateSummingUtilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/utils/StateSummingUtilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/CurrenciesTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/CurrenciesTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/CommercialPaperTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/CommercialPaperTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/FinanceTypesTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/FinanceTypesTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/DummyFungibleContract.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/DummyFungibleContract.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/math/InterpolatorsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/math/InterpolatorsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashExitFlowTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashExitFlowTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashIssueFlowTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashIssueFlowTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCashSchemaV1.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCashSchemaV1.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCashSchemaV2.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCashSchemaV2.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCashSchemaV3.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCashSchemaV3.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCommercialPaperSchemaV1.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCommercialPaperSchemaV1.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCommercialPaperSchemaV2.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/schemas/SampleCommercialPaperSchemaV2.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/utils/CityDatabaseTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/utils/CityDatabaseTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/RPCApi.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/RPCApi.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/VerifierApi.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/VerifierApi.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/exceptions/RpcExceptions.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/exceptions/RpcExceptions.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingClient.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingClient.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingComponent.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingComponent.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ContractsScanning.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ContractsScanning.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/DeduplicationChecker.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/DeduplicationChecker.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/KeyStoreConfigHelpers.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/KeyStoreConfigHelpers.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/MessageSizeChecksInterceptor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/MessageSizeChecksInterceptor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ShutdownHook.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ShutdownHook.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/SignedNodeInfo.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/SignedNodeInfo.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeControlListener.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeControlListener.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeControlMessages.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeControlMessages.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeManager.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeManager.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/SSLConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/SSLConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/User.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/User.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/ContentSignerBuilder.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/ContentSignerBuilder.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/KeyStoreUtilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/KeyStoreUtilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509KeyStore.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509KeyStore.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkMap.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkMap.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkParametersCopier.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkParametersCopier.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NodeInfoFilesCopier.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NodeInfoFilesCopier.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/DatabaseTransaction.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/DatabaseTransaction.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/HibernateConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/HibernateConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/HibernateStatistics.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/HibernateStatistics.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/EventProcessor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/EventProcessor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/NettyWritable.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/NettyWritable.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/messages/ApplicationMessage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/messages/ApplicationMessage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/messages/MessageStatus.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/messages/MessageStatus.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/messages/ReceivedMessage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/messages/ReceivedMessage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/messages/SendableMessage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/messages/SendableMessage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/messages/impl/ReceivedMessageImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/messages/impl/ReceivedMessageImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/messages/impl/SendableMessageImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/messages/impl/SendableMessageImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPChannelHandler.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPChannelHandler.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPClient.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPClient.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPServer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPServer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/ConnectionChange.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/ConnectionChange.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelper.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelper.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/Eventually.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/Eventually.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/SignedNodeInfoTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/SignedNodeInfoTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/config/ConfigParsingTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/config/ConfigParsingTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapperTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapperTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NodeInfoFilesCopierTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NodeInfoFilesCopierTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/ClientRelevantException.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/ClientRelevantException.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/RpcInfo.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/RpcInfo.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/BootTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/BootTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/CordappConfigFileProviderTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/CordappConfigFileProviderTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/CordappScanningDriverTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/CordappScanningDriverTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeStartAndStopTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeStartAndStopTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeStartupPerformanceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeStartupPerformanceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeUnloadHandlerTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeUnloadHandlerTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/flows/FlowRetryTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/RpcFlowsDrainingModeTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/RpcFlowsDrainingModeTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/persistence/NodeStatePersistenceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/persistence/NodeStatePersistenceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/BFTSMaRtTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/BFTSMaRtTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/distributed/DistributedServiceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/distributed/DistributedServiceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsNodeTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsNodeTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsRPCTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsRPCTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMQSecurityTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMQSecurityTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/RPCMQSecurityTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/RPCMQSecurityTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/SimpleMQClient.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/SimpleMQClient.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/testMessage/MessageState.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/testMessage/MessageState.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/testMessage/ScheduledState.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/testMessage/ScheduledState.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/Corda.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/Corda.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/CordaClock.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/CordaClock.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/JolokiaSlf4jAdapter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/JolokiaSlf4jAdapter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/NodeArgsParser.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/NodeArgsParser.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/SerialFilter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/SerialFilter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/VersionInfo.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/VersionInfo.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/DataSourceFactory.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/DataSourceFactory.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/InitiatedFlowFactory.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/InitiatedFlowFactory.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/InvocationHandlerTemplate.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/InvocationHandlerTemplate.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/LifecycleSupport.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/LifecycleSupport.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/Node.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/Node.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeUniqueIdProvider.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeUniqueIdProvider.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/ServicesForResolutionImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/ServicesForResolutionImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/StartedNode.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/StartedNode.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/ArtemisBroker.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/ArtemisBroker.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/BrokerJaasLoginModule.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/BrokerJaasLoginModule.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/CertificateChainCheckPolicy.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/CertificateChainCheckPolicy.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/ReactiveArtemisConsumer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/ReactiveArtemisConsumer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/SecureArtemisConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/SecureArtemisConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/classloading/Utils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/classloading/Utils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappConfigFileProvider.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappConfigFileProvider.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappConfigProvider.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappConfigProvider.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderInternal.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderInternal.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/TypesafeCordappConfig.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/TypesafeCordappConfig.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/AuthenticatedRpcOpsProxy.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/AuthenticatedRpcOpsProxy.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/ExceptionSerialisingRpcOpsProxy.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/ExceptionSerialisingRpcOpsProxy.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/schemas/NodeInfoSchema.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/schemas/NodeInfoSchema.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/AuthorizingSubject.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/AuthorizingSubject.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/Password.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/Password.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/RPCSecurityManager.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/RPCSecurityManager.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/RPCSecurityManagerImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/RPCSecurityManagerImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/RPCSecurityManagerWithAdditionalUser.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/RPCSecurityManagerWithAdditionalUser.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/amqp/AMQPServerSerializationScheme.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/amqp/AMQPServerSerializationScheme.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/amqp/RpcServerCordaFutureSerialiser.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/amqp/RpcServerCordaFutureSerialiser.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/amqp/RpcServerObservableSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/amqp/RpcServerObservableSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/CordaClassResolver.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/CordaClassResolver.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/CordaClosureSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/CordaClosureSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/DefaultKryoCustomizer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/DefaultKryoCustomizer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoSerializationScheme.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoSerializationScheme.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoServerSerializationScheme.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoServerSerializationScheme.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoStreams.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoStreams.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/SerializeAsTokenSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/SerializeAsTokenSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/Permissions.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/Permissions.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/AuditService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/AuditService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/IdentityServiceInternal.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/IdentityServiceInternal.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/MonitoringService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/MonitoringService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/NodePropertiesStore.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/NodePropertiesStore.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/SchedulerService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/SchedulerService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/SchemaService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/SchemaService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/VaultServiceInternal.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/VaultServiceInternal.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/rpc/NodeRpcOptions.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/rpc/NodeRpcOptions.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/shell/ShellConfig.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/shell/ShellConfig.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepository.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepository.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/ScheduledActivityObserver.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/ScheduledActivityObserver.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/IdentityServiceUtil.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/IdentityServiceUtil.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/E2ETestKeyManagementService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/E2ETestKeyManagementService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/logging/ContextualLoggingUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/logging/ContextualLoggingUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/InternalRPCMessagingClient.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/InternalRPCMessagingClient.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/MessagingExecutor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/MessagingExecutor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/ObservableContextInterface.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/ObservableContextInterface.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessageDeduplicator.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessageDeduplicator.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/RpcAuthContext.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/RpcAuthContext.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/VerifierMessagingClient.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/VerifierMessagingClient.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyDescriptor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyDescriptor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyToX500NameAsStringConverter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyToX500NameAsStringConverter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionMappingStorage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionMappingStorage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/NodePropertiesPersistentStore.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/persistence/NodePropertiesPersistentStore.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/ArtemisRpcBroker.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/ArtemisRpcBroker.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/RolesAdderOnLogin.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/RolesAdderOnLogin.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/rpc/RpcBrokerConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/schema/HibernateObserver.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/schema/HibernateObserver.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/CountUpDownLatch.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/CountUpDownLatch.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/DeduplicationId.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/DeduplicationId.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/Event.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/Event.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowFiber.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowFiber.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowHospital.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowHospital.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMessaging.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowMessaging.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowSessionImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowSessionImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStackSnapshotFactory.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStackSnapshotFactory.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/PropagatingFlowHospital.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/PropagatingFlowHospital.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SessionMessage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SessionMessage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SessionRejectException.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SessionRejectException.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SubFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SubFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutorImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutorImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/DumpHistoryOnErrorInterceptor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/DumpHistoryOnErrorInterceptor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/FiberDeserializationCheckingInterceptor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/FiberDeserializationCheckingInterceptor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/HospitalisingInterceptor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/HospitalisingInterceptor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/MetricInterceptor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/MetricInterceptor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/PrintingInterceptor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/PrintingInterceptor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/TransitionDiagnosticRecord.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/TransitionDiagnosticRecord.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DeliverSessionMessageTransition.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DeliverSessionMessageTransition.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DoRemainingWorkTransition.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StateMachine.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StateMachine.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/Transition.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/Transition.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TransitionBuilder.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TransitionBuilder.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TransitionResult.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TransitionResult.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/UnstartedFlowTransition.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/UnstartedFlowTransition.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRt.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRt.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRtConfig.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRtConfig.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/InMemoryTransactionVerifierService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/InMemoryTransactionVerifierService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/OutOfProcessTransactionVerifierService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/OutOfProcessTransactionVerifierService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/PathManager.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/PathManager.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftNonValidatingNotaryService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftNonValidatingNotaryService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLog.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLog.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftUniquenessProvider.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftUniquenessProvider.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftValidatingNotaryService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftValidatingNotaryService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/SimpleNotaryService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/SimpleNotaryService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/upgrade/ContractUpgradeServiceImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/upgrade/ContractUpgradeServiceImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AbstractArgsParser.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AbstractArgsParser.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AddressUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AddressUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AffinityExecutor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AffinityExecutor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/DemoClock.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/DemoClock.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/JVMAgentRegistry.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/JVMAgentRegistry.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/NamedThreadFactory.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/NamedThreadFactory.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/NodeBuildProperties.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/NodeBuildProperties.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/NonInvalidatingCache.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/NonInvalidatingCache.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/NonInvalidatingUnboundCache.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/NonInvalidatingUnboundCache.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/ObjectDiffer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/ObjectDiffer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/PersistentMap.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/PersistentMap.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/HTTPNetworkRegistrationService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/HTTPNetworkRegistrationService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/NodeArgsParserTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/NodeArgsParserTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/SerialFilterTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/SerialFilterTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/AbstractNodeTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/AbstractNodeTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/NetworkParametersTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/NetworkParametersTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappLoaderTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappLoaderTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappProviderImplTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappProviderImplTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/TypesafeCordappConfigTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/cordapp/TypesafeCordappConfigTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/security/PasswordTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/security/PasswordTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/RoundTripObservableSerializerTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/RoundTripObservableSerializerTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/RpcServerObservableSerializerTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/RpcServerObservableSerializerTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/testutils/AMQPTestSerialiationScheme.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/testutils/AMQPTestSerialiationScheme.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/testutils/TestObservableContext.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/testutils/TestObservableContext.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/testutils/TestSerializationContext.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/testutils/TestSerializationContext.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/InMemoryMessagingTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/InMemoryMessagingTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/modes/draining/ScheduledFlowsDrainingModeTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/modes/draining/ScheduledFlowsDrainingModeTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/serialization/kryo/KryoStreamsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/serialization/kryo/KryoStreamsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/serialization/kryo/KryoTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/serialization/kryo/KryoTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/RPCSecurityManagerTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/RPCSecurityManagerTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/ServiceHubConcurrentUsageTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/ServiceHubConcurrentUsageTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/ConfigOperatorTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/ConfigOperatorTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepositoryTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepositoryTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/identity/InMemoryIdentityServiceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/identity/InMemoryIdentityServiceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/identity/PersistentIdentityServiceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/identity/PersistentIdentityServiceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/keys/KMSUtilsTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/keys/KMSUtilsTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapCacheTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapCacheTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentStorageTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentStorageTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/TransactionCallbackTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/TransactionCallbackTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/schema/HibernateObserverTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/schema/HibernateObserverTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/schema/NodeSchemaServiceTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/schema/NodeSchemaServiceTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImplTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowLogicRefFactoryImplTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/RetryFlowMockTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/BFTSMaRtConfigTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/BFTSMaRtConfigTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/MaxTransactionSizeTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/MaxTransactionSizeTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/PathManagerTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/PathManagerTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/PersistentUniquenessProviderTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/PersistentUniquenessProviderTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLogTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLogTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/AddressUtilsTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/AddressUtilsTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/AffinityExecutorTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/AffinityExecutorTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ClockUtilsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ClockUtilsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/PersistentMapTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/PersistentMapTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/TLSAuthenticationTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/TLSAuthenticationTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/Main.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/Main.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaCordformTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaCordformTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaCordform.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaCordform.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaClientApi.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaClientApi.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaWebApi.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaWebApi.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/plugin/BankOfCordaPlugin.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/plugin/BankOfCordaPlugin.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/cordapp-configuration/src/main/kotlin/net/corda/configsample/GetStringConfigFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/cordapp-configuration/src/main/kotlin/net/corda/configsample/GetStringConfigFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRS.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRS.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRSExport.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRSExport.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRSUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/contract/IRSUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/utilities/OracleUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/utilities/OracleUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/Main.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/Main.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/NodeInterestRatesTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/NodeInterestRatesTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/flows/UpdateBusinessDayFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/flows/UpdateBusinessDayFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/system-test/kotlin/net/corda/irs/IRSDemoDockerTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/system-test/kotlin/net/corda/irs/IRSDemoDockerTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/main/kotlin/net/corda/irs/web/IrsDemoWebApplication.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/main/kotlin/net/corda/irs/web/IrsDemoWebApplication.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/main/kotlin/net/corda/irs/web/api/InterestSwapRestAPI.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/main/kotlin/net/corda/irs/web/api/InterestSwapRestAPI.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/IrsDemoWebApplicationTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/IrsDemoWebApplicationTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/api/InterestRatesSwapDemoAPI.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/api/InterestRatesSwapDemoAPI.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/demo/IRSDemo.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/demo/IRSDemo.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/demo/IrsDemoClientApi.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/demo/IrsDemoClientApi.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserView.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserView.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserViewModel.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserViewModel.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/Simulation.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/Simulation.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/test/kotlin/net/corda/netmap/simulation/IRSSimulationTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/test/kotlin/net/corda/netmap/simulation/IRSSimulationTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/Clean.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/Clean.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/CustomNotaryCordform.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/CustomNotaryCordform.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/Notarise.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/Notarise.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/DummyIssueAndMove.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/DummyIssueAndMove.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/RPCStartableNotaryFlowClient.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/RPCStartableNotaryFlowClient.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/analytics/CordaMarketData.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/analytics/CordaMarketData.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/analytics/InitialMarginTriple.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/analytics/InitialMarginTriple.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/IRSState.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/IRSState.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/OGTrade.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/OGTrade.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/PortfolioState.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/PortfolioState.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/PortfolioSwap.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/PortfolioSwap.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/PortfolioValuation.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/PortfolioValuation.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/RevisionedState.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/RevisionedState.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/SwapData.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/contracts/SwapData.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/AnalyticsEngine.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/AnalyticsEngine.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/OGStub.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/OGStub.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/OGUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/OGUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingCcpExample.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingCcpExample.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingExample.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/analytics/example/OGSwapPricingExample.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/IRSTradeFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/IRSTradeFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/OpenGammaCordaUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/OpenGammaCordaUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmRevaluation.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmRevaluation.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/StateRevisionFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/StateRevisionFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/portfolio/Portfolio.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/portfolio/Portfolio.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApi.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApi.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApiUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApiUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/SwapDataModel.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/SwapDataModel.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/SwapDataView.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/SwapDataView.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/SimmPlugin.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/SimmPlugin.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/SimmPluginRegistry.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/SimmPluginRegistry.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/CurrencyParameterSensitivitiesSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/CurrencyParameterSensitivitiesSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/CurrencyParameterSensitivitySerialiser.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/CurrencyParameterSensitivitySerialiser.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/CurrencySerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/CurrencySerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/DoubleArraySerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/DoubleArraySerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/MultiCurrencyAmountSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/MultiCurrencyAmountSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/TenorDateParameterMetadataSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/TenorDateParameterMetadataSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/TenorSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/plugin/customserializers/TenorSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/Main.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/Main.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/SwapExample.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/SwapExample.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemo.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemo.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TransactionGraphSearch.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TransactionGraphSearch.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/BuyerFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/BuyerFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/CommercialPaperIssueFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/CommercialPaperIssueFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/Main.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/Main.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/TransactionGraphSearchTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/TransactionGraphSearchTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/AllButBlacklisted.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/AllButBlacklisted.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/AttachmentsClassLoader.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/AttachmentsClassLoader.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ByteBufferStreams.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ByteBufferStreams.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ClassWhitelists.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ClassWhitelists.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ClientContexts.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ClientContexts.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/DefaultWhitelist.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/DefaultWhitelist.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/GeneratedAttachment.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/GeneratedAttachment.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/OrdinalIO.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/OrdinalIO.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/SerializationFormat.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/SerializationFormat.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/SerializationScheme.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/SerializationScheme.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/SerializeAsTokenContextImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/SerializeAsTokenContextImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ServerContexts.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ServerContexts.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/SharedContexts.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/SharedContexts.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/UseCaseAwareness.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/UseCaseAwareness.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPDescriptorRegistry.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPDescriptorRegistry.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPExceptions.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPExceptions.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPPrimitiveSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPPrimitiveSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializerFactories.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializerFactories.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPStreams.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPStreams.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ArraySerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ArraySerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CollectionSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CollectionSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CorDappCustomSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CorDappCustomSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializationInput.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializationInput.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedGenericArrayType.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedGenericArrayType.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedType.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedType.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EnumEvolutionSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EnumEvolutionSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EnumSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EnumSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Envelope.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Envelope.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/FingerPrinter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/FingerPrinter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/MapSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/MapSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertySerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertySerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertySerializers.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertySerializers.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/Schema.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationOutput.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationOutput.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SingletonSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SingletonSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SupportedTransforms.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SupportedTransforms.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformTypes.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformTypes.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformsSchema.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformsSchema.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/BigDecimalSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/BigDecimalSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/BigIntegerSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/BigIntegerSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/BitSetSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/BitSetSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/CertPathSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/CertPathSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ClassSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ClassSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ContractAttachmentSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ContractAttachmentSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/CurrencySerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/CurrencySerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/DurationSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/DurationSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/EnumSetSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/EnumSetSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/InputStreamSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/InputStreamSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/InstantSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/InstantSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/LocalDateSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/LocalDateSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/LocalDateTimeSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/LocalDateTimeSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/LocalTimeSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/LocalTimeSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/MonthDaySerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/MonthDaySerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/OffsetDateTimeSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/OffsetDateTimeSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/OffsetTimeSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/OffsetTimeSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/OpaqueBytesSubSequenceSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/OpaqueBytesSubSequenceSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PeriodSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PeriodSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PrivateKeySerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PrivateKeySerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PublicKeySerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PublicKeySerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/RxNotificationSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/RxNotificationSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/SimpleStringSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/SimpleStringSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/StringBufferSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/StringBufferSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ThrowableSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ThrowableSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/X509CRLSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/X509CRLSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/X509CertificateSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/X509CertificateSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/YearMonthSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/YearMonthSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/YearSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/YearSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ZoneIdSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ZoneIdSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ZonedDateTimeSerializer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ZonedDateTimeSerializer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/AMQPSchemaExtensions.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/AMQPSchemaExtensions.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/Exceptions.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/Exceptions.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/MetaCarpenter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/MetaCarpenter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/Schema.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/Schema.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/SchemaFields.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/SchemaFields.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/nodeapi/DummyContractBackdoor.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/nodeapi/DummyContractBackdoor.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/AttachmentsClassLoaderTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/AttachmentsClassLoaderTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/ContractAttachmentSerializerTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/ContractAttachmentSerializerTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/ListsSerializationTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/ListsSerializationTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/MapsSerializationTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/MapsSerializationTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/PrivateKeySerializationTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/PrivateKeySerializationTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/SerializationTokenTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/SerializationTokenTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/SetsSerializationTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/SetsSerializationTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/CorDappSerializerTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/CorDappSerializerTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeAndReturnEnvelopeTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeAndReturnEnvelopeTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeMapTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeMapTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentryOfEnumsTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentryOfEnumsTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentrySimpleTypesTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentrySimpleTypesTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentryTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentryTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedTypeTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedTypeTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolvabilityTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolvabilityTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolveTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolveTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/ErrorMessagesTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/ErrorMessagesTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializerGetterTesting.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializerGetterTesting.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolvabilityTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EvolvabilityTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/FingerPrinterTesting.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/FingerPrinterTesting.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/GenericsTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/GenericsTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/OverridePKSerializerTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/OverridePKSerializerTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/PrivatePropertyTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/PrivatePropertyTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/RoundTripTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/RoundTripTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationPropertyOrdering.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationPropertyOrdering.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationSchemaTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationSchemaTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializeAndReturnSchemaTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializeAndReturnSchemaTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/StaticInitialisationOfSerializedObjectTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/StaticInitialisationOfSerializedObjectTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/StreamTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/StreamTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/testutils/AMQPTestUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/testutils/AMQPTestUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/testutils/TestSerializationContext.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/testutils/TestSerializationContext.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CarpenterExceptionTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CarpenterExceptionTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTestUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTestUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterWhitelistTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterWhitelistTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/EnumClassTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/EnumClassTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/InheritanceSchemaToClassCarpenterTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/InheritanceSchemaToClassCarpenterTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/MultiMemberCompositeSchemaToClassCarpenterTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/MultiMemberCompositeSchemaToClassCarpenterTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/SingleMemberCompositeSchemaToClassCarpenterTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/SingleMemberCompositeSchemaToClassCarpenterTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/FlowStackSnapshotTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/FlowStackSnapshotTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/MockNetworkIntegrationTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/MockNetworkIntegrationTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/internal/InternalMockNetworkIntegrationTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/internal/InternalMockNetworkIntegrationTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/internal/ProcessUtilitiesTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/internal/ProcessUtilitiesTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/DriverInternal.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/DriverInternal.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/NodeTestUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/NodeTestUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/NotarySpec.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/NotarySpec.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/TestClock.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/TestClock.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/User.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/User.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DummyClusterSpec.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DummyClusterSpec.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InMemoryMessage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InMemoryMessage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockKeyManagementService.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockKeyManagementService.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockTransactionStorage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockTransactionStorage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ShutdownManager.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ShutdownManager.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/demorun/CordformNodeRunner.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/demorun/CordformNodeRunner.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/demorun/CordformUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/demorun/CordformUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/performance/Injectors.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/performance/Injectors.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/performance/Reporter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/performance/Reporter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/InternalMockNetworkTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/InternalMockNetworkTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeConfig.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeConfig.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeProcess.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeProcess.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/CommonSerializationTestHelpers.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/CommonSerializationTestHelpers.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ProjectStructure.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ProjectStructure.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/Thoroughness.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/Thoroughness.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/UnsafeCertificatesFactory.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/UnsafeCertificatesFactory.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContract.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContract.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV2.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV2.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyState.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyState.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/SerializationTestHelpers.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/SerializationTestHelpers.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/TestConstants.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/TestConstants.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/TestUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/TestUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/LedgerDSLInterpreter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/LedgerDSLInterpreter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TransactionDSLInterpreter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TransactionDSLInterpreter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/http/HttpApi.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/http/HttpApi.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/http/HttpUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/http/HttpUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/FlowStackSnapshot.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/FlowStackSnapshot.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalSerializationTestHelpers.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalSerializationTestHelpers.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestConstants.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestConstants.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/LogHelper.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/LogHelper.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/MockCordappConfigProvider.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/MockCordappConfigProvider.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/MockCordappProvider.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/MockCordappProvider.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/RigorousMock.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/RigorousMock.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/TestNodeInfoBuilder.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/TestNodeInfoBuilder.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/TestThreadFactory.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/TestThreadFactory.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/performance/Rate.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/performance/Rate.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyDealContract.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyDealContract.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyDealStateSchemaV1.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyDealStateSchemaV1.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyLinearContract.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyLinearContract.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyLinearStateSchemaV1.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyLinearStateSchemaV1.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyLinearStateSchemaV2.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyLinearStateSchemaV2.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/services/MockAttachmentStorage.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/services/MockAttachmentStorage.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/test/kotlin/net/corda/testing/TestIdentityTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/test/kotlin/net/corda/testing/TestIdentityTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/test/kotlin/net/corda/testing/internal/RigorousMockTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/test/kotlin/net/corda/testing/internal/RigorousMockTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/blobinspector/src/main/kotlin/net/corda/blobinspector/Main.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/blobinspector/src/main/kotlin/net/corda/blobinspector/Main.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/DemoBench.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/DemoBench.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/explorer/Explorer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/explorer/Explorer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/DemoBenchNodeInfoFilesCopier.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/DemoBenchNodeInfoFilesCopier.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/HasCordapps.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/HasCordapps.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/InstallFactory.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/InstallFactory.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/JVMConfig.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/JVMConfig.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeController.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeController.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeData.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeData.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeState.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeState.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/plugin/CordappController.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/plugin/CordappController.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/profile/ProfileController.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/profile/ProfileController.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/pty/PtyProcessTtyConnector.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/pty/PtyProcessTtyConnector.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/pty/R3Pty.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/pty/R3Pty.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/pty/ZeroFilter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/pty/ZeroFilter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/rpc/NodeRPC.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/rpc/NodeRPC.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/ui/CloseableTab.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/ui/CloseableTab.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/ui/PropertyLabel.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/ui/PropertyLabel.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/DemoBenchView.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/DemoBenchView.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/web/DBViewer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/web/DBViewer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/web/WebServer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/web/WebServer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/web/WebServerController.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/web/WebServerController.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/org/h2/server/web/LocalWebServer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/org/h2/server/web/LocalWebServer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/LoggingTestSuite.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/LoggingTestSuite.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/JVMConfigTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/JVMConfigTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/pty/ZeroFilterTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/test/kotlin/net/corda/demobench/pty/ZeroFilterTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/AmountDiff.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/AmountDiff.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/AmountFormatter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/AmountFormatter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/Formatter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/Formatter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/NumberFormatter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/NumberFormatter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/PartyNameFormatter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/PartyNameFormatter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/identicon/IdenticonRenderer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/identicon/IdenticonRenderer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/CordaViewModel.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/CordaViewModel.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/IssuerModel.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/IssuerModel.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/ReportingCurrencyModel.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/ReportingCurrencyModel.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/SettingsModel.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/SettingsModel.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/TransactionTypes.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/TransactionTypes.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/ui/ListViewUtilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/ui/ListViewUtilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/ui/SingleRowSelection.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/ui/SingleRowSelection.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/ui/TableViewUtilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/ui/TableViewUtilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/ui/TreeTableViewUtilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/ui/TreeTableViewUtilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/Dashboard.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/Dashboard.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/Formatter.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/Formatter.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/GuiUtilities.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/GuiUtilities.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/LoginView.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/LoginView.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/MainView.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/MainView.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/Network.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/Network.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/SearchField.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/SearchField.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/Settings.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/Settings.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/CashViewer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/CashViewer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/test/kotlin/net/corda/explorer/model/SettingsModelTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/test/kotlin/net/corda/explorer/model/SettingsModelTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/test/kotlin/net/corda/explorer/views/GuiUtilitiesKtTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/test/kotlin/net/corda/explorer/views/GuiUtilitiesKtTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/ConnectionManager.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/ConnectionManager.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/Disruption.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/Disruption.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTestConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTestConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/Main.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/Main.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/NodeConnection.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/NodeConnection.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/GenerateHelpers.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/GenerateHelpers.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/NotaryTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/NotaryTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/SelfIssueTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/SelfIssueTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/StabilityTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/StabilityTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/SSHServerTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/SSHServerTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/CordaAuthenticationPlugin.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/CordaAuthenticationPlugin.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/CordaSSHAuthInfo.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/CordaSSHAuthInfo.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/FlowWatchPrintingSubscriber.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/FlowWatchPrintingSubscriber.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShellCommand.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShellCommand.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/RPCOpsWithContext.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/RPCOpsWithContext.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/SSHDConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/SSHDConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/SerializationSupport.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/SerializationSupport.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/ShellConfiguration.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/ShellConfiguration.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/StandaloneShell.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/StandaloneShell.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/StandaloneShellArgsParser.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/StandaloneShellArgsParser.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/CustomTypeJsonParsingTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/CustomTypeJsonParsingTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/InteractiveShellTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/InteractiveShellTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/StandaloneShellArgsParserTest.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/test/kotlin/net/corda/tools/shell/StandaloneShellArgsParserTest.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/integration-test/kotlin/net/corda/webserver/WebserverDriverTests.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/integration-test/kotlin/net/corda/webserver/WebserverDriverTests.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/WebArgsParser.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/WebArgsParser.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/WebServer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/WebServer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/WebServerConfig.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/WebServerConfig.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/api/APIServer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/api/APIServer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/api/Query.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/api/Query.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/converters/Converters.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/converters/Converters.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/internal/APIServerImpl.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/internal/APIServerImpl.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/internal/AllExceptionMapper.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/internal/AllExceptionMapper.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/services/WebServerPluginRegistry.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/services/WebServerPluginRegistry.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/CorDappInfoServlet.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/CorDappInfoServlet.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/DataUploadServlet.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/DataUploadServlet.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/ObjectMapperConfig.kt':[
-0,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/ObjectMapperConfig.kt": [
+0
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/ResponseFilter.kt':[
-0,
-],
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/ResponseFilter.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1821.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1821.json
@@ -1,43 +1,43 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt':[
-305,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt": [
+305
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/Try.kt':[
-55,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/Try.kt": [
+55
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/PrettyPrint.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/PrettyPrint.kt": [
 86,
 100,
 105,
 111,
-136,
+136
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt": [
 50,
 73,
 193,
 220,
-258,
+258
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Util.kt':[
-103,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Util.kt": [
+103
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt':[
-116,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt": [
+116
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/RPCSecurityManagerImpl.kt':[
-166,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/security/RPCSecurityManagerImpl.kt": [
+166
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt':[
-314,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt": [
+314
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt':[
-754,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt": [
+754
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt':[
-269,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt": [
+269
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt": [
 57,
 66,
 76,
@@ -45,15 +45,15 @@
 95,
 261,
 283,
-315,
+315
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt':[
-794,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt": [
+794
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt':[
-346,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt": [
+346
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt':[
-154,
-],
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt": [
+154
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1871.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S1871.json
@@ -1,5 +1,5 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt':[
-366,
-],
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt": [
+366
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S2068.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S2068.json
@@ -1,36 +1,36 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/PartyAndCertificateTest.kt':[
-48,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/identity/PartyAndCertificateTest.kt": [
+48
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/Configuration.kt':[
-57,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/node/configuration/Configuration.kt": [
+57
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt':[
-36,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt": [
+36
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt": [
 184,
 185,
 220,
-221,
+221
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt": [
 111,
-112,
+112
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt": [
 251,
-252,
+252
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt": [
 213,
-214,
+214
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/IrsDemoWebApplicationTests.kt':[
-11,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/web/src/test/kotlin/net/corda/irs/web/IrsDemoWebApplicationTests.kt": [
+11
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt": [
 133,
-134,
-],
+134
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S3776.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S3776.json
@@ -1,89 +1,89 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AggregatedList.kt':[
-70,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AggregatedList.kt": [
+70
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ConcatenatedList.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ConcatenatedList.kt": [
 64,
-123,
+123
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/FlattenedList.kt':[
-51,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/FlattenedList.kt": [
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/MappedList.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/MappedList.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ReplayedList.kt':[
-18,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ReplayedList.kt": [
+18
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/mock/src/main/kotlin/net/corda/client/mock/Generator.kt':[
-178,
+"kotlin-corda-project:sources/kotlin/corda/client/mock/src/main/kotlin/net/corda/client/mock/Generator.kt": [
+178
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt':[
-290,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt": [
+290
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt':[
-240,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt": [
+240
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt": [
 128,
-343,
+343
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt':[
-49,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt": [
+49
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt':[
-53,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt": [
+53
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt':[
-327,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt": [
+327
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLog.kt':[
-75,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLog.kt": [
+75
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt':[
-275,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt": [
+275
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt": [
 130,
-410,
+410
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/ObjectDiffer.kt':[
-60,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/utilities/ObjectDiffer.kt": [
+60
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt':[
-215,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt": [
+215
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt':[
-46,
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt": [
+46
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializationInput.kt':[
-129,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializationInput.kt": [
+129
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedType.kt':[
-51,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedType.kt": [
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/FingerPrinter.kt':[
-90,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/FingerPrinter.kt": [
+90
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt':[
-124,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt": [
+124
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt':[
-318,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt": [
+318
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt':[
-610,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt": [
+610
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/performance/Injectors.kt':[
-19,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/performance/Injectors.kt": [
+19
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt':[
-141,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt": [
+141
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/LoginView.kt':[
-34,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/LoginView.kt": [
+34
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt':[
-70,
-],
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt": [
+70
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S3923.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S3923.json
@@ -1,5 +1,5 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApiUtils.kt':[
-128,
-],
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApiUtils.kt": [
+128
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S4144.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S4144.json
@@ -1,18 +1,18 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt':[
-171,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt": [
+171
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/RPCMQSecurityTest.kt':[
-30,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/RPCMQSecurityTest.kt": [
+30
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt':[
-704,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt": [
+704
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/PersistentMapTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/utilities/PersistentMapTests.kt": [
 82,
-126,
+126
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt':[
-210,
-],
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt": [
+210
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S5612.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S5612.json
@@ -1,209 +1,209 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt':[
-239,
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt": [
+239
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt": [
 56,
-140,
+140
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AssociatedList.kt':[
-26,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AssociatedList.kt": [
+26
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ConcatenatedList.kt':[
-65,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ConcatenatedList.kt": [
+65
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/MapValuesList.kt':[
-31,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/MapValuesList.kt": [
+31
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt':[
-92,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt": [
+92
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt": [
 290,
 371,
 443,
 498,
 535,
-576,
+576
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt':[
-104,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt": [
+104
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt':[
-103,
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt": [
+103
 ],
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt": [
 85,
-86,
+86
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt':[
-226,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt": [
+226
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt':[
-128,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt": [
+128
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/ToggleFieldTest.kt':[
-146,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/internal/ToggleFieldTest.kt": [
+146
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt':[
-29,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt": [
+29
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt':[
-53,
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt": [
+53
 ],
-'kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt':[
+"kotlin-corda-project:sources/kotlin/corda/docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt": [
 236,
-278,
+278
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/avalanche/src/main/kotlin/net/corda/avalanche/Main.kt':[
-133,
+"kotlin-corda-project:sources/kotlin/corda/experimental/avalanche/src/main/kotlin/net/corda/avalanche/Main.kt": [
+133
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/process/Command.kt':[
-51,
+"kotlin-corda-project:sources/kotlin/corda/experimental/behave/src/main/kotlin/net/corda/behave/process/Command.kt": [
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/corda-utils/src/test/kotlin/io/cryptoblk/core/StatusTransitionsTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/corda-utils/src/test/kotlin/io/cryptoblk/core/StatusTransitionsTest.kt": [
 107,
-246,
+246
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/quasar-hook/src/main/kotlin/net/corda/quasarhook/QuasarInstrumentationHook.kt':[
-108,
+"kotlin-corda-project:sources/kotlin/corda/experimental/quasar-hook/src/main/kotlin/net/corda/quasarhook/QuasarInstrumentationHook.kt": [
+108
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt": [
 67,
 68,
 69,
 207,
-279,
+279
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Caplet.kt':[
-87,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Caplet.kt": [
+87
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXFwdTimeOption.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXFwdTimeOption.kt": [
 72,
-101,
+101
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/IRS.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/IRS.kt": [
 55,
 56,
 57,
-150,
+150
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Swaption.kt':[
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Swaption.kt": [
 23,
-25,
+25
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt':[
-129,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt": [
+129
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt':[
-58,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt": [
+58
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/CommercialPaperTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/CommercialPaperTests.kt": [
 117,
-148,
+148
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt": [
 128,
 294,
-788,
+788
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt':[
-112,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt": [
+112
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt':[
-51,
+"kotlin-corda-project:sources/kotlin/corda/finance/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt": [
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt':[
-30,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt": [
+30
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt':[
-51,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt": [
+51
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt':[
-100,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt": [
+100
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt": [
 55,
-313,
+313
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt':[
-56,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt": [
+56
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt':[
-123,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt": [
+123
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/distributed/DistributedServiceTests.kt':[
-85,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/distributed/DistributedServiceTests.kt": [
+85
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt':[
-92,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt": [
+92
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt':[
-95,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt": [
+95
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt':[
-75,
+"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt": [
+75
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt':[
-251,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt": [
+251
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt':[
-323,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt": [
+323
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/DefaultKryoCustomizer.kt':[
-63,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/DefaultKryoCustomizer.kt": [
+63
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoSerializationScheme.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoSerializationScheme.kt": [
 45,
-89,
+89
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt':[
-307,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt": [
+307
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt':[
-130,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt": [
+130
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt':[
-189,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt": [
+189
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt':[
-92,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt": [
+92
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt':[
-654,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt": [
+654
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt':[
-40,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/ErrorFlowTransition.kt": [
+40
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt':[
-152,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt": [
+152
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLog.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLog.kt": [
 76,
-78,
+78
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt':[
-494,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt": [
+494
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt':[
-412,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt": [
+412
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt": [
 109,
-164,
+164
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt": [
 112,
 164,
 222,
 342,
 398,
-446,
+446
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt':[
-466,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt": [
+466
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt": [
 554,
 768,
 806,
@@ -211,86 +211,86 @@
 973,
 1701,
 1738,
-2172,
+2172
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt": [
 178,
 179,
 209,
-210,
+210
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt':[
-22,
+"kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt": [
+22
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt':[
-32,
+"kotlin-corda-project:sources/kotlin/corda/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt": [
+32
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt": [
 419,
 617,
 687,
-715,
+715
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt':[
-58,
+"kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt": [
+58
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt": [
 79,
 173,
-216,
+216
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt": [
 50,
-54,
+54
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt':[
-35,
+"kotlin-corda-project:sources/kotlin/corda/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt": [
+35
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt':[
-71,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt": [
+71
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt": [
 158,
 162,
 173,
 240,
 241,
 295,
-298,
+298
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt':[
-318,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt": [
+318
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformsSchema.kt':[
-203,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformsSchema.kt": [
+203
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt": [
 183,
-367,
+367
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/AttachmentsClassLoaderTests.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/AttachmentsClassLoaderTests.kt": [
 303,
-304,
+304
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/FlowStackSnapshotTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/FlowStackSnapshotTest.kt": [
 306,
-309,
+309
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt": [
 443,
-444,
+444
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/performance/Injectors.kt':[
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/performance/Injectors.kt": [
 25,
-70,
+70
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt':[
-158,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt": [
+158
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/profile/ProfileController.kt':[
-95,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/profile/ProfileController.kt": [
+95
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt": [
 70,
 74,
 82,
@@ -298,65 +298,65 @@
 90,
 115,
 145,
-230,
+230
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt':[
-150,
+"kotlin-corda-project:sources/kotlin/corda/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt": [
+150
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/LoginView.kt':[
-35,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/LoginView.kt": [
+35
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/MainView.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/MainView.kt": [
 56,
-61,
+61
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt": [
 105,
 148,
 278,
-279,
+279
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/CashViewer.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/CashViewer.kt": [
 172,
-314,
+314
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt':[
-90,
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt": [
+90
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/ConnectionManager.kt':[
-30,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/ConnectionManager.kt": [
+30
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/Disruption.kt':[
-78,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/Disruption.kt": [
+78
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt": [
 86,
 88,
-173,
+173
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt": [
 124,
 151,
 229,
-248,
+248
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/SelfIssueTest.kt':[
-71,
+"kotlin-corda-project:sources/kotlin/corda/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/SelfIssueTest.kt": [
+71
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt": [
 145,
 196,
-197,
+197
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt':[
-146,
+"kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt": [
+146
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt':[
-105,
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt": [
+105
 ],
-'kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/CorDappInfoServlet.kt':[
+"kotlin-corda-project:sources/kotlin/corda/webserver/src/main/kotlin/net/corda/webserver/servlets/CorDappInfoServlet.kt": [
 22,
 26,
-31,
-],
+31
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S6510.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S6510.json
@@ -1,17 +1,17 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AggregatedList.kt':[
-132,
+"kotlin-corda-project:sources/kotlin/corda/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AggregatedList.kt": [
+132
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/DefaultKryoCustomizer.kt':[
-215,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/serialization/kryo/DefaultKryoCustomizer.kt": [
+215
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutorImpl.kt':[
-41,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutorImpl.kt": [
+41
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt':[
-34,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt": [
+34
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt':[
-627,
-],
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt": [
+627
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S6511.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S6511.json
@@ -1,24 +1,24 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt':[
-210,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/ConfigUtilities.kt": [
+210
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt':[
-198,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt": [
+198
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt':[
-216,
+"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt": [
+216
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ByteBufferStreams.kt':[
-33,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ByteBufferStreams.kt": [
+33
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedType.kt':[
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializedParameterizedType.kt": [
 58,
-88,
+88
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/FingerPrinter.kt':[
-141,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/FingerPrinter.kt": [
+141
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt':[
-41,
-],
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializationHelper.kt": [
+41
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S6517.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S6517.json
@@ -1,93 +1,93 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/jackson/src/main/kotlin/net/corda/client/jackson/internal/CordaModule.kt": [
 415,
-423,
+423
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt':[
-13,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt": [
+13
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Structures.kt':[
-233,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/contracts/Structures.kt": [
+233
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/FlowAsyncOperation.kt':[
-13,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/FlowAsyncOperation.kt": [
+13
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/UniquenessProvider.kt':[
-15,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/internal/notary/UniquenessProvider.kt": [
+15
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/TransactionVerifierService.kt':[
-12,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/TransactionVerifierService.kt": [
+12
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt':[
-18,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt": [
+18
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt": [
 269,
-274,
+274
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/SerializationToken.kt':[
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/serialization/SerializationToken.kt": [
 22,
-29,
+29
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt':[
-90,
+"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt": [
+90
 ],
-'kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Literal.kt':[
-126,
+"kotlin-corda-project:sources/kotlin/corda/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Literal.kt": [
+126
 ],
-'kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/math/Interpolators.kt':[
+"kotlin-corda-project:sources/kotlin/corda/finance/src/main/kotlin/net/corda/finance/contracts/math/Interpolators.kt": [
 5,
-9,
+9
 ],
-'kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ShutdownHook.kt':[
-3,
+"kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/ShutdownHook.kt": [
+3
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/CertificateChainCheckPolicy.kt':[
-11,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/CertificateChainCheckPolicy.kt": [
+11
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappConfigProvider.kt':[
-5,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappConfigProvider.kt": [
+5
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/AuditService.kt':[
-126,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/api/AuditService.kt": [
+126
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/MessagingExecutor.kt':[
-15,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/messaging/MessagingExecutor.kt": [
+15
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutor.kt':[
-8,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutor.kt": [
+8
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt':[
-89,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt": [
+89
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutor.kt':[
-11,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/statemachine/TransitionExecutor.kt": [
+11
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRt.kt':[
-76,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRt.kt": [
+76
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt':[
-30,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt": [
+30
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt':[
-21,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt": [
+21
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentryTests.kt':[
-15,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeNeedingCarpentryTests.kt": [
+15
 ],
-'kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CarpenterExceptionTests.kt':[
-29,
+"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CarpenterExceptionTests.kt": [
+29
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt':[
-157,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt": [
+157
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt':[
-112,
+"kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt": [
+112
 ],
-'kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/LedgerDSLInterpreter.kt':[
-19,
+"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/LedgerDSLInterpreter.kt": [
+19
 ],
-'kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/Formatter.kt':[
-3,
-],
+"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/formatters/Formatter.kt": [
+3
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S6558.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S6558.json
@@ -1,25 +1,25 @@
 {
-'kotlin-corda-project:sources/kotlin/corda/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt':[
+"kotlin-corda-project:sources/kotlin/corda/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt": [
 106,
-121,
+121
 ],
-'kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/CompatibleTransactionTests.kt':[
-92,
+"kotlin-corda-project:sources/kotlin/corda/core/src/test/kotlin/net/corda/core/transactions/CompatibleTransactionTests.kt": [
+92
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt':[
-177,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt": [
+177
 ],
-'kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt':[
-72,
+"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt": [
+72
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt':[
-157,
+"kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt": [
+157
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt':[
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/flows/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt": [
 150,
-267,
+267
 ],
-'kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApiUtils.kt':[
-41,
-],
+"kotlin-corda-project:sources/kotlin/corda/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApiUtils.kt": [
+41
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S100.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S100.json
@@ -1,29 +1,29 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/test/kotlin/org/toml/ide/TomlAnnotatorTest.kt':[
-11,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/test/kotlin/org/toml/ide/TomlAnnotatorTest.kt": [
+11
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/commands/CargoFmtTest.kt':[
-14,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/commands/CargoFmtTest.kt": [
+14
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt':[
-20,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt": [
+20
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/CargoProjectsServiceTest.kt':[
-16,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/CargoProjectsServiceTest.kt": [
+16
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherIntegrationTest.kt':[
-17,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherIntegrationTest.kt": [
+17
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherTest.kt": [
 19,
 33,
 41,
-77,
+77
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/RunConfigurationTestCase.kt':[
-22,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/RunConfigurationTestCase.kt": [
+22
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterTest.kt": [
 21,
 26,
 35,
@@ -33,28 +33,28 @@
 55,
 60,
 63,
-66,
+66
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsConsoleFilterTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsConsoleFilterTest.kt": [
 12,
 17,
 24,
 30,
-36,
+36
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsExplainFilterTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsExplainFilterTest.kt": [
 14,
 19,
 24,
 29,
-34,
+34
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsPanicFilterTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsPanicFilterTest.kt": [
 15,
 20,
-25,
+25
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt": [
 40,
 47,
 54,
@@ -72,31 +72,31 @@
 188,
 200,
 207,
-219,
+219
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/test/CargoTestRunLineMarkerContributorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/test/CargoTestRunLineMarkerContributorTest.kt": [
 14,
 21,
 30,
-40,
+40
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/toolchain/CargoCommandLineTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/toolchain/CargoCommandLineTest.kt": [
 14,
 22,
 30,
 38,
 46,
-54,
+54
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt": [
 16,
 25,
 34,
 54,
 63,
-72,
+72
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt": [
 19,
 33,
 38,
@@ -106,9 +106,9 @@
 65,
 70,
 75,
-80,
+80
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsJoinLinesHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsJoinLinesHandlerTest.kt": [
 9,
 11,
 12,
@@ -133,18 +133,18 @@
 207,
 218,
 225,
-232,
+232
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsJoinRawLinesHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsJoinRawLinesHandlerTest.kt": [
 9,
 21,
 43,
 61,
 75,
 90,
-106,
+106
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsMoveLeftRightHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsMoveLeftRightHandlerTest.kt": [
 14,
 24,
 30,
@@ -166,9 +166,9 @@
 154,
 168,
 178,
-184,
+184
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMoverTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMoverTest.kt": [
 9,
 21,
 33,
@@ -181,9 +181,9 @@
 129,
 138,
 150,
-162,
+162
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsItemUpDownMoverTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsItemUpDownMoverTest.kt": [
 11,
 17,
 27,
@@ -205,21 +205,21 @@
 223,
 231,
 243,
-253,
+253
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsMatchArmUpDownMoverTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsMatchArmUpDownMoverTest.kt": [
 9,
 25,
 49,
 64,
-84,
+84
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsCrateDocLineMarkerProviderTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsCrateDocLineMarkerProviderTest.kt": [
 19,
 24,
-28,
+28
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt": [
 11,
 13,
 18,
@@ -305,9 +305,9 @@
 1105,
 1110,
 1115,
-1121,
+1121
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt": [
 10,
 46,
 107,
@@ -319,9 +319,9 @@
 176,
 181,
 188,
-195,
+195
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt": [
 10,
 17,
 26,
@@ -333,23 +333,23 @@
 91,
 98,
 108,
-118,
+118
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt": [
 10,
 19,
-28,
+28
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsLiteralAnnotatorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsLiteralAnnotatorTest.kt": [
 9,
 19,
-30,
+30
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsStdlibErrorAnnotatorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsStdlibErrorAnnotatorTest.kt": [
 18,
-27,
+27
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt": [
 9,
 16,
 33,
@@ -369,19 +369,19 @@
 216,
 226,
 233,
-241,
+241
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddAsTyFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddAsTyFixTest.kt": [
 12,
 22,
 32,
-44,
+44
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddSelfTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddSelfTest.kt": [
 11,
-29,
+29
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt": [
 15,
 29,
 43,
@@ -392,9 +392,9 @@
 121,
 150,
 240,
-288,
+288
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFixTest.kt": [
 14,
 20,
 22,
@@ -403,39 +403,39 @@
 46,
 68,
 71,
-76,
+76
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeTest.kt": [
 11,
 25,
 49,
 67,
 81,
 95,
-109,
+109
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToOwnedTyFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToOwnedTyFixTest.kt": [
 14,
 48,
-67,
+67
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToSizedTypeFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToSizedTypeFixTest.kt": [
 12,
 18,
 24,
-32,
+32
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFixTest.kt": [
 14,
-24,
+24
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStringFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStringFixTest.kt": [
 14,
 24,
 34,
-44,
+44
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromStrFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromStrFixTest.kt": [
 15,
 16,
 17,
@@ -446,20 +446,20 @@
 104,
 130,
 154,
-168,
+168
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFixTest.kt": [
 14,
 34,
 47,
-57,
+57
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTraitFixTestBase.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTraitFixTestBase.kt": [
 19,
 43,
-57,
+57
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFixTest.kt": [
 15,
 43,
 73,
@@ -468,9 +468,9 @@
 167,
 195,
 211,
-224,
+224
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFixTest.kt": [
 13,
 25,
 37,
@@ -483,9 +483,9 @@
 106,
 113,
 125,
-138,
+138
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt": [
 21,
 22,
 23,
@@ -496,9 +496,9 @@
 29,
 31,
 32,
-33,
+33
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt": [
 14,
 41,
 49,
@@ -575,9 +575,9 @@
 913,
 938,
 946,
-954,
+954
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt": [
 13,
 31,
 45,
@@ -641,21 +641,21 @@
 669,
 683,
 694,
-701,
+701
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt": [
 15,
 22,
 30,
 40,
 48,
-58,
+58
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsStdlibResolveLinkTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsStdlibResolveLinkTest.kt": [
 17,
-24,
+24
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/folding/RsFoldingBuilderTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/folding/RsFoldingBuilderTest.kt": [
 13,
 14,
 15,
@@ -675,9 +675,9 @@
 29,
 30,
 31,
-32,
+32
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsAutoIndentTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsAutoIndentTest.kt": [
 11,
 19,
 31,
@@ -699,9 +699,9 @@
 211,
 230,
 243,
-254,
+254
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterLineBreaksTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterLineBreaksTest.kt": [
 15,
 16,
 18,
@@ -711,9 +711,9 @@
 160,
 174,
 180,
-192,
+192
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt": [
 13,
 14,
 15,
@@ -762,12 +762,12 @@
 348,
 376,
 401,
-415,
+415
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsMatchArmCommaFormatProcessorTest.kt':[
-10,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsMatchArmCommaFormatProcessorTest.kt": [
+10
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsSingleImportRemoveBracesFormatProcessorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsSingleImportRemoveBracesFormatProcessorTest.kt": [
 10,
 12,
 15,
@@ -780,21 +780,21 @@
 35,
 37,
 41,
-45,
+45
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsStatementSemicolonFormatProcessorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsStatementSemicolonFormatProcessorTest.kt": [
 10,
 44,
 62,
 102,
-142,
+142
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsTrailingCommaFormatProcessorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsTrailingCommaFormatProcessorTest.kt": [
 9,
 61,
-77,
+77
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt": [
 22,
 31,
 40,
@@ -811,9 +811,9 @@
 161,
 174,
 187,
-207,
+207
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsInlayParameterHintsProviderTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsInlayParameterHintsProviderTest.kt": [
 30,
 64,
 72,
@@ -831,14 +831,14 @@
 207,
 223,
 242,
-257,
+257
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsParameterInfoHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsParameterInfoHandlerTest.kt": [
 35,
 40,
-148,
+148
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsQuickDefinitionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsQuickDefinitionTest.kt": [
 20,
 32,
 46,
@@ -849,9 +849,9 @@
 110,
 122,
 135,
-148,
+148
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt": [
 9,
 23,
 41,
@@ -859,9 +859,9 @@
 69,
 87,
 101,
-112,
+112
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspectionTest.kt": [
 10,
 21,
 32,
@@ -888,12 +888,12 @@
 270,
 292,
 308,
-316,
+316
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsExperimentalChecksInspectionTest.kt':[
-9,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsExperimentalChecksInspectionTest.kt": [
+9
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspectionTest.kt": [
 10,
 14,
 18,
@@ -902,13 +902,13 @@
 30,
 37,
 43,
-55,
+55
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspectionTest.kt": [
 10,
-16,
+16
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt": [
 10,
 17,
 24,
@@ -929,17 +929,17 @@
 138,
 150,
 162,
-172,
+172
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt": [
 47,
 55,
-62,
+62
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspectionTest.kt':[
-9,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspectionTest.kt": [
+9
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt": [
 10,
 44,
 52,
@@ -949,9 +949,9 @@
 91,
 158,
 182,
-249,
+249
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsTypeCheckInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsTypeCheckInspectionTest.kt": [
 9,
 15,
 19,
@@ -967,16 +967,16 @@
 99,
 108,
 119,
-130,
+130
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt": [
 12,
 22,
 28,
 34,
-45,
+45
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsVariableMutableInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsVariableMutableInspectionTest.kt": [
 10,
 16,
 22,
@@ -990,18 +990,18 @@
 107,
 118,
 132,
-146,
+146
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberTest.kt": [
 10,
 25,
 36,
 49,
 58,
 64,
-73,
+73
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspectionTest.kt": [
 10,
 32,
 36,
@@ -1013,9 +1013,9 @@
 133,
 143,
 157,
-167,
+167
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt": [
 14,
 22,
 38,
@@ -1031,9 +1031,9 @@
 229,
 261,
 299,
-312,
+312
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt": [
 10,
 30,
 50,
@@ -1071,9 +1071,9 @@
 895,
 924,
 974,
-1010,
+1010
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddCurlyBracesIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddCurlyBracesIntentionTest.kt": [
 10,
 15,
 20,
@@ -1081,28 +1081,28 @@
 30,
 35,
 40,
-45,
+45
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddDeriveIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddDeriveIntentionTest.kt": [
 10,
 17,
 25,
-36,
+36
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddElseIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddElseIntentionTest.kt": [
 16,
 26,
 40,
 54,
 72,
-90,
+90
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddImplIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddImplIntentionTest.kt": [
 9,
 21,
-29,
+29
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/DemorgansLawIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/DemorgansLawIntentionTest.kt": [
 10,
 20,
 30,
@@ -1114,18 +1114,18 @@
 90,
 100,
 110,
-120,
+120
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt": [
 15,
 39,
-63,
+63
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionStdTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionStdTest.kt": [
 14,
-27,
+27
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionTest.kt": [
 10,
 33,
 56,
@@ -1133,34 +1133,34 @@
 105,
 128,
 154,
-167,
+167
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntentionTest.kt':[
-14,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntentionTest.kt": [
+14
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt": [
 9,
 23,
 40,
 57,
 78,
-99,
+99
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MatchToIfLetIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MatchToIfLetIntentionTest.kt": [
 9,
 25,
 41,
 57,
-92,
+92
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MoveGuardToMatchArmIntentionITest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MoveGuardToMatchArmIntentionITest.kt": [
 9,
 17,
 31,
 51,
-67,
+67
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntentionTest.kt": [
 10,
 15,
 20,
@@ -1172,9 +1172,9 @@
 50,
 55,
 60,
-62,
+62
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToWhereClauseIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToWhereClauseIntentionTest.kt": [
 9,
 14,
 19,
@@ -1189,28 +1189,28 @@
 64,
 76,
 82,
-84,
+84
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntentionTest.kt": [
 10,
 15,
-26,
+26
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RemoveParenthesesFromExprIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RemoveParenthesesFromExprIntentionTest.kt": [
+9
+],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt": [
+16
+],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SetImmutableIntentionTest.kt": [
 9,
+14
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt':[
-16,
-],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SetImmutableIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SetMutableIntentionTest.kt": [
 9,
-14,
+14
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SetMutableIntentionTest.kt':[
-9,
-14,
-],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntentionTest.kt": [
 12,
 22,
 32,
@@ -1236,20 +1236,20 @@
 216,
 226,
 236,
-246,
+246
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt": [
 9,
 14,
 19,
-23,
+23
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/ToggleIgnoreTestIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/ToggleIgnoreTestIntentionTest.kt": [
 9,
 18,
-27,
+27
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt": [
 9,
 15,
 21,
@@ -1258,9 +1258,9 @@
 43,
 53,
 63,
-77,
+77
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntentionTest.kt": [
 9,
 21,
 31,
@@ -1271,9 +1271,9 @@
 79,
 95,
 111,
-127,
+127
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/UnwrapToTryIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/UnwrapToTryIntentionTest.kt": [
 9,
 19,
 29,
@@ -1286,31 +1286,31 @@
 95,
 101,
 107,
-113,
+113
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/WrapLambdaExprIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/WrapLambdaExprIntentionTest.kt": [
 9,
-25,
+25
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt':[
-11,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt": [
+11
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsRecursiveCallLineMarkerProviderTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsRecursiveCallLineMarkerProviderTest.kt": [
 13,
 19,
 28,
 37,
 47,
-56,
+56
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt": [
 15,
-39,
+39
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/miscExtensions/RsBreadcrumbsInfoProviderTest.kt':[
-16,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/miscExtensions/RsBreadcrumbsInfoProviderTest.kt": [
+16
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandlerTest.kt": [
 15,
 29,
 45,
@@ -1319,9 +1319,9 @@
 93,
 107,
 115,
-128,
+128
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoTypeDeclarationTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoTypeDeclarationTest.kt": [
 14,
 22,
 36,
@@ -1339,9 +1339,9 @@
 174,
 182,
 194,
-232,
+232
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt": [
 14,
 60,
 66,
@@ -1351,23 +1351,23 @@
 108,
 129,
 152,
-173,
+173
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsConvertToNamedFieldsActionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsConvertToNamedFieldsActionTest.kt": [
 13,
-22,
+22
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsDowngradeModuleToFileTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsDowngradeModuleToFileTest.kt": [
 17,
 30,
 43,
-53,
+53
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsPromoteModuleToDirectoryActionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsPromoteModuleToDirectoryActionTest.kt": [
 19,
-31,
+31
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt": [
 14,
 23,
 41,
@@ -1375,9 +1375,9 @@
 70,
 97,
 110,
-131,
+131
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/structure/RsStructureViewTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/structure/RsStructureViewTest.kt": [
 18,
 32,
 45,
@@ -1393,22 +1393,22 @@
 266,
 270,
 274,
-337,
+337
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt": [
 90,
 99,
-105,
+105
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplateTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplateTest.kt": [
 9,
 37,
-53,
+53
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/NotPostfixTemplateTest.kt':[
-9,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/NotPostfixTemplateTest.kt": [
+9
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsAngleBraceTypedHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsAngleBraceTypedHandlerTest.kt": [
 11,
 12,
 13,
@@ -1426,22 +1426,22 @@
 38,
 41,
 44,
-47,
+47
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsBraceMatcherTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsBraceMatcherTest.kt": [
 15,
 21,
 27,
 33,
 35,
 37,
-70,
+70
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsDotTypedHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsDotTypedHandlerTest.kt": [
 9,
-23,
+23
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsEnterInLineCommentHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsEnterInLineCommentHandlerTest.kt": [
 11,
 12,
 13,
@@ -1457,9 +1457,9 @@
 25,
 27,
 28,
-30,
+30
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsEnterInStringLiteralHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsEnterInStringLiteralHandlerTest.kt": [
 13,
 26,
 43,
@@ -1478,9 +1478,9 @@
 184,
 193,
 202,
-214,
+214
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsQuoteHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsQuoteHandlerTest.kt": [
 11,
 21,
 31,
@@ -1497,9 +1497,9 @@
 98,
 110,
 111,
-112,
+112
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsRawLiteralHashesBalancerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsRawLiteralHashesBalancerTest.kt": [
 11,
 21,
 31,
@@ -1513,9 +1513,9 @@
 111,
 121,
 135,
-146,
+146
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/assist/RsSmartEnterProcessorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/assist/RsSmartEnterProcessorTest.kt": [
 41,
 42,
 43,
@@ -1524,15 +1524,15 @@
 46,
 47,
 48,
-49,
+49
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/wordSelection/RsListSelectionHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/wordSelection/RsListSelectionHandlerTest.kt": [
 10,
 22,
 34,
-44,
+44
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTest.kt": [
 9,
 14,
 19,
@@ -1552,19 +1552,19 @@
 102,
 107,
 112,
-117,
+117
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt':[
-25,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt": [
+25
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt": [
 9,
-27,
+27
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionPriorityTest.kt':[
-16,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionPriorityTest.kt": [
+16
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt": [
 9,
 15,
 23,
@@ -1620,9 +1620,9 @@
 541,
 550,
 561,
-569,
+569
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProviderTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProviderTest.kt": [
 16,
 28,
 40,
@@ -1633,15 +1633,15 @@
 82,
 87,
 93,
-98,
+98
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsExternCrateCompletionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsExternCrateCompletionTest.kt": [
 16,
 21,
 25,
-29,
+29
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt": [
 12,
 20,
 28,
@@ -1734,9 +1734,9 @@
 469,
 479,
 489,
-503,
+503
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt": [
 16,
 21,
 28,
@@ -1750,15 +1750,15 @@
 76,
 81,
 88,
-93,
+93
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsModCompletionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsModCompletionTest.kt": [
 9,
 19,
 29,
-39,
+39
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsPartialParseCompletionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsPartialParseCompletionTest.kt": [
 9,
 15,
 21,
@@ -1777,9 +1777,9 @@
 129,
 134,
 154,
-159,
+159
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt": [
 15,
 21,
 27,
@@ -1819,17 +1819,17 @@
 246,
 253,
 260,
-267,
+267
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt": [
 13,
 19,
 26,
 33,
 41,
-47,
+47
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt": [
 9,
 19,
 29,
@@ -1842,9 +1842,9 @@
 153,
 165,
 179,
-189,
+189
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt": [
 26,
 27,
 28,
@@ -1862,17 +1862,17 @@
 52,
 90,
 99,
-126,
+126
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsErrorChainMacroExpansionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsErrorChainMacroExpansionTest.kt": [
 11,
 102,
 136,
 170,
 196,
-216,
+216
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt": [
 9,
 20,
 40,
@@ -1902,9 +1902,9 @@
 405,
 420,
 437,
-451,
+451
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/parser/RsCompleteParsingTestCase.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/parser/RsCompleteParsingTestCase.kt": [
 12,
 13,
 14,
@@ -1941,9 +1941,9 @@
 45,
 47,
 48,
-50,
+50
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/parser/RsPartialParsingTestCase.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/parser/RsPartialParsingTestCase.kt": [
 16,
 17,
 18,
@@ -1956,9 +1956,9 @@
 25,
 26,
 27,
-28,
+28
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt": [
 50,
 55,
 61,
@@ -1984,16 +1984,16 @@
 207,
 217,
 227,
-239,
+239
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactoryTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactoryTest.kt": [
 12,
-20,
+20
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsNumericLiteralValueTest.kt':[
-43,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsNumericLiteralValueTest.kt": [
+43
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsClosuresResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsClosuresResolveTest.kt": [
 25,
 39,
 52,
@@ -2009,18 +2009,18 @@
 247,
 258,
 269,
-281,
+281
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt": [
 9,
 26,
 48,
 70,
 92,
 115,
-143,
+143
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt": [
 10,
 23,
 33,
@@ -2030,14 +2030,14 @@
 70,
 86,
 101,
-112,
+112
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt": [
 13,
 21,
-29,
+29
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsNamespaceResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsNamespaceResolveTest.kt": [
 9,
 25,
 35,
@@ -2052,24 +2052,24 @@
 152,
 166,
 173,
-184,
+184
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsOperatorsResolve.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsOperatorsResolve.kt": [
 12,
 36,
 59,
-81,
+81
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt": [
 16,
 28,
 41,
 54,
 67,
 80,
-95,
+95
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt": [
 11,
 28,
 51,
@@ -2082,9 +2082,9 @@
 171,
 190,
 212,
-234,
+234
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt": [
 10,
 18,
 27,
@@ -2186,9 +2186,9 @@
 1035,
 1044,
 1051,
-1059,
+1059
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt": [
 15,
 24,
 32,
@@ -2242,9 +2242,9 @@
 478,
 491,
 510,
-527,
+527
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt": [
 9,
 22,
 37,
@@ -2273,9 +2273,9 @@
 366,
 386,
 397,
-407,
+407
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt": [
 12,
 20,
 31,
@@ -2332,9 +2332,9 @@
 794,
 811,
 828,
-843,
+843
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt": [
 11,
 23,
 33,
@@ -2384,9 +2384,9 @@
 623,
 633,
 643,
-655,
+655
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt": [
 10,
 22,
 36,
@@ -2426,15 +2426,15 @@
 501,
 526,
 538,
-550,
+550
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/stubs/RsStubAccessTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/stubs/RsStubAccessTest.kt": [
 34,
 47,
 51,
-62,
+62
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt": [
 16,
 25,
 34,
@@ -2444,23 +2444,23 @@
 82,
 93,
 107,
-120,
+120
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsArithmeticOpsTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsArithmeticOpsTest.kt": [
 12,
 35,
 58,
 82,
-112,
+112
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsDivergingTypeInferenceTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsDivergingTypeInferenceTest.kt": [
 10,
 17,
 24,
 31,
-46,
+46
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsEnumPatternTypeInferenceTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsEnumPatternTypeInferenceTest.kt": [
 9,
 20,
 33,
@@ -2468,9 +2468,9 @@
 58,
 72,
 87,
-102,
+102
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt": [
 9,
 21,
 30,
@@ -2591,9 +2591,9 @@
 1022,
 1034,
 1043,
-1051,
+1051
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt": [
 11,
 21,
 31,
@@ -2716,9 +2716,9 @@
 1386,
 1400,
 1413,
-1424,
+1424
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt": [
 19,
 21,
 26,
@@ -2739,18 +2739,18 @@
 108,
 113,
 120,
-127,
+127
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsIndexTypeInferenceTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsIndexTypeInferenceTest.kt": [
 12,
 29,
 46,
 64,
 88,
 105,
-121,
+121
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt": [
 9,
 15,
 21,
@@ -2818,9 +2818,9 @@
 480,
 491,
 503,
-511,
+511
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt": [
 9,
 17,
 27,
@@ -2838,14 +2838,14 @@
 145,
 154,
 163,
-174,
+174
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsSnapshotMapTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsSnapshotMapTest.kt": [
 25,
 31,
-40,
+40
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt": [
 18,
 27,
 37,
@@ -2891,12 +2891,12 @@
 434,
 441,
 474,
-485,
+485
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt':[
-10,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt": [
+10
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt": [
 13,
 22,
 29,
@@ -2937,16 +2937,16 @@
 259,
 265,
 271,
-277,
+277
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsUnificationTableTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsUnificationTableTest.kt": [
 76,
 80,
 86,
 92,
-99,
+99
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsExtractFunctionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsExtractFunctionTest.kt": [
 20,
 38,
 103,
@@ -2980,9 +2980,9 @@
 791,
 817,
 853,
-881,
+881
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsImportOptimizerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsImportOptimizerTest.kt": [
 13,
 19,
 30,
@@ -3002,9 +3002,9 @@
 182,
 187,
 195,
-211,
+211
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsIntroduceVariableHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsIntroduceVariableHandlerTest.kt": [
 19,
 30,
 40,
@@ -3016,9 +3016,9 @@
 119,
 129,
 144,
-163,
+163
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt": [
 15,
 19,
 45,
@@ -3033,9 +3033,9 @@
 335,
 364,
 406,
-447,
+447
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/implementMembers/RsNameSuggestionsKtTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/implementMembers/RsNameSuggestionsKtTest.kt": [
 18,
 30,
 43,
@@ -3045,28 +3045,28 @@
 83,
 98,
 116,
-124,
+124
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/stdext/AsyncValueTest.kt':[
-16,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/stdext/AsyncValueTest.kt": [
+16
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt": [
 44,
 52,
 57,
 62,
 67,
 72,
-77,
+77
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/toml/CargoTomlCompletionContributorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/toml/CargoTomlCompletionContributorTest.kt": [
 12,
 21,
 26,
 31,
-36,
+36
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt": [
 18,
 35,
 55,
@@ -3075,31 +3075,31 @@
 169,
 192,
 217,
-240,
+240
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectServiceTest.kt':[
-16,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectServiceTest.kt": [
+16
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectStructureTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectStructureTest.kt": [
 17,
-49,
+49
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorTest.kt": [
 23,
 27,
 34,
 43,
 70,
-108,
+108
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsCompilerSourcesPerformance.kt':[
-33,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsCompilerSourcesPerformance.kt": [
+33
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsHighlightingPerformanceTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsHighlightingPerformanceTest.kt": [
 26,
-29,
+29
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsTypingEmptyFileFuzzyTest.kt':[
-12,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsTypingEmptyFileFuzzyTest.kt": [
+12
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S103.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S103.json
@@ -1,11 +1,11 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsDowngradeModuleToFile.kt':[
-21,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsDowngradeModuleToFile.kt": [
+21
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsLiteralAnnotatorTest.kt':[
-25,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsLiteralAnnotatorTest.kt": [
+25
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt": [
 125,
 137,
 188,
@@ -14,17 +14,17 @@
 593,
 737,
 910,
-964,
+964
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt": [
 98,
 153,
 183,
 227,
 432,
-476,
+476
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsQuickDefinitionTest.kt':[
-174,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsQuickDefinitionTest.kt": [
+174
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S104.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S104.json
@@ -1,14 +1,14 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt':[
-0,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1066.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1066.json
@@ -1,22 +1,22 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/processors/RsStatementSemicolonFormatProcessor.kt':[
-31,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/processors/RsStatementSemicolonFormatProcessor.kt": [
+31
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt':[
-77,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt": [
+77
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt':[
-89,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt": [
+89
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt": [
 267,
 277,
 543,
 602,
-724,
+724
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/impl.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/impl.kt": [
 92,
-100,
-],
+100
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1067.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1067.json
@@ -1,29 +1,29 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt':[
-184,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt": [
+184
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt':[
-120,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt": [
+120
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt':[
-166,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt": [
+166
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt':[
-172,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt": [
+172
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt':[
-36,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt": [
+36
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt':[
-270,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt": [
+270
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsMacroDefinitionCompletionProvider.kt':[
-50,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsMacroDefinitionCompletionProvider.kt": [
+50
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt':[
-315,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt": [
+315
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionConfig.kt':[
-173,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionConfig.kt": [
+173
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S107.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S107.json
@@ -1,5 +1,5 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt':[
-132,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt": [
+132
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S108.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S108.json
@@ -1,11 +1,11 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsLiteralAnnotator.kt':[
-37,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsLiteralAnnotator.kt": [
+37
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt':[
-119,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt": [
+119
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt':[
-1478,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt": [
+1478
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1125.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1125.json
@@ -1,14 +1,14 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsQuoteHandler.kt':[
-45,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsQuoteHandler.kt": [
+45
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsMacroDefinitionCompletionProvider.kt':[
-38,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsMacroDefinitionCompletionProvider.kt": [
+38
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt':[
-119,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt": [
+119
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fold.kt':[
-99,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fold.kt": [
+99
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1128.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1128.json
@@ -1,58 +1,58 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt": [
 8,
 9,
 10,
 11,
 14,
-17,
+17
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt':[
-23,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt": [
+23
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt':[
-21,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt": [
+21
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/UnwrapToTryIntention.kt':[
-15,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/UnwrapToTryIntention.kt": [
+15
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt':[
-20,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt": [
+20
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt':[
-9,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt": [
+9
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt": [
+10
+],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsAssocTypeBindingReferenceImpl.kt": [
 10,
+11
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsAssocTypeBindingReferenceImpl.kt':[
-10,
-11,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersFix.kt": [
+13
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersFix.kt':[
-13,
-],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/impl.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/impl.kt": [
 14,
-15,
+15
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ui.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ui.kt": [
 20,
-21,
+21
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt':[
-14,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt": [
+14
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/RsTomlCompletionProvider.kt':[
-23,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/RsTomlCompletionProvider.kt": [
+23
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt':[
-9,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt": [
+9
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt':[
-8,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt": [
+8
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt':[
-8,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt": [
+8
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1134.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1134.json
@@ -1,52 +1,52 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt':[
-190,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt": [
+190
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt':[
-53,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt": [
+53
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt':[
-43,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt": [
+43
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt':[
-100,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt": [
+100
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsQuoteHandler.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsQuoteHandler.kt": [
 27,
-39,
+39
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/SearchByOffset.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/SearchByOffset.kt": [
 56,
-57,
+57
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt':[
-71,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt": [
+71
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt':[
-108,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt": [
+108
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionHandlerAction.kt':[
-40,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionHandlerAction.kt": [
+40
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt':[
-32,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt": [
+32
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsAutoIndentTest.kt':[
-224,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsAutoIndentTest.kt": [
+224
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt':[
-114,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt": [
+114
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddDeriveIntentionTest.kt':[
-24,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddDeriveIntentionTest.kt": [
+24
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/statement/RsWithBlockSurrounderTest.kt':[
-162,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/statement/RsWithBlockSurrounderTest.kt": [
+162
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsEnterInStringLiteralHandlerTest.kt':[
-213,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsEnterInStringLiteralHandlerTest.kt": [
+213
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt':[
-354,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt": [
+354
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1135.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1135.json
@@ -1,69 +1,69 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt':[
-185,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt": [
+185
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/filters/RegexpFileLinkFilter.kt':[
-32,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/filters/RegexpFileLinkFilter.kt": [
+32
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/colors/RsColorSettingsPage.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/colors/RsColorSettingsPage.kt": [
 18,
-23,
+23
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt": [
 235,
-334,
+334
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt':[
-481,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt": [
+481
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/ui.kt':[
-60,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/ui.kt": [
+60
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt':[
-18,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt": [
+18
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/FillMatchArmsIntention.kt':[
-27,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/FillMatchArmsIntention.kt": [
+27
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntention.kt':[
-28,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntention.kt": [
+28
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt':[
-40,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt": [
+40
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt':[
-73,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt": [
+73
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt": [
 46,
 47,
-59,
+59
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt':[
-27,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt": [
+27
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt':[
-42,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt": [
+42
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt':[
-33,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt": [
+33
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt": [
 214,
 315,
 468,
-495,
+495
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt':[
-369,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt": [
+369
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt':[
-75,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt": [
+75
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt':[
-101,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt": [
+101
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt": [
 427,
 432,
 436,
@@ -75,34 +75,34 @@
 1272,
 1401,
 1449,
-1455,
+1455
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsItemUpDownMoverTest.kt':[
-98,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsItemUpDownMoverTest.kt": [
+98
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt':[
-642,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt": [
+642
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsNamingInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsNamingInspectionTest.kt": [
 27,
-376,
+376
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsTypeCheckInspectionTest.kt':[
-72,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsTypeCheckInspectionTest.kt": [
+72
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntentionTest.kt':[
-20,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntentionTest.kt": [
+20
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt':[
-602,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt": [
+602
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt':[
-347,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt": [
+347
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt':[
-38,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt": [
+38
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt':[
-200,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt": [
+200
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1151.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1151.json
@@ -1,43 +1,43 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructureTree.kt':[
-45,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructureTree.kt": [
+45
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt':[
-158,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt": [
+158
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt':[
-44,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt": [
+44
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFix.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFix.kt": [
 147,
-152,
+152
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt':[
-44,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt": [
+44
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt": [
 103,
-165,
+165
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt':[
-38,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt": [
+38
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt':[
-340,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt": [
+340
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt':[
-616,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt": [
+616
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt':[
-21,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt": [
+21
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt':[
-186,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt": [
+186
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt": [
 267,
 458,
 809,
-1511,
-],
+1511
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S117.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S117.json
@@ -1,5 +1,5 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/RustcMessage.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/RustcMessage.kt": [
 14,
 45,
 46,
@@ -15,22 +15,22 @@
 66,
 67,
 72,
-75,
+75
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt": [
 46,
 52,
 81,
 108,
-115,
+115
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFix.kt':[
-68,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFix.kt": [
+68
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsInspectionSuppressor.kt':[
-39,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsInspectionSuppressor.kt": [
+39
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsClosuresResolveTest.kt':[
-12,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsClosuresResolveTest.kt": [
+12
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1186.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1186.json
@@ -1,26 +1,26 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt':[
-104,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt": [
+104
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt':[
-32,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt": [
+32
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/RsCrateDocLineMarkerProvider.kt':[
-41,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/RsCrateDocLineMarkerProvider.kt": [
+41
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt": [
 37,
-42,
+42
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/RsPlaceholderStub.kt':[
-25,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/RsPlaceholderStub.kt": [
+25
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/RsStubElementType.kt':[
-22,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/RsStubElementType.kt": [
+22
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt": [
 477,
 1063,
-1104,
-],
+1104
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1192.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1192.json
@@ -1,131 +1,131 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt':[
-93,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt": [
+93
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherIntegrationTest.kt':[
-19,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherIntegrationTest.kt": [
+19
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt": [
 42,
 56,
-76,
+76
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsJoinLinesHandlerTest.kt':[
-19,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsJoinLinesHandlerTest.kt": [
+19
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsAnnotatorTestBase.kt':[
-19,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsAnnotatorTestBase.kt": [
+19
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeTest.kt':[
-67,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeTest.kt": [
+67
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStringFixTest.kt':[
-14,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStringFixTest.kt": [
+14
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromStrFixTest.kt':[
-20,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromStrFixTest.kt": [
+20
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFixTest.kt':[
-15,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFixTest.kt": [
+15
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFixTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFixTest.kt": [
 13,
-61,
+61
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt": [
 29,
-29,
+29
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsParameterInfoHandlerTest.kt':[
-63,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsParameterInfoHandlerTest.kt": [
+63
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt": [
 9,
-55,
+55
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt':[
-126,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt": [
+126
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt':[
-10,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt": [
+10
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspectionTest.kt':[
-66,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspectionTest.kt": [
+66
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt':[
-17,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt": [
+17
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntentionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntentionTest.kt": [
 16,
 26,
-76,
+76
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt':[
-108,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt": [
+108
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsDowngradeModuleToFileTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsDowngradeModuleToFileTest.kt": [
 21,
-21,
+21
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/ElsePostfixTemplateTest.kt':[
-137,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/ElsePostfixTemplateTest.kt": [
+137
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/WhileNotPostfixTemplateTest.kt':[
-137,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/WhileNotPostfixTemplateTest.kt": [
+137
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsAngleBraceTypedHandlerTest.kt':[
-45,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsAngleBraceTypedHandlerTest.kt": [
+45
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/RsTestBase.kt':[
-219,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/RsTestBase.kt": [
+219
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt": [
 16,
 128,
 221,
 225,
-325,
+325
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt':[
-387,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt": [
+387
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt':[
-18,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt": [
+18
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/doc/RsDocRemoveDecorationTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/doc/RsDocRemoveDecorationTest.kt": [
 41,
-57,
+57
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsIntroduceVariableHandlerTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsIntroduceVariableHandlerTest.kt": [
 23,
-23,
+23
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt':[
-211,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt": [
+211
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/utils/RsEscapesUtilsTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/utils/RsEscapesUtilsTest.kt": [
 38,
 41,
-43,
+43
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt": [
 19,
 27,
 33,
-68,
+68
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectServiceTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectServiceTest.kt": [
 19,
-26,
+26
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectStructureTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectStructureTest.kt": [
 27,
-35,
+35
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorTest.kt": [
 45,
 45,
 53,
-62,
-],
+62
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S122.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S122.json
@@ -1,8 +1,8 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt':[
-61,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt": [
+61
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt':[
-197,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt": [
+197
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S125.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S125.json
@@ -1,8 +1,8 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/IfLetToMatchIntention.kt':[
-51,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/IfLetToMatchIntention.kt": [
+51
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/RsContextType.kt':[
-63,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/RsContextType.kt": [
+63
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S126.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S126.json
@@ -1,30 +1,30 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt':[
-121,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt": [
+121
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt": [
 296,
-325,
+325
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberInspection.kt':[
-30,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberInspection.kt": [
+30
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/IfLetToMatchIntention.kt':[
-116,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/IfLetToMatchIntention.kt": [
+116
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsLiteralKind.kt':[
-125,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsLiteralKind.kt": [
+125
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt':[
-436,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt": [
+436
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt": [
 61,
 93,
 101,
-113,
+113
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsParameterInfoHandlerTest.kt':[
-193,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsParameterInfoHandlerTest.kt": [
+193
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S134.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S134.json
@@ -1,30 +1,30 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt':[
-86,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt": [
+86
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsBraceMatcher.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsBraceMatcher.kt": [
 64,
 73,
-74,
+74
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt':[
-73,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt": [
+73
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt':[
-105,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt": [
+105
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt": [
 228,
 444,
 611,
 637,
 638,
-639,
+639
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt": [
 87,
 90,
 94,
-97,
-],
+97
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S138.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S138.json
@@ -1,5 +1,5 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsErrorChainMacroExpansionTest.kt':[
-216,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsErrorChainMacroExpansionTest.kt": [
+216
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1451.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1451.json
@@ -1,2258 +1,2258 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/RsLineBreakpointFileTypesProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/RsLineBreakpointFileTypesProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerEditorsExtension.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerEditorsExtension.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerLanguageSupport.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerLanguageSupport.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerTypesHelper.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerTypesHelper.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunParameters.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunParameters.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsLocalDebugProcess.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsLocalDebugProcess.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettingsConfigurable.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettingsConfigurable.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/ide/TomlAnnotator.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/ide/TomlAnnotator.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/ide/TomlBraceMatcher.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/ide/TomlBraceMatcher.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/ide/TomlCommenter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/ide/TomlCommenter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/ide/TomlHighlighter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/ide/TomlHighlighter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/ide/TomlQuoteHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/ide/TomlQuoteHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/TomlFileTypeDetector.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/TomlFileTypeDetector.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/TomlFileTypeFactory.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/TomlFileTypeFactory.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/TomlLanguage.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/TomlLanguage.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/parse/TomlLexer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/parse/TomlLexer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/parse/TomlParserDefinition.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/parse/TomlParserDefinition.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/parse/TomlParserUtil.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/parse/TomlParserUtil.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/psi/ElementTypes.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/psi/ElementTypes.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/psi/Psi.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/psi/Psi.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/psi/TomlFile.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/psi/TomlFile.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/psi/impl/Psi.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/main/kotlin/org/toml/lang/psi/impl/Psi.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/test/kotlin/org/toml/ide/TomlAnnotatorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/test/kotlin/org/toml/ide/TomlAnnotatorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/test/kotlin/org/toml/lang/TomlParserTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/intellij-toml/src/test/kotlin/org/toml/lang/TomlParserTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/CargoConstants.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/CargoConstants.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/model/AttachCargoProjectAction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/model/AttachCargoProjectAction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/model/DetachCargoProjectAction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/model/DetachCargoProjectAction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcher.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcher.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructure.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructure.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructureTree.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructureTree.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoToolWindow.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoToolWindow.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/workspace/PackageOrigin.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/workspace/PackageOrigin.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/RsProjectTasksRunner.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/RsProjectTasksRunner.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/RsRunner.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/RsRunner.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfigurationType.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfigurationType.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/command/CargoExecutableRunConfigurationProducer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/command/CargoExecutableRunConfigurationProducer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandAction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandAction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandActionBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandActionBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/command/RunClippyAction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/command/RunClippyAction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/console/CargoConsoleBuilder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/console/CargoConsoleBuilder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/console/CargoConsoleView.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/console/CargoConsoleView.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/filters/RegexpFileLinkFilter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/filters/RegexpFileLinkFilter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/filters/RsConsoleFilter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/filters/RsConsoleFilter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/filters/RsExplainFilter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/filters/RsExplainFilter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/filters/RsPanicFilter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/filters/RsPanicFilter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/ui/RunCargoCommandDialog.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/runconfig/ui/RunCargoCommandDialog.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/BacktraceMode.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/BacktraceMode.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/ProxyHelper.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/ProxyHelper.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/RustChannel.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/RustChannel.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/RustcMessage.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/RustcMessage.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/util/CargoCommandCompletionProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/util/CargoCommandCompletionProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/util/CargoCommandLineEditor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/util/CargoCommandLineEditor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/RsConstants.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/RsConstants.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RsBuildAction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RsBuildAction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RsCreateFileAction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RsCreateFileAction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RsJoinLinesHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RsJoinLinesHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RsJoinRawLinesHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RsJoinRawLinesHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RsMoveLeftRightHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RsMoveLeftRightHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RustfmtFileAction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RustfmtFileAction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMover.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMover.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/mover/RsItemUpDownMover.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/mover/RsItemUpDownMover.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/mover/RsLineMover.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/mover/RsLineMover.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/mover/RsMatchArmUpDownMover.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/mover/RsMatchArmUpDownMover.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsExpressionAnnotator.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsExpressionAnnotator.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsLiteralAnnotator.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsLiteralAnnotator.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddAsTyFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddAsTyFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddModuleFileFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddModuleFileFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddSelfFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddSelfFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddUnsafeFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddUnsafeFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToSizedTypeFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToSizedTypeFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTraitFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTraitFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/SurroundWithUnsafeFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/SurroundWithUnsafeFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/colors/RsColorSettingsPage.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/colors/RsColorSettingsPage.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/colors/RsColors.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/colors/RsColors.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/commenter/RsCommenter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/commenter/RsCommenter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingOptionsProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingOptionsProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingSettings.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingSettings.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/folding/impl/RsCodeFoldingSettingsImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/folding/impl/RsCodeFoldingSettingsImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/RsAlignmentStrategy.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/RsAlignmentStrategy.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/RsFmtContext.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/RsFmtContext.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/RsFormattingModelBuilder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/RsFormattingModelBuilder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/Util.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/Util.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/blocks/RsFmtBlock.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/blocks/RsFmtBlock.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/blocks/RsMacroArgFmtBlock.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/blocks/RsMacroArgFmtBlock.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/blocks/RsMultilineStringLiteralBlock.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/blocks/RsMultilineStringLiteralBlock.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/blocks/SyntheticRsFmtBlock.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/blocks/SyntheticRsFmtBlock.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/alignment.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/alignment.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/indent.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/indent.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/utils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/utils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/processors/RsMatchArmCommaFormatProcessor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/processors/RsMatchArmCommaFormatProcessor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/processors/RsSingleImportRemoveBracesFormatProcessor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/processors/RsSingleImportRemoveBracesFormatProcessor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/processors/RsStatementSemicolonFormatProcessor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/processors/RsStatementSemicolonFormatProcessor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/processors/RsTrailingCommaFormatProcessor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/processors/RsTrailingCommaFormatProcessor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/processors/Util.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/processors/Util.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/settings/RsCodeStyleSettings.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/settings/RsCodeStyleSettings.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/settings/RsCodeStyleSettingsProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/settings/RsCodeStyleSettingsProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactory.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactory.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/highlight/RsHighlighter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/highlight/RsHighlighter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/highlight/RsHighlighterFactory.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/highlight/RsHighlighterFactory.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/highlight/RsRainbowVisitor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/highlight/RsRainbowVisitor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/hints/RsExpressionTypeProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/hints/RsExpressionTypeProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/hints/RsImplementationTextSelectioner.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/hints/RsImplementationTextSelectioner.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/hints/RsInlayParameterHintsProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/hints/RsInlayParameterHintsProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/hints/RsParameterInfoHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/hints/RsParameterInfoHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/idea/CargoConfigurationWizardStep.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/idea/CargoConfigurationWizardStep.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/idea/RsModuleBuilder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/idea/RsModuleBuilder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/idea/RsModuleType.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/idea/RsModuleType.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/idea/RsProjectStructureDetector.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/idea/RsProjectStructureDetector.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsApproxConstantInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsApproxConstantInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsCStringPointerInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsCStringPointerInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsDanglingElseInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsDanglingElseInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsDiagnosticBasedInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsDiagnosticBasedInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsDoubleNegInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsDoubleNegInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsDropRefInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsDropRefInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsInspectionSuppressor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsInspectionSuppressor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsLint.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsLint.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsLintLevel.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsLintLevel.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsMissingElseInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsMissingElseInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsTryMacroInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsTryMacroInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsVariableMutableInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsVariableMutableInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveMutableFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveMutableFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveRefFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveRefFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveTypeParameter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveTypeParameter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/fixes/RenameFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/fixes/RenameFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/fixes/SubstituteTextFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/fixes/SubstituteTextFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportHintFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportHintFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/ui.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/ui.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/AddCurlyBracesIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/AddCurlyBracesIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/AddDeriveIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/AddDeriveIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/AddElseIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/AddElseIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/AddImplIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/AddImplIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/DemorgansLawIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/DemorgansLawIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/FillMatchArmsIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/FillMatchArmsIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/IfLetToMatchIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/IfLetToMatchIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/MatchToIfLetIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/MatchToIfLetIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/MoveGuardToMatchArmIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/MoveGuardToMatchArmIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/MoveTypeConstraintToWhereClauseIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/MoveTypeConstraintToWhereClauseIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/RemoveParenthesesFromExprIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/RemoveParenthesesFromExprIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/RsElementBaseIntentionAction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/RsElementBaseIntentionAction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/SetImmutableIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/SetImmutableIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/SetMutableIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/SetMutableIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/ToggleIgnoreTestIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/ToggleIgnoreTestIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/UnElideLifetimesIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/UnElideLifetimesIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/UnwrapToTryIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/UnwrapToTryIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/WrapLambdaExprIntention.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/WrapLambdaExprIntention.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/CargoExecutableRunLineMarkerContributor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/CargoExecutableRunLineMarkerContributor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/RsCrateDocLineMarkerProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/RsCrateDocLineMarkerProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/RsRecursiveCallLineMarkerProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/RsRecursiveCallLineMarkerProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/miscExtensions/RsBreadcrumbsInfoProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/miscExtensions/RsBreadcrumbsInfoProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/miscExtensions/RsModTabTitleProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/miscExtensions/RsModTabTitleProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsClassNavigationContributor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsClassNavigationContributor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsGotoTargetRendererProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsGotoTargetRendererProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsImplsSearch.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsImplsSearch.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsNavigationContributorBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsNavigationContributorBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsSymbolNavigationContributor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsSymbolNavigationContributor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/newProject/ConfigurationData.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/newProject/ConfigurationData.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/newProject/RsProjectGeneratorPeer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/newProject/RsProjectGeneratorPeer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/newProject/RsProjectSettingsStep.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/newProject/RsProjectSettingsStep.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/notifications/Utils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/notifications/Utils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/PresentationInfo.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/PresentationInfo.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/RsDescriptionProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/RsDescriptionProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/Ty.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/Ty.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/Utils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/Utils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/projectView/RsTreeStructureProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/projectView/RsTreeStructureProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/search/RsFindUsagesProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/search/RsFindUsagesProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/search/RsUsageTypeProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/search/RsUsageTypeProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/search/RsWordScanner.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/search/RsWordScanner.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/settings/RsAutoImportOptions.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/settings/RsAutoImportOptions.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/settings/RsCodeInsightSettings.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/settings/RsCodeInsightSettings.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/spelling/RsSpellcheckingStrategy.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/spelling/RsSpellcheckingStrategy.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/spelling/StringLiteralTokenizer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/spelling/StringLiteralTokenizer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/structure/RsPsiStructureViewFactory.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/structure/RsPsiStructureViewFactory.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/structure/RsStructureViewModel.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/structure/RsStructureViewModel.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/expression/RsExpressionSurroundDescriptor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/expression/RsExpressionSurroundDescriptor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/expression/RsExpressionSurrounderBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/expression/RsExpressionSurrounderBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithIfExpSurrounder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithIfExpSurrounder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithNotSurrounder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithNotSurrounder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithParenthesesSurrounder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithParenthesesSurrounder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithWhileExpSurrounder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/expression/RsWithWhileExpSurrounder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsStatementsSurroundDescriptor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsStatementsSurroundDescriptor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsStatementsSurrounderBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsStatementsSurrounderBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsWithBlockSurrounder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsWithBlockSurrounder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsWithForSurrounder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsWithForSurrounder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsWithIfSurrounder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsWithIfSurrounder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsWithLoopSurrounder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsWithLoopSurrounder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsWithWhileSurrounder.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/statement/RsWithWhileSurrounder.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/utils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/surroundWith/utils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/RsContextType.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/RsContextType.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/RsLiveTemplatesProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/RsLiveTemplatesProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/macros/RsCollectionElementNameMacro.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/macros/RsCollectionElementNameMacro.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/macros/RsSuggestIndexNameMacro.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/macros/RsSuggestIndexNameMacro.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/postfix/surrounderBasedPostfixTemplates.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/postfix/surrounderBasedPostfixTemplates.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/postfix/utils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/postfix/utils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsAngleBraceHandlers.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsAngleBraceHandlers.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsBraceMatcher.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsBraceMatcher.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsDotTypedHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsDotTypedHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsEnableableBackspaceHandlerDelegate.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsEnableableBackspaceHandlerDelegate.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsEnterInLineCommentHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsEnterInLineCommentHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsEnterInStringLiteralHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsEnterInStringLiteralHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsQuoteHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsQuoteHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RustRawLiteralHashesBalancer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RustRawLiteralHashesBalancer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/assist/MethodCallFixer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/assist/MethodCallFixer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/assist/RsSmartEnterProcessor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/assist/RsSmartEnterProcessor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/assist/SemicolonFixer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/assist/SemicolonFixer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/utils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/utils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/ui/layout.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/ui/layout.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/update/UpdateComponent.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/update/UpdateComponent.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/CallInfo.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/CallInfo.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/SearchByOffset.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/SearchByOffset.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/wordSelection/RsListSelectionHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/wordSelection/RsListSelectionHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/RsFileType.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/RsFileType.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/RsFileTypeFactory.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/RsFileTypeFactory.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/RsLanguage.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/RsLanguage.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/ControlFlow.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/ControlFlow.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/AttributeCompletionProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/AttributeCompletionProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsMacroDefinitionCompletionProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsMacroDefinitionCompletionProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsPlatformPatterns.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/RsPlatformPatterns.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/LexerBaseEx.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/LexerBaseEx.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RsHighlightingLexer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RsHighlightingLexer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RsLexer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RsLexer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/utils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/utils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/macros/ExpansionResult.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/macros/ExpansionResult.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/macros/LazyStatic.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/macros/LazyStatic.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/LiteralOffsets.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/LiteralOffsets.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/PsiModificationUtils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/PsiModificationUtils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactory.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactory.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsCompositeElementType.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsCompositeElementType.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsLiteralKind.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsLiteralKind.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsTokenType.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/RsTokenType.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayExpr.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayExpr.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsAssocTypeBinding.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsAssocTypeBinding.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsBaseType.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsBaseType.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsBinaryOp.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsBinaryOp.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumVariant.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumVariant.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldDecl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldDecl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldLookp.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldLookp.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsGenericDeclaration.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsGenericDeclaration.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsIndexExpr.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsIndexExpr.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsInferenceContextOwner.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsInferenceContextOwner.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemElement.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemElement.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsLabel.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsLabel.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsLabelDecl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsLabelDecl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsLabeledExpression.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsLabeledExpression.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsLifetimeParameter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsLifetimeParameter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsLifetimeRef.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsLifetimeRef.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsLitExpr.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsLitExpr.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroBinding.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroBinding.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroDefinition.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroDefinition.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroReference.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroReference.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMatchArmGuard.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMatchArmGuard.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMethodCall.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMethodCall.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedElement.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedElement.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatBinding.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatBinding.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsPathReferenceElement.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsPathReferenceElement.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsRefLikeType.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsRefLikeType.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsReferenceElement.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsReferenceElement.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsSelfParameter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsSelfParameter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructItem.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructItem.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructLiteralField.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructLiteralField.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructOrEnumItemElement.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructOrEnumItemElement.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitOrImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitOrImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitRef.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitRef.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitType.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitType.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTupleFieldDecl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTupleFieldDecl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeDeclarationElement.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeDeclarationElement.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeElement.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeElement.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeParameter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeParameter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeReference.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeReference.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsUnsafetyOwner.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsUnsafetyOwner.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseGroup.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseGroup.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseItem.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseItem.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseSpeck.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseSpeck.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsValueParameter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsValueParameter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RustLifetimeParameterElement.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RustLifetimeParameterElement.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsLangItemIndex.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsLangItemIndex.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsAssocTypeBindingReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsAssocTypeBindingReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsBinaryOpReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsBinaryOpReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsExternCrateReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsExternCrateReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLabelReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLabelReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLifetimeReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLifetimeReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroCallReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroCallReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMetaItemReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMetaItemReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsModReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsModReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPatBindingReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPatBindingReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReference.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReference.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReference.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReference.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceCached.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceCached.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsStructExprFieldReferenceImpl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsStructExprFieldReferenceImpl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/RsElementStub.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/RsElementStub.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/RsPlaceholderStub.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/RsPlaceholderStub.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/RsStubElementType.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/RsStubElementType.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/StubInterfaces.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/StubInterfaces.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/index/RsGotoClassIndex.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/index/RsGotoClassIndex.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/index/RsModulesIndex.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/index/RsModulesIndex.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/index/RsNamedElementIndex.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/index/RsNamedElementIndex.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/index/RsReexportIndex.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/index/RsReexportIndex.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/Extensions.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/Extensions.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/RsPsiTypeImplUtil.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/RsPsiTypeImplUtil.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/TraitRef.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/TraitRef.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/TyFingerprint.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/TyFingerprint.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fold.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fold.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/ProjectionCache.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/ProjectionCache.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Snapshot.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Snapshot.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/SnapshotMap.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/SnapshotMap.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Unify.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Unify.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyAdt.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyAdt.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyAnon.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyAnon.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyInfer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyInfer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyProjection.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyProjection.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyUnknown.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/TyUnknown.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/doc/RsDocPipeline.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/doc/RsDocPipeline.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/doc/lexer/RsDocHighlightingLexer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/doc/lexer/RsDocHighlightingLexer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/doc/psi/RsDocKind.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/doc/psi/RsDocKind.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/doc/psi/RsDocTokenType.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/doc/psi/RsDocTokenType.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsConvertToNamedFieldsAction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsConvertToNamedFieldsAction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsDowngradeModuleToFile.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsDowngradeModuleToFile.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsImportOptimizer.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsImportOptimizer.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsNamesValidator.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsNamesValidator.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsPromoteModuleToDirectoryAction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsPromoteModuleToDirectoryAction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsRefactoringSupportProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsRefactoringSupportProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsRenameProcessor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/RsRenameProcessor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionConfig.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionConfig.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionHandlerAction.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionHandlerAction.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/ui.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/ui.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersFix.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersFix.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/impl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/impl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ui.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ui.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/introduceVariable/RsIntroduceVariableHandler.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/introduceVariable/RsIntroduceVariableHandler.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/introduceVariable/RsNameSuggestions.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/introduceVariable/RsNameSuggestions.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/introduceVariable/impl.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/introduceVariable/impl.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/introduceVariable/ui.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/introduceVariable/ui.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsBooleanExpUtils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsBooleanExpUtils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsEscapesUtils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsEscapesUtils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/AsyncTasks.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/AsyncTasks.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/ProjectCache.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/ProjectCache.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/Query.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/Query.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/Testmark.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/Testmark.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/psi.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/psi.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/ui.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/ui.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/utils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/openapiext/utils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/stdext/Collections.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/stdext/Collections.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/stdext/Concurrency.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/stdext/Concurrency.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/stdext/Profiling.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/stdext/Profiling.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/stdext/Utils.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/stdext/Utils.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/CargoTomlCompletionContributor.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/CargoTomlCompletionContributor.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/RsTomlCompletionProvider.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/RsTomlCompletionProvider.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/TomlSchema.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/TomlSchema.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/Util.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/Util.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/FileTree.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/FileTree.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/RustWithToolchainTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/RustWithToolchainTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/commands/CargoFmtTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/commands/CargoFmtTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/CargoProjectsServiceTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/CargoProjectsServiceTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherIntegrationTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherIntegrationTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/RunConfigurationTestCase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/RunConfigurationTestCase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/HighlightFilterTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/HighlightFilterTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsConsoleFilterTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsConsoleFilterTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsExplainFilterTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsExplainFilterTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsPanicFilterTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/filters/RsPanicFilterTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/test/CargoTestRunLineMarkerContributorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/runconfig/test/CargoTestRunLineMarkerContributorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/toolchain/CargoCommandLineTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/toolchain/CargoCommandLineTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsJoinLinesHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsJoinLinesHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsJoinLinesHandlerTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsJoinLinesHandlerTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsJoinRawLinesHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsJoinRawLinesHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsMoveLeftRightHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/RsMoveLeftRightHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMoverTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMoverTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsItemUpDownMoverTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsItemUpDownMoverTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsMatchArmUpDownMoverTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsMatchArmUpDownMoverTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsAnnotatorTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsAnnotatorTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsCrateDocLineMarkerProviderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsCrateDocLineMarkerProviderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsLiteralAnnotatorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsLiteralAnnotatorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsStdlibErrorAnnotatorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsStdlibErrorAnnotatorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddAsTyFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddAsTyFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddSelfTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddSelfTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToBorrowedTyFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToBorrowedTyFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToBorrowedTyWithMutFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToBorrowedTyWithMutFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToMutTyFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToMutTyFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToOwnedTyFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToOwnedTyFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToRefTyFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToRefTyFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToSizedTypeFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToSizedTypeFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStringFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStringFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromStrFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromStrFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTraitFixTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTraitFixTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsDocumentationProviderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsDocumentationProviderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsStdlibResolveLinkTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/docs/RsStdlibResolveLinkTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/folding/RsFoldingBuilderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/folding/RsFoldingBuilderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsAutoIndentTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsAutoIndentTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterLineBreaksTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterLineBreaksTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsFormatterTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsMatchArmCommaFormatProcessorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsMatchArmCommaFormatProcessorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsSingleImportRemoveBracesFormatProcessorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsSingleImportRemoveBracesFormatProcessorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsStatementSemicolonFormatProcessorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsStatementSemicolonFormatProcessorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsTrailingCommaFormatProcessorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/formatter/RsTrailingCommaFormatProcessorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/highlight/RsRainbowVisitorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/highlight/RsRainbowVisitorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsInlayParameterHintsProviderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsInlayParameterHintsProviderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsParameterInfoHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsParameterInfoHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsQuickDefinitionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/hints/RsQuickDefinitionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/NamingNotationsTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/NamingNotationsTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsApproxConstantInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsApproxConstantInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsCStringPointerInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsCStringPointerInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsDanglingElseInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsDanglingElseInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsDoubleNegInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsDoubleNegInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsDropRefInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsDropRefInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsExperimentalChecksInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsExperimentalChecksInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsInspectionSuppressorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsInspectionSuppressorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsLintLevelTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsLintLevelTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsMissingElseInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsMissingElseInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsNamingInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsNamingInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsTryMacroInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsTryMacroInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsTypeCheckInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsTypeCheckInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsVariableMutableInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsVariableMutableInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspectionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspectionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddCurlyBracesIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddCurlyBracesIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddDeriveIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddDeriveIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddElseIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddElseIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddImplIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/AddImplIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/DemorgansLawIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/DemorgansLawIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionStdTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionStdTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MatchToIfLetIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MatchToIfLetIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MoveGuardToMatchArmIntentionITest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MoveGuardToMatchArmIntentionITest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToWhereClauseIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToWhereClauseIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RemoveParenthesesFromExprIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RemoveParenthesesFromExprIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SetImmutableIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SetImmutableIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SetMutableIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SetMutableIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/ToggleIgnoreTestIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/ToggleIgnoreTestIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/UnwrapToTryIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/UnwrapToTryIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/WrapLambdaExprIntentionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/WrapLambdaExprIntentionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsLineMarkerProviderTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsLineMarkerProviderTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsRecursiveCallLineMarkerProviderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsRecursiveCallLineMarkerProviderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/miscExtensions/RsBreadcrumbsInfoProviderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/miscExtensions/RsBreadcrumbsInfoProviderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoTypeDeclarationTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoTypeDeclarationTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsConvertToNamedFieldsActionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsConvertToNamedFieldsActionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsDowngradeModuleToFileTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsDowngradeModuleToFileTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsPromoteModuleToDirectoryActionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/refactoring/RsPromoteModuleToDirectoryActionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/spellchecker/RsSpellCheckerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/spellchecker/RsSpellCheckerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/structure/RsStructureViewTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/structure/RsStructureViewTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/RsSurrounderTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/RsSurrounderTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/expression/RsWithIfExpSurrounderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/expression/RsWithIfExpSurrounderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/expression/RsWithNotSurrounderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/expression/RsWithNotSurrounderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/expression/RsWithParenthesesSurrounderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/expression/RsWithParenthesesSurrounderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/expression/RsWithWhileExpSurrounderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/expression/RsWithWhileExpSurrounderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/statement/RsWithBlockSurrounderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/statement/RsWithBlockSurrounderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/statement/RsWithForSurrounderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/statement/RsWithForSurrounderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/statement/RsWithIfSurrounderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/statement/RsWithIfSurrounderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/statement/RsWithLoopSurrounderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/statement/RsWithLoopSurrounderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/statement/RsWithWhileSurrounderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/surroundWith/statement/RsWithWhileSurrounderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/AssertPostfixTemplateTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/AssertPostfixTemplateTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/DebugAssertPostfixTemplateTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/DebugAssertPostfixTemplateTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/ElsePostfixTemplateTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/ElsePostfixTemplateTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/IfPostfixTemplateTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/IfPostfixTemplateTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/LambdaPostfixTemplateTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/LambdaPostfixTemplateTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/LetPostfixTemplateTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/LetPostfixTemplateTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplateTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplateTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/NotPostfixTemplateTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/NotPostfixTemplateTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/ParenPostfixTemplateTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/ParenPostfixTemplateTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/PostfixTemplateTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/PostfixTemplateTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/WhileNotPostfixTemplateTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/WhileNotPostfixTemplateTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/WhilePostfixTemplateTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/template/postfix/WhilePostfixTemplateTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsAngleBraceTypedHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsAngleBraceTypedHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsBraceMatcherTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsBraceMatcherTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsDotTypedHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsDotTypedHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsEnterInLineCommentHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsEnterInLineCommentHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsEnterInStringLiteralHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsEnterInStringLiteralHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsQuoteHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsQuoteHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsRawLiteralHashesBalancerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsRawLiteralHashesBalancerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsTypingTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/RsTypingTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/assist/RsSmartEnterProcessorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/typing/assist/RsSmartEnterProcessorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/wordSelection/RsListSelectionHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/wordSelection/RsListSelectionHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/wordSelection/RsSelectionHandlerTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/wordSelection/RsSelectionHandlerTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/RsTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/RsTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/RsTestCase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/RsTestCase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionPriorityTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionPriorityTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProviderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProviderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsExternCrateCompletionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsExternCrateCompletionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsModCompletionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsModCompletionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsPartialParseCompletionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsPartialParseCompletionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/lexer/RsEscapesLexingTestCase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/lexer/RsEscapesLexingTestCase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/lexer/RsHighlightingLexingTestCase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/lexer/RsHighlightingLexingTestCase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/lexer/RsLexingTestCase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/lexer/RsLexingTestCase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/lexer/RsLexingTestCaseBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/lexer/RsLexingTestCaseBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsErrorChainMacroExpansionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsErrorChainMacroExpansionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/parser/RsCompleteParsingTestCase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/parser/RsCompleteParsingTestCase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/parser/RsParsingTestCaseBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/parser/RsParsingTestCaseBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/parser/RsPartialParsingTestCase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/parser/RsPartialParsingTestCase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactoryTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactoryTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsLiteralOffsetsTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsLiteralOffsetsTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsNumericLiteralValueTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/psi/RsNumericLiteralValueTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsClosuresResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsClosuresResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsNamespaceResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsNamespaceResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsNonPhysicalFileResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsNonPhysicalFileResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsOperatorsResolve.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsOperatorsResolve.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/stubs/RsStubAccessTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/stubs/RsStubAccessTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsArithmeticOpsTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsArithmeticOpsTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsDivergingTypeInferenceTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsDivergingTypeInferenceTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsEnumPatternTypeInferenceTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsEnumPatternTypeInferenceTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsIndexTypeInferenceTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsIndexTypeInferenceTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsSnapshotMapTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsSnapshotMapTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsTypificationTestBase.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsTypificationTestBase.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsUnificationTableTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsUnificationTableTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/doc/RsDocRemoveDecorationTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/doc/RsDocRemoveDecorationTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsExtractFunctionTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsExtractFunctionTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsImportOptimizerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsImportOptimizerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsIntroduceVariableHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/RsIntroduceVariableHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/implementMembers/RsNameSuggestionsKtTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/refactoring/implementMembers/RsNameSuggestionsKtTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/utils/RsEscapesUtilsTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/utils/RsEscapesUtilsTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/stdext/AsyncValueTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/stdext/AsyncValueTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/toml/CargoTomlCompletionContributorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/toml/CargoTomlCompletionContributorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectServiceTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectServiceTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectStructureTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectStructureTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsCompilerSourcesPerformance.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsCompilerSourcesPerformance.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsHighlightingPerformanceTest.kt':[
-0,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsHighlightingPerformanceTest.kt": [
+0
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsTypingEmptyFileFuzzyTest.kt':[
-0,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/RsTypingEmptyFileFuzzyTest.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1479.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1479.json
@@ -1,8 +1,8 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/highlight/RsHighlighter.kt':[
-29,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/highlight/RsHighlighter.kt": [
+29
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt':[
-72,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt": [
+72
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1821.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1821.json
@@ -1,101 +1,101 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt':[
-203,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt": [
+203
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructureTree.kt':[
-49,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructureTree.kt": [
+49
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RsJoinRawLinesHandler.kt':[
-45,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/actions/RsJoinRawLinesHandler.kt": [
+45
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt": [
 98,
-399,
+399
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt':[
-91,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt": [
+91
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFix.kt':[
-148,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFix.kt": [
+148
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt": [
 78,
-304,
+304
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt": [
 471,
 480,
-491,
+491
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt':[
-38,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt": [
+38
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/PresentationInfo.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/PresentationInfo.kt": [
 60,
-69,
+69
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/Ty.kt':[
-71,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/Ty.kt": [
+71
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/search/RsUsageTypeProvider.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/search/RsUsageTypeProvider.kt": [
 23,
-52,
+52
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/structure/RsStructureViewModel.kt':[
-70,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/structure/RsStructureViewModel.kt": [
+70
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt": [
 38,
 43,
 49,
 137,
 143,
 165,
-186,
+186
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt": [
 59,
 67,
 76,
 122,
-135,
+135
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt':[
-46,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt": [
+46
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt": [
 314,
 315,
 322,
 323,
 330,
-334,
+334
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt':[
-38,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt": [
+38
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt':[
-43,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt": [
+43
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt':[
-94,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt": [
+94
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt": [
 221,
-345,
+345
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/TyFingerprint.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/TyFingerprint.kt": [
 34,
-39,
+39
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt": [
 33,
-48,
+48
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt':[
-189,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt": [
+189
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt": [
 256,
 270,
 290,
@@ -103,15 +103,15 @@
 460,
 740,
 811,
-1538,
+1538
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt':[
-111,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt": [
+111
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsEscapesUtils.kt':[
-80,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsEscapesUtils.kt": [
+80
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/RsTomlCompletionProvider.kt':[
-47,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/toml/RsTomlCompletionProvider.kt": [
+47
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1871.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S1871.json
@@ -1,12 +1,12 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt": [
 25,
-29,
+29
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt':[
-399,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt": [
+399
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt':[
-992,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt": [
+992
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S2068.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S2068.json
@@ -1,5 +1,5 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt':[
-41,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt": [
+41
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S3776.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S3776.json
@@ -1,73 +1,73 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt':[
-125,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt": [
+125
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt':[
-144,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt": [
+144
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt':[
-153,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt": [
+153
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt':[
-111,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt": [
+111
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt": [
 60,
-221,
+221
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/Ty.kt':[
-21,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/Ty.kt": [
+21
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsBraceMatcher.kt':[
-33,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/typing/RsBraceMatcher.kt": [
+33
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt':[
-93,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt": [
+93
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt':[
-90,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt": [
+90
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt':[
-58,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt": [
+58
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt": [
 20,
-22,
+22
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt':[
-240,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt": [
+240
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt": [
 33,
-48,
+48
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt": [
 193,
 421,
 494,
 502,
-568,
+568
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt':[
-16,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt": [
+16
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt':[
-171,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt": [
+171
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt": [
 305,
-1476,
+1476
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionConfig.kt':[
-147,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionConfig.kt": [
+147
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionHandlerAction.kt':[
-55,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionHandlerAction.kt": [
+55
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/impl.kt':[
-50,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/implementMembers/impl.kt": [
+50
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt':[
-52,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt": [
+52
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S3923.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S3923.json
@@ -1,5 +1,5 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt':[
-1400,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt": [
+1400
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S5612.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S5612.json
@@ -1,55 +1,55 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt": [
 134,
-148,
+148
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt':[
-154,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt": [
+154
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt':[
-60,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt": [
+60
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/Utils.kt':[
-26,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/presentation/Utils.kt": [
+26
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt':[
-57,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt": [
+57
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt':[
-89,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt": [
+89
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt':[
-58,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt": [
+58
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherIntegrationTest.kt':[
-18,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherIntegrationTest.kt": [
+18
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt':[
-100,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt": [
+100
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt':[
-39,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt": [
+39
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsOperatorsResolve.kt':[
-12,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/resolve/RsOperatorsResolve.kt": [
+12
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsArithmeticOpsTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/type/RsArithmeticOpsTest.kt": [
 58,
 82,
-112,
+112
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/stdext/AsyncValueTest.kt':[
-16,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/stdext/AsyncValueTest.kt": [
+16
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt": [
 56,
 96,
-240,
+240
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectServiceTest.kt':[
-17,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectServiceTest.kt": [
+17
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectStructureTest.kt':[
-57,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rustSlowTests/CargoProjectStructureTest.kt": [
+57
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S6510.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S6510.json
@@ -1,13 +1,13 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/DemorgansLawIntention.kt':[
-107,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/intentions/DemorgansLawIntention.kt": [
+107
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/macros/RsCollectionElementNameMacro.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/template/macros/RsCollectionElementNameMacro.kt": [
 40,
-50,
+50
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt':[
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/lexer/RustEscapesLexer.kt": [
 63,
-73,
-],
+73
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S6511.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S6511.json
@@ -1,5 +1,5 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt':[
-82,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt": [
+82
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S6517.json
+++ b/its/ruling/src/test/resources/expected/kotlin/intellij-rust/kotlin-S6517.json
@@ -1,20 +1,20 @@
 {
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt':[
-60,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt": [
+60
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt':[
-53,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt": [
+53
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/ui.kt':[
-53,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/ide/inspections/import/ui.kt": [
+53
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Snapshot.kt':[
-14,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/core/types/infer/Snapshot.kt": [
+14
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/ui.kt':[
-48,
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/main/kotlin/org/rust/lang/refactoring/extractFunction/ui.kt": [
+48
 ],
-'kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/RsTestCase.kt':[
-11,
-],
+"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/RsTestCase.kt": [
+11
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S103.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S103.json
@@ -1,11 +1,11 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt':[
-27,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt": [
+27
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt':[
-182,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt": [
+182
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt':[
-526,
-],
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt": [
+526
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S105.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S105.json
@@ -1,32 +1,32 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/Decompiler.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/Decompiler.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/FernflowerDecompiler.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/FernflowerDecompiler.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/util/LoggingMessageCollector.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/util/LoggingMessageCollector.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/AsyncExecutor.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/AsyncExecutor.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Debouncer.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Debouncer.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/DelegatePrintStream.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/DelegatePrintStream.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/KotlinLSException.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/KotlinLSException.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Utils.kt':[
-0,
-],
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Utils.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1066.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1066.json
@@ -1,8 +1,8 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt':[
-179,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt": [
+179
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt':[
-111,
-],
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt": [
+111
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1128.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1128.json
@@ -1,73 +1,73 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt": [
 3,
 12,
 16,
-17,
+17
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/SourceFiles.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/SourceFiles.kt": [
 4,
 10,
 20,
-22,
+22
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/AddMissingImportsQuickFix.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/AddMissingImportsQuickFix.kt": [
 7,
-12,
+12
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt": [
 16,
 19,
 25,
-27,
+27
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt": [
 8,
 9,
 10,
-22,
+22
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/diagnostic/ConvertDiagnostic.kt':[
-11,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/diagnostic/ConvertDiagnostic.kt": [
+11
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt": [
 4,
 5,
-10,
+10
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/references/FindReferences.kt':[
-7,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/references/FindReferences.kt": [
+7
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt": [
 23,
 27,
-31,
+31
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt": [
 5,
 7,
-22,
+22
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/Logger.kt':[
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/Logger.kt": [
 3,
 4,
-6,
+6
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt':[
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt": [
 4,
-8,
+8
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/BackupClassPathResolver.kt':[
-10,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/BackupClassPathResolver.kt": [
+10
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/AsyncExecutor.kt':[
-4,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/AsyncExecutor.kt": [
+4
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Debouncer.kt':[
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Debouncer.kt": [
 5,
-10,
+10
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/DelegatePrintStream.kt':[
-5,
-],
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/DelegatePrintStream.kt": [
+5
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1135.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1135.json
@@ -1,72 +1,72 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompiledFile.kt':[
-61,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompiledFile.kt": [
+61
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt':[
-41,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt": [
+41
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt':[
-147,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt": [
+147
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/SourcePath.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/SourcePath.kt": [
 54,
 72,
-252,
+252
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/AddMissingImportsQuickFix.kt':[
-50,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/AddMissingImportsQuickFix.kt": [
+50
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt':[
-143,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt": [
+143
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt": [
 134,
 137,
 412,
-444,
+444
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt": [
 94,
 124,
-144,
+144
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/JdkSourceArchiveProvider.kt':[
-16,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/JdkSourceArchiveProvider.kt": [
+16
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/imports/Imports.kt':[
-29,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/imports/Imports.kt": [
+29
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/Symbol.kt':[
-6,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/Symbol.kt": [
+6
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt':[
-177,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt": [
+177
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt": [
 111,
 300,
 350,
-505,
+505
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/references/FindReferences.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/references/FindReferences.kt": [
 94,
-158,
+158
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt':[
-119,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt": [
+119
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt": [
 43,
 84,
-115,
+115
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt':[
-10,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt": [
+10
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/BackupClassPathResolver.kt':[
-81,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/BackupClassPathResolver.kt": [
+81
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt':[
-7,
-],
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt": [
+7
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1144.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1144.json
@@ -1,5 +1,5 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt':[
-58,
-],
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt": [
+58
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1151.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1151.json
@@ -1,12 +1,12 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt':[
-280,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt": [
+280
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt": [
 133,
-162,
+162
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/StringUtils.kt':[
-20,
-],
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/StringUtils.kt": [
+20
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1186.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1186.json
@@ -1,16 +1,16 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt':[
-164,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt": [
+164
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/progress/Progress.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/progress/Progress.kt": [
 15,
-17,
+17
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/util/LoggingMessageCollector.kt':[
-9,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/util/LoggingMessageCollector.kt": [
+9
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/Logger.kt':[
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/Logger.kt": [
 28,
-30,
-],
+30
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1192.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1192.json
@@ -1,8 +1,8 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt':[
-107,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt": [
+107
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt':[
-465,
-],
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt": [
+465
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S125.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S125.json
@@ -1,5 +1,5 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompiledFile.kt':[
-93,
-],
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompiledFile.kt": [
+93
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S134.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S134.json
@@ -1,12 +1,12 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt':[
-150,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt": [
+150
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt':[
-76,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt": [
+76
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/StringUtils.kt':[
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/StringUtils.kt": [
 35,
-46,
-],
+46
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S138.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S138.json
@@ -1,5 +1,5 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt':[
-144,
-],
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt": [
+144
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1451.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1451.json
@@ -1,227 +1,227 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompiledFile.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompiledFile.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/Configuration.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/Configuration.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinProtocolExtensionService.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinProtocolExtensionService.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinProtocolExtensions.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinProtocolExtensions.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/Main.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/Main.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/SourceFiles.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/SourceFiles.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/SourcePath.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/SourcePath.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/URIContentProvider.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/URIContentProvider.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/CodeAction.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/CodeAction.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/AddMissingImportsQuickFix.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/AddMissingImportsQuickFix.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/QuickFix.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/QuickFix.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/command/Commands.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/command/Commands.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/RenderCompletionItem.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/RenderCompletionItem.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/diagnostic/ConvertDiagnostic.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/diagnostic/ConvertDiagnostic.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/docs/FindDoc.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/docs/FindDoc.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/ClassContentProvider.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/ClassContentProvider.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/ClassPathSourceArchiveProvider.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/ClassPathSourceArchiveProvider.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/Decompiler.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/Decompiler.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/FernflowerDecompiler.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/FernflowerDecompiler.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/JdkSourceArchiveProvider.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/JdkSourceArchiveProvider.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/KlsURI.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/KlsURI.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/SourceArchiveProvider.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/SourceArchiveProvider.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/formatting/Formatter.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/formatting/Formatter.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/hover/Hovers.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/hover/Hovers.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/imports/Imports.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/imports/Imports.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/ExtractSymbolExtensionReceiverType.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/ExtractSymbolExtensionReceiverType.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/ExtractSymbolKind.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/ExtractSymbolKind.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/ExtractSymbolVisibility.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/ExtractSymbolVisibility.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/Symbol.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/Symbol.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaTypeConverter.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaTypeConverter.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/PlatformTypeConverter.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/PlatformTypeConverter.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/position/Position.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/position/Position.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/progress/LanguageClientProgress.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/progress/LanguageClientProgress.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/progress/Progress.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/progress/Progress.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/references/FindReferences.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/references/FindReferences.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/rename/Rename.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/rename/Rename.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/resolve/ResolveMain.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/resolve/ResolveMain.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/symbols/Symbols.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/symbols/Symbols.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/util/LoggingMessageCollector.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/util/LoggingMessageCollector.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/util/PsiUtils.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/util/PsiUtils.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/util/TcpSockets.kt':[
-0,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/util/TcpSockets.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/Logger.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/Logger.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/BackupClassPathResolver.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/BackupClassPathResolver.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/ClassPathEntry.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/ClassPathEntry.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/ClassPathResolver.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/ClassPathResolver.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/DefaultClassPathResolver.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/DefaultClassPathResolver.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/GradleClassPathResolver.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/GradleClassPathResolver.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/ShellClassPathResolver.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/ShellClassPathResolver.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/WithStdlibResolver.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/WithStdlibResolver.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/AsyncExecutor.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/AsyncExecutor.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Debouncer.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Debouncer.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/DelegatePrintStream.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/DelegatePrintStream.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/ExitingInputStream.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/ExitingInputStream.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/KotlinLSException.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/KotlinLSException.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/ShellPathUtils.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/ShellPathUtils.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/StringUtils.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/StringUtils.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/TemporaryDirectory.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/TemporaryDirectory.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/URIs.kt':[
-0,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/URIs.kt": [
+0
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Utils.kt':[
-0,
-],
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Utils.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1821.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S1821.json
@@ -1,15 +1,15 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt':[
-108,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt": [
+108
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt": [
 135,
 138,
 144,
 163,
-194,
+194
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/StringUtils.kt':[
-47,
-],
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/StringUtils.kt": [
+47
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S3776.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S3776.json
@@ -1,17 +1,17 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt':[
-136,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt": [
+136
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt':[
-254,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt": [
+254
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt':[
-28,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt": [
+28
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt':[
-126,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt": [
+126
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/StringUtils.kt':[
-17,
-],
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/StringUtils.kt": [
+17
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S5612.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S5612.json
@@ -1,15 +1,15 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt':[
-69,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt": [
+69
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt':[
-89,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt": [
+89
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt": [
 94,
-139,
+139
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt':[
-50,
-],
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt": [
+50
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S5867.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S5867.json
@@ -1,5 +1,5 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt": [
 174,
 215,
 215,
@@ -10,16 +10,16 @@
 260,
 271,
 395,
-396,
+396
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/RenderCompletionItem.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/RenderCompletionItem.kt": [
 28,
-28,
+28
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt':[
-26,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt": [
+26
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/GradleClassPathResolver.kt':[
-105,
-],
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/GradleClassPathResolver.kt": [
+105
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S6510.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S6510.json
@@ -1,28 +1,28 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompiledFile.kt':[
-49,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompiledFile.kt": [
+49
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt':[
-132,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt": [
+132
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt':[
-490,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt": [
+490
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt": [
 284,
 395,
 467,
 499,
 515,
-530,
+530
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/references/FindReferences.kt':[
-192,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/references/FindReferences.kt": [
+192
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/GradleClassPathResolver.kt':[
-64,
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/classpath/GradleClassPathResolver.kt": [
+64
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Utils.kt':[
-38,
-],
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Utils.kt": [
+38
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S6517.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S6517.json
@@ -1,11 +1,11 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/QuickFix.kt':[
-13,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/QuickFix.kt": [
+13
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/SourceArchiveProvider.kt':[
-5,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/externalsources/SourceArchiveProvider.kt": [
+5
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/progress/Progress.kt':[
-20,
-],
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/progress/Progress.kt": [
+20
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S6518.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S6518.json
@@ -1,13 +1,13 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt':[
-553,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/completion/Completions.kt": [
+553
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/Logger.kt':[
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/Logger.kt": [
 150,
-151,
+151
 ],
-'kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Utils.kt':[
+"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/util/Utils.kt": [
 38,
-38,
-],
+38
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S6519.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S6519.json
@@ -1,5 +1,5 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/QuickFix.kt':[
-19,
-],
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/QuickFix.kt": [
+19
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S6529.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S6529.json
@@ -1,8 +1,8 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt':[
-133,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt": [
+133
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt':[
-38,
-],
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt": [
+38
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S6611.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S6611.json
@@ -1,6 +1,6 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/SourcePath.kt':[
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/SourcePath.kt": [
 137,
-196,
-],
+196
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S899.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin-language-server/kotlin-S899.json
@@ -1,8 +1,8 @@
 {
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt':[
-145,
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt": [
+145
 ],
-'kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt':[
-553,
-],
+"kotlin-kotlin-language-server-project:server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt": [
+553
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-ParsingError.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-ParsingError.json
@@ -1,14 +1,14 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/manyClasses/src/main/kotlin/classes.kt':[
-7,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/manyClasses/src/main/kotlin/classes.kt": [
+7
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/maven-archetypes/kotlin-archetype-js/src/main/resources/archetype-resources/src/main/kotlin/Hello.kt':[
-1,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/maven-archetypes/kotlin-archetype-js/src/main/resources/archetype-resources/src/main/kotlin/Hello.kt": [
+1
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/maven-archetypes/kotlin-archetype-jvm/src/main/resources/archetype-resources/src/main/kotlin/Hello.kt':[
-1,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/maven-archetypes/kotlin-archetype-jvm/src/main/resources/archetype-resources/src/main/kotlin/Hello.kt": [
+1
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/maven-archetypes/kotlin-archetype-jvm/src/main/resources/archetype-resources/src/test/kotlin/HelloTest.kt':[
-1,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/maven-archetypes/kotlin-archetype-jvm/src/main/resources/archetype-resources/src/test/kotlin/HelloTest.kt": [
+1
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S100.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S100.json
@@ -1,5 +1,5 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/tests/org/jetbrains/kotlin/container/tests/ComponentContainerTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/tests/org/jetbrains/kotlin/container/tests/ComponentContainerTest.kt": [
 26,
 34,
 40,
@@ -19,9 +19,9 @@
 294,
 325,
 336,
-354,
+354
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/CompilerCallbackServicesFacadeServer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/CompilerCallbackServicesFacadeServer.kt": [
 53,
 56,
 59,
@@ -33,9 +33,9 @@
 79,
 81,
 91,
-93,
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompilerCallbackServicesFacade.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompilerCallbackServicesFacade.kt": [
 47,
 50,
 53,
@@ -47,33 +47,33 @@
 73,
 76,
 79,
-84,
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationChecker.kt": [
 272,
-283,
+283
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt':[
-241,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt": [
+241
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionBindingContextProvider.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionBindingContextProvider.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionSession.kt':[
-223,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionSession.kt": [
+223
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleConfiguratorTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleConfiguratorTest.kt": [
 1039,
 1072,
 1105,
-1177,
+1177
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleFacetImportTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleFacetImportTest.kt": [
 206,
 376,
-991,
+991
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/tests/org/jetbrains/kotlin/idea/liveTemplates/LiveTemplatesTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/tests/org/jetbrains/kotlin/idea/liveTemplates/LiveTemplatesTest.kt": [
 35,
 39,
 43,
@@ -83,17 +83,17 @@
 63,
 190,
 198,
-206,
+206
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/editor/TemplateTokenSequenceTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/editor/TemplateTokenSequenceTest.kt": [
 29,
 33,
 37,
 41,
 46,
-51,
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/ArgumentNameHintsTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/ArgumentNameHintsTest.kt": [
 19,
 38,
 45,
@@ -110,37 +110,37 @@
 165,
 171,
 177,
-188,
+188
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/UpdateConfigurationQuickFixTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/UpdateConfigurationQuickFixTest.kt": [
 76,
 123,
-136,
+136
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/regex.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/regex.kt": [
 174,
-179,
+179
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/ListSpecificTest.kt':[
-15,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/ListSpecificTest.kt": [
+15
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/idl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/idl.kt": [
 181,
 308,
 375,
 411,
-540,
+540
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/AbstractKotlinAndroidGradleTests.kt':[
-392,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/AbstractKotlinAndroidGradleTests.kt": [
+392
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/parcel/ParcelBoxTest.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/parcel/ParcelBoxTest.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/tests/org/jetbrains/kotlin/sourceSections/SourceSectionsTest.kt':[
-151,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/tests/org/jetbrains/kotlin/sourceSections/SourceSectionsTest.kt": [
+151
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S101.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S101.json
@@ -1,31 +1,31 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/xml.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/xml.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrStatementOrigin.kt':[
-96,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrStatementOrigin.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/CallType.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/CallType.kt": [
 127,
 130,
 131,
-132,
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSteppingCommandProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSteppingCommandProvider.kt": [
 272,
 276,
 280,
-287,
+287
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/runtime/hacks.kt':[
-14,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/runtime/hacks.kt": [
+14
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/annotations.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/annotations.kt": [
 12,
 16,
 20,
 24,
 27,
-30,
-],
+30
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S103.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S103.json
@@ -1,77 +1,77 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ProtoCompareGenerated.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ProtoCompareGenerated.kt": [
 125,
 325,
 331,
-358,
+358
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/Bootstrap.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/Bootstrap.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/plugins/PublishedKotlinModule.kt':[
-96,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/plugins/PublishedKotlinModule.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/PropertyReferenceCodegen.kt':[
-248,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/PropertyReferenceCodegen.kt": [
+248
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt':[
-319,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt": [
+319
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/GenericCompilerState.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/GenericCompilerState.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt": [
 155,
 254,
 280,
 344,
-418,
+418
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt": [
 218,
-222,
+222
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/RemoteIncrementalCacheClient.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/RemoteIncrementalCacheClient.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/RemoteIncrementalCompilationComponentsClient.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/RemoteIncrementalCompilationComponentsClient.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/synthetic/JavaSyntheticPropertiesScope.kt':[
-199,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/synthetic/JavaSyntheticPropertiesScope.kt": [
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/BuildDiffsStorageTest.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/BuildDiffsStorageTest.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/LoweredFunction.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/LoweredFunction.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/InlineTestUtil.kt':[
-235,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/InlineTestUtil.kt": [
+235
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/test/testFramework/MockProjects.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/test/testFramework/MockProjects.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/cli/jvm/KotlinCliJavaFileManagerTest.kt':[
-140,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/cli/jvm/KotlinCliJavaFileManagerTest.kt": [
+140
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt": [
 319,
 624,
 817,
-865,
+865
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/native/kotlin/Any.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/native/kotlin/Any.kt": [
 30,
-40,
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/native/kotlin/Enum.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/native/kotlin/Enum.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererImpl.kt':[
-208,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererImpl.kt": [
+208
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/FunctionWithAllInvokes.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/FunctionWithAllInvokes.kt": [
 61,
 62,
 63,
@@ -82,76 +82,76 @@
 68,
 69,
 70,
-71,
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt':[
-254,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt": [
+254
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/IDEKotlinAsJavaSupport.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/IDEKotlinAsJavaSupport.kt": [
 246,
-251,
+251
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionUtils.kt':[
-221,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionUtils.kt": [
+221
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KotlinCompletionContributor.kt':[
-109,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KotlinCompletionContributor.kt": [
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindMemberUsagesHandler.kt':[
-90,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindMemberUsagesHandler.kt": [
+90
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinLanguageCodeStyleSettingsProvider.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinLanguageCodeStyleSettingsProvider.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinColorSettingsPage.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinColorSettingsPage.kt": [
 48,
 49,
 50,
 53,
 54,
 59,
-96,
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ConflictingExtensionPropertyInspection.kt':[
-219,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ConflictingExtensionPropertyInspection.kt": [
+219
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToConcatenatedStringIntention.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToConcatenatedStringIntention.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/SafeAccessToIfThenIntention.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/SafeAccessToIfThenIntention.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/AddToCollectionTransformation.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/AddToCollectionTransformation.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessings.kt':[
-88,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessings.kt": [
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeCallableReturnTypeFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeCallableReturnTypeFix.kt": [
 64,
-250,
+250
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/AbstractImportsTest.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/AbstractImportsTest.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/ResolveElementCacheTest.kt':[
-259,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/ResolveElementCacheTest.kt": [
+259
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/KotlinShortNamesCacheTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/KotlinShortNamesCacheTest.kt": [
 99,
-233,
+233
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/run/KotlinConsoleFilterTest.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/run/KotlinConsoleFilterTest.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/SpecialMethod.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/SpecialMethod.kt": [
 211,
-274,
+274
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/host/scriptHostUtil.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/host/scriptHostUtil.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Arrays.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Arrays.kt": [
 12987,
 13009,
 13034,
@@ -169,29 +169,29 @@
 13269,
 13281,
 13293,
-13305,
+13305
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt": [
 2189,
-2211,
+2211
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt": [
 1645,
-1669,
+1669
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.khronos.webgl.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.khronos.webgl.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.events.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.events.kt": [
 70,
 131,
 210,
 268,
 323,
 382,
-427,
+427
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt": [
 201,
 1493,
 1686,
@@ -207,77 +207,77 @@
 3589,
 3640,
 3716,
-3759,
+3759
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.fetch.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.fetch.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.notifications.kt':[
-114,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.notifications.kt": [
+114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.workers.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.workers.kt": [
 133,
 267,
-361,
+361
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.xhr.kt':[
-112,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.xhr.kt": [
+112
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/JvmClassMapping.kt':[
-90,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/JvmClassMapping.kt": [
+90
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/functions/Functions.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/functions/Functions.kt": [
 108,
 111,
 113,
 116,
 118,
 121,
-123,
+123
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/text/RegexJVMTest.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/text/RegexJVMTest.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/ExceptionTest.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/ExceptionTest.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/gen.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/gen.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/main.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/main.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/model.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/model.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/render.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/render.kt": [
 148,
 150,
 183,
-287,
+287
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/typeMappings.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/typeMappings.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Strings.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Strings.kt": [
 13,
-63,
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/AbstractAndroidExtensionsExpressionCodegenExtension.kt':[
-255,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/AbstractAndroidExtensionsExpressionCodegenExtension.kt": [
+255
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/ResourcePropertyStackValue.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/ResourcePropertyStackValue.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/src/org/jetbrains/kotlin/sourceSections/FilteredSectionsVirtualFile.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/src/org/jetbrains/kotlin/sourceSections/FilteredSectionsVirtualFile.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/tests/org/jetbrains/kotlin/sourceSections/SourceSectionsTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/tests/org/jetbrains/kotlin/sourceSections/SourceSectionsTest.kt": [
 170,
 180,
-211,
+211
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/AbstractKotlinRenderLogTest.kt':[
-85,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/AbstractKotlinRenderLogTest.kt": [
+85
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S104.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S104.json
@@ -1,56 +1,56 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ProtoCompareGenerated.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ProtoCompareGenerated.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleConfiguratorTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleConfiguratorTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleFacetImportTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleFacetImportTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/test/org/jetbrains/kotlin/idea/maven/KotlinMavenImporterTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/test/org/jetbrains/kotlin/idea/maven/KotlinMavenImporterTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/smartEnter/SmartEnterTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/smartEnter/SmartEnterTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Arrays.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Arrays.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Strings.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Strings.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.khronos.webgl.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.khronos.webgl.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/generated/_ArraysJvm.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/generated/_ArraysJvm.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/util/MathJVM.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/util/MathJVM.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/Strings.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/Strings.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/ArraysTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/ArraysTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/text/StringTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/text/StringTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt':[
-0,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S105.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S105.json
@@ -1,11 +1,11 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/editor/TypedHandlerTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/editor/TypedHandlerTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/default/jvmOverloads.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/default/jvmOverloads.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithTests/src/test/kotlin/MainTest.kt':[
-0,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithTests/src/test/kotlin/MainTest.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1066.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1066.json
@@ -1,5 +1,5 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ProtoCompareGenerated.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ProtoCompareGenerated.kt": [
 49,
 54,
 59,
@@ -123,524 +123,524 @@
 1099,
 1104,
 1109,
-1114,
+1114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/test/org/jetbrains/kotlin/incremental/testingUtils/classFilesComparison.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/test/org/jetbrains/kotlin/incremental/testingUtils/classFilesComparison.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/kotlinPluginArtifact.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/kotlinPluginArtifact.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend-common/src/org/jetbrains/kotlin/backend/common/CodegenUtil.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend-common/src/org/jetbrains/kotlin/backend/common/CodegenUtil.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/MultifileClassCodegen.kt':[
-263,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/MultifileClassCodegen.kt": [
+263
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/builtinSpecialBridges.kt':[
-100,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/builtinSpecialBridges.kt": [
+100
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt':[
-267,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt": [
+267
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CliTrace.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CliTrace.kt": [
 74,
 75,
-76,
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/index/JvmDependenciesIndexImpl.kt':[
-212,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/index/JvmDependenciesIndexImpl.kt": [
+212
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JavaTypeAccessibilityChecker.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JavaTypeAccessibilityChecker.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/declarationCheckers.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/declarationCheckers.kt": [
 58,
-141,
+141
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ConstructorConsistencyChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ConstructorConsistencyChecker.kt": [
 149,
-160,
+160
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt": [
 449,
 776,
-782,
+782
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt':[
-1247,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt": [
+1247
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/PseudocodeVariablesData.kt':[
-250,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/PseudocodeVariablesData.kt": [
+250
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/PseudocodeImpl.kt':[
-163,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/PseudocodeImpl.kt": [
+163
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/PositioningStrategies.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/PositioningStrategies.kt": [
 37,
 536,
-549,
+549
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt": [
 608,
-898,
+898
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/FunctionDescriptorResolver.kt':[
-397,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/FunctionDescriptorResolver.kt": [
+397
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/ModifiersChecker.kt':[
-284,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/ModifiersChecker.kt": [
+284
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/QualifiedExpressionResolver.kt':[
-411,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/QualifiedExpressionResolver.kt": [
+411
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt": [
 285,
 296,
-315,
+315
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/CapturingInClosureChecker.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/CapturingInClosureChecker.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/InlineChecker.kt':[
-279,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/InlineChecker.kt": [
+279
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/OperatorCallChecker.kt':[
-73,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/OperatorCallChecker.kt": [
+73
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/TypeBoundsImpl.kt':[
-95,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/TypeBoundsImpl.kt": [
+95
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewResolutionOldInference.kt':[
-206,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewResolutionOldInference.kt": [
+206
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/util/callUtil.kt':[
-240,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/util/callUtil.kt": [
+240
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/ExperimentalUsageChecker.kt':[
-247,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/ExperimentalUsageChecker.kt": [
+247
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt':[
-463,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt": [
+463
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/deprecationUtil.kt':[
-286,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/deprecationUtil.kt": [
+286
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/diagnostics/KotlinSuppressCache.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/diagnostics/KotlinSuppressCache.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyImportScope.kt':[
-114,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyImportScope.kt": [
+114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/sinceKotlinUtil.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/sinceKotlinUtil.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/storage/ExceptionTracker.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/storage/ExceptionTracker.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt": [
 149,
-556,
+556
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/FunctionsTypingVisitor.kt':[
-215,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/FunctionsTypingVisitor.kt": [
+215
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/LabelResolver.kt':[
-155,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/LabelResolver.kt": [
+155
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/PatternMatchingTypingVisitor.kt':[
-258,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/PatternMatchingTypingVisitor.kt": [
+258
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/util/slicedMap/OpenAddressLinearProbingHashTable.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/util/slicedMap/OpenAddressLinearProbingHashTable.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/SecondaryCtorLowering.kt':[
-204,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/SecondaryCtorLowering.kt": [
+204
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt": [
 247,
-257,
+257
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassBase.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassBase.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForSourceDeclaration.kt':[
-402,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForSourceDeclaration.kt": [
+402
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtCodeFragment.kt':[
-142,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtCodeFragment.kt": [
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ResolutionParts.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ResolutionParts.kt": [
 33,
-360,
+360
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/SimpleArgumentsChecks.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/SimpleArgumentsChecks.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/KotlinConstraintSystemCompleter.kt':[
-81,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/KotlinConstraintSystemCompleter.kt": [
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/FlatSignature.kt':[
-144,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/FlatSignature.kt": [
+144
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/types/TypeApproximator.kt':[
-249,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/types/TypeApproximator.kt": [
+249
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/renderer/AbstractDescriptorRendererTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/renderer/AbstractDescriptorRendererTest.kt": [
 120,
-122,
+122
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/util/KotlinVersionsTest.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/util/KotlinVersionsTest.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/types/JavaTypeResolver.kt':[
-160,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/types/JavaTypeResolver.kt": [
+160
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererImpl.kt':[
-480,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererImpl.kt": [
+480
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/DescriptorUtils.kt':[
-423,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/DescriptorUtils.kt": [
+423
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt':[
-90,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt": [
+90
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt": [
 208,
-608,
+608
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/NodeIndentStrategy.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/NodeIndentStrategy.kt": [
 108,
-123,
+123
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/navigation/SourceNavigationHelper.kt':[
-138,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/navigation/SourceNavigationHelper.kt": [
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/textBuilder/buildDecompiledText.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/textBuilder/buildDecompiledText.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinChangeLocalityDetector.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinChangeLocalityDetector.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/VariablesHighlightingVisitor.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/VariablesHighlightingVisitor.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt": [
 425,
-488,
+488
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/KtSimpleNameReference.kt':[
-125,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/KtSimpleNameReference.kt": [
+125
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/declarationsSearch/overridersSearch.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/declarationsSearch/overridersSearch.kt": [
 141,
-169,
+169
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinReferencesSearcher.kt':[
-116,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinReferencesSearcher.kt": [
+116
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/utils.kt": [
 187,
-195,
+195
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionSession.kt':[
-170,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionSession.kt": [
+170
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/InsertHandlerProvider.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/InsertHandlerProvider.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinClassifierInsertHandler.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinClassifierInsertHandler.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinFunctionInsertHandler.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinFunctionInsertHandler.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt':[
-376,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt": [
+376
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/KotlinExtraSteppingFilter.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/KotlinExtraSteppingFilter.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinFrameExtraVariablesProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinFrameExtraVariablesProvider.kt": [
 143,
-168,
+168
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinEvaluationBuilder.kt':[
-359,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinEvaluationBuilder.kt": [
+359
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/classLoading/ClassLoadingAdapter.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/classLoading/ClassLoadingAdapter.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/render/KotlinClassWithDelegatedPropertyRenderer.kt':[
-79,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/render/KotlinClassWithDelegatedPropertyRenderer.kt": [
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/RequestHintWithMethodFilter.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/RequestHintWithMethodFilter.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/injection/KotlinLanguageInjectionSupport.kt':[
-216,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/injection/KotlinLanguageInjectionSupport.kt": [
+216
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/inspections/api/IncompatibleAPIJavaVisitor.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/inspections/api/IncompatibleAPIJavaVisitor.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/quickfix/ChangeCoroutineSupportFix.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/quickfix/ChangeCoroutineSupportFix.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/quickfix/EnableUnsupportedFeatureFix.kt':[
-127,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/quickfix/EnableUnsupportedFeatureFix.kt": [
+127
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/actions/MavenPluginSourcesSwap.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/actions/MavenPluginSourcesSwap.kt": [
 142,
-147,
+147
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinFoldingBuilder.kt':[
-199,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinFoldingBuilder.kt": [
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinPluginUpdater.kt':[
-111,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinPluginUpdater.kt": [
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/SearchNotPropertyCandidatesAction.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/SearchNotPropertyCandidatesAction.kt": [
 126,
-147,
+147
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt':[
-265,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt": [
+265
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/UsageReplacementStrategy.kt':[
-189,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/UsageReplacementStrategy.kt": [
+189
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt':[
-147,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt": [
+147
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinCopyPasteReferenceProcessor.kt':[
-269,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinCopyPasteReferenceProcessor.kt": [
+269
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/postfix/KtPostfixTemplateProvider.kt':[
-146,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/postfix/KtPostfixTemplateProvider.kt": [
+146
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/ConvertJavaCopyPasteProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/ConvertJavaCopyPasteProcessor.kt": [
 133,
-138,
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt':[
-246,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt": [
+246
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinRawStringBackspaceHandler.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinRawStringBackspaceHandler.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/fixers/KotlinFunctionDeclarationBodyFixer.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/fixers/KotlinFunctionDeclarationBodyFixer.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/fixers/KotlinMissingIfBranchFixer.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/fixers/KotlinMissingIfBranchFixer.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/fixers/KotlinPropertySetterBodyFixer.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/fixers/KotlinPropertySetterBodyFixer.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindClassUsagesHandler.kt':[
-94,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindClassUsagesHandler.kt": [
+94
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/hierarchy/calls/KotlinCallerTreeStructure.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/hierarchy/calls/KotlinCallerTreeStructure.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/markers/KotlinLineMarkerProvider.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/markers/KotlinLineMarkerProvider.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/imports/KotlinImportOptimizer.kt':[
-141,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/imports/KotlinImportOptimizer.kt": [
+141
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeParameterInspection.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeParameterInspection.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeValInspection.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeValInspection.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSamConstructorInspection.kt':[
-183,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSamConstructorInspection.kt": [
+183
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSemicolonInspection.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSemicolonInspection.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SimplifyAssertNotNullInspection.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SimplifyAssertNotNullInspection.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt':[
-272,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt": [
+272
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UseExpressionBodyInspection.kt':[
-184,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UseExpressionBodyInspection.kt": [
+184
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/SimplifiableCallChainInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/SimplifiableCallChainInspection.kt": [
 25,
-30,
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/UselessCallOnCollectionInspection.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/UselessCallOnCollectionInspection.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/kdoc/KDocMissingDocumentationInspection.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/kdoc/KDocMissingDocumentationInspection.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTwoComparisonsToRangeCheckIntention.kt':[
-159,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTwoComparisonsToRangeCheckIntention.kt": [
+159
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/InvertIfConditionIntention.kt':[
-144,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/InvertIfConditionIntention.kt": [
+144
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt": [
 284,
-291,
+291
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessings.kt':[
-364,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessings.kt": [
+364
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/projectView/KtClassOrObjectTreeNode.kt':[
-100,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/projectView/KtClassOrObjectTreeNode.kt": [
+100
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ImportFix.kt':[
-252,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ImportFix.kt": [
+252
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt':[
-211,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt": [
+211
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/SuperClassNotInitialized.kt':[
-127,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/SuperClassNotInitialized.kt": [
+127
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
-1101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
+1101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/ui/KotlinChangeSignatureDialog.kt':[
-334,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/ui/KotlinChangeSignatureDialog.kt": [
+334
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/duplicateUtil.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/duplicateUtil.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt": [
 264,
-269,
+269
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveUtils.kt": [
 149,
-160,
+160
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt':[
-248,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt": [
+248
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/pullUpConflictsUtils.kt':[
-200,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/pullUpConflictsUtils.kt": [
+200
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/pushDownImpl.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/pushDownImpl.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/inspections/InspectionDescriptionTest.kt':[
-142,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/inspections/InspectionDescriptionTest.kt": [
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/AbstractNameSuggestionProviderTest.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/AbstractNameSuggestionProviderTest.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt':[
-130,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt": [
+130
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt": [
 500,
-681,
+681
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt": [
 138,
 156,
-594,
+594
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt':[
-353,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt": [
+353
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/propertyDetection.kt':[
-199,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/propertyDetection.kt": [
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/platforms/KotlinJvmModuleBuildTarget.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/platforms/KotlinJvmModuleBuildTarget.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt':[
-406,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt": [
+406
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsBuiltinNameClashChecker.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsBuiltinNameClashChecker.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsExternalChecker.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsExternalChecker.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsNameClashChecker.kt':[
-161,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsNameClashChecker.kt": [
+161
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutineTransformer.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutineTransformer.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/DoWhileGuardElimination.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/DoWhileGuardElimination.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/EmptyStatementElimination.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/EmptyStatementElimination.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt':[
-464,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt": [
+464
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/ClassModelGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/ClassModelGenerator.kt": [
 57,
-266,
+266
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/DeclarationBodyVisitor.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/DeclarationBodyVisitor.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt':[
-300,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt": [
+300
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/util/AssertionsJVM.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/util/AssertionsJVM.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/Files.kt':[
-466,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/Files.kt": [
+466
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/Kapt3KotlinGradleSubplugin.kt':[
-386,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/Kapt3KotlinGradleSubplugin.kt": [
+386
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt':[
-247,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt": [
+247
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableAnnotationChecker.kt':[
-97,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableAnnotationChecker.kt": [
+97
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableCodegenExtension.kt':[
-196,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableCodegenExtension.kt": [
+196
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/AndroidLayoutXmlFileManager.kt':[
-122,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/AndroidLayoutXmlFileManager.kt": [
+122
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/parcel/quickfixes/ParcelMigrateToParcelizeQuickFix.kt':[
-273,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/parcel/quickfixes/ParcelMigrateToParcelizeQuickFix.kt": [
+273
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/AndroidPsiTreeChangePreprocessor.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/AndroidPsiTreeChangePreprocessor.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/javac/KaptJavaLog.kt':[
-92,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/javac/KaptJavaLog.kt": [
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt':[
-750,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt": [
+750
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1067.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1067.json
@@ -1,465 +1,465 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend-common/src/org/jetbrains/kotlin/backend/common/CodegenUtil.kt':[
-144,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend-common/src/org/jetbrains/kotlin/backend/common/CodegenUtil.kt": [
+144
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/MultifileClassPartCodegen.kt':[
-192,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/MultifileClassPartCodegen.kt": [
+192
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/RangeCodegenUtil.kt':[
-205,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/RangeCodegenUtil.kt": [
+205
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt':[
-394,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt": [
+394
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt':[
-155,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt": [
+155
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInlinerUtil.kt':[
-123,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInlinerUtil.kt": [
+123
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/TransformationInfo.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/TransformationInfo.kt": [
 97,
-98,
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt':[
-547,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt": [
+547
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingMethodTransformer.kt':[
-434,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingMethodTransformer.kt": [
+434
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt": [
 118,
-129,
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/fixStack/FixStackContext.kt':[
-94,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/fixStack/FixStackContext.kt": [
+94
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/AbstractForInProgressionOrRangeLoopGenerator.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/AbstractForInProgressionOrRangeLoopGenerator.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt':[
-293,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt": [
+293
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/classFiles/ClassifierResolutionContext.kt':[
-97,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/classFiles/ClassifierResolutionContext.kt": [
+97
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt": [
 236,
 437,
 517,
-674,
+674
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt": [
 701,
 771,
-776,
+776
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/GenericCandidateResolver.kt':[
-406,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/GenericCandidateResolver.kt": [
+406
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/AbstractReflectionApiCallChecker.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/AbstractReflectionApiCallChecker.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/LambdaWithSuspendModifierCallChecker.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/LambdaWithSuspendModifierCallChecker.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/InlineClassDeclarationChecker.kt':[
-78,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/InlineClassDeclarationChecker.kt": [
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/duplicateJvmSignatureUtil.kt':[
-124,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/duplicateJvmSignatureUtil.kt": [
+124
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/KtLightMethodImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/KtLightMethodImpl.kt": [
 150,
-151,
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/lightClassUtils.kt':[
-155,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/lightClassUtils.kt": [
+155
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtFile.kt':[
-195,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtFile.kt": [
+195
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ResolutionParts.kt':[
-229,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ResolutionParts.kt": [
+229
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/util/isFromStdlibJre7Or8.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/util/isFromStdlibJre7Or8.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt':[
-370,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt": [
+370
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/CompilerTestLanguageVersionSettings.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/CompilerTestLanguageVersionSettings.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/LazyOperationsLog.kt':[
-128,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/LazyOperationsLog.kt": [
+128
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/jvm/compiler/CompileKotlinAgainstCustomBinariesTest.kt':[
-460,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/jvm/compiler/CompileKotlinAgainstCustomBinariesTest.kt": [
+460
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/util/KotlinVersionsTest.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/util/KotlinVersionsTest.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/src/kotlin/Progressions.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/src/kotlin/Progressions.kt": [
 47,
 47,
 101,
 101,
 155,
-155,
+155
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/src/kotlin/Ranges.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/src/kotlin/Ranges.kt": [
 22,
 48,
-74,
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/JvmBuiltInsSettings.kt':[
-294,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/JvmBuiltInsSettings.kt": [
+294
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/ReflectionTypes.kt':[
-164,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/ReflectionTypes.kt": [
+164
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/constants/constantValues.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/constants/constantValues.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewKotlinTypeChecker.kt':[
-482,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewKotlinTypeChecker.kt": [
+482
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata/src/org/jetbrains/kotlin/metadata/deserialization/BinaryVersion.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata/src/org/jetbrains/kotlin/metadata/deserialization/BinaryVersion.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/members.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/members.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt':[
-185,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt": [
+185
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinSpacingBuilder.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinSpacingBuilder.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/psi/patternMatching/KotlinPsiUnifier.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/psi/patternMatching/KotlinPsiUnifier.kt": [
 528,
-529,
+529
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/IDELightClassContexts.kt':[
-206,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/IDELightClassContexts.kt": [
+206
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/IdeaModuleInfos.kt':[
-97,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/IdeaModuleInfos.kt": [
+97
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/referenceUtil.kt':[
-185,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/referenceUtil.kt": [
+185
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/idea-android-output-parser/src/org/jetbrains/kotlin/android/KotlinOutputParserHelper.kt':[
-109,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/idea-android-output-parser/src/org/jetbrains/kotlin/android/KotlinOutputParserHelper.kt": [
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/ParcelableUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/ParcelableUtil.kt": [
 69,
-232,
+232
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/folding/ResourceFoldingBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/folding/ResourceFoldingBuilder.kt": [
 74,
-117,
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/intention/AbstractRegisterComponentAction.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/intention/AbstractRegisterComponentAction.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/quickfix/AddTargetApiQuickFix.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/quickfix/AddTargetApiQuickFix.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/quickfix/AddTargetVersionCheckQuickFix.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/quickfix/AddTargetVersionCheckQuickFix.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt':[
-408,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt": [
+408
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt':[
-285,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt": [
+285
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/src/org/jetbrains/kotlin/idea/liveTemplates/macro/AnonymousSuperMacro.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/src/org/jetbrains/kotlin/idea/liveTemplates/macro/AnonymousSuperMacro.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/PomFile.kt':[
-659,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/PomFile.kt": [
+659
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/inspections/KotlinMavenPluginPhaseInspection.kt':[
-109,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/inspections/KotlinMavenPluginPhaseInspection.kt": [
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinFoldingBuilder.kt':[
-107,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinFoldingBuilder.kt": [
+107
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinPairMatcher.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinPairMatcher.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateEqualsAndHashcodeAction.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateEqualsAndHashcodeAction.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateSecondaryConstructorAction.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateSecondaryConstructorAction.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/SearchNotPropertyCandidatesAction.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/SearchNotPropertyCandidatesAction.kt": [
 86,
-87,
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt':[
-78,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt": [
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinQuoteHandler.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinQuoteHandler.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesHandlerFactory.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesHandlerFactory.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindClassUsagesHandler.kt':[
-174,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindClassUsagesHandler.kt": [
+174
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/hierarchy/calls/callHierarchyUtils.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/hierarchy/calls/callHierarchyUtils.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRainbowVisitor.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRainbowVisitor.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/markers/OverridenPropertyMarker.kt':[
-129,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/markers/OverridenPropertyMarker.kt": [
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MayBeConstantInspection.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MayBeConstantInspection.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/PublicApiImplicitTypeInspection.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/PublicApiImplicitTypeInspection.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceWithOperatorAssignmentInspection.kt':[
-96,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceWithOperatorAssignmentInspection.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt": [
 219,
-355,
+355
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/AddAccessorIntentions.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/AddAccessorIntentions.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionTypeParameterToReceiverIntention.kt':[
-241,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionTypeParameterToReceiverIntention.kt": [
+241
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt':[
-117,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt": [
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt':[
-195,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt": [
+195
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/JoinDeclarationAndAssignmentIntention.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/JoinDeclarationAndAssignmentIntention.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MovePropertyToClassBodyIntention.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MovePropertyToClassBodyIntention.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MovePropertyToConstructorIntention.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MovePropertyToConstructorIntention.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SimplifyBooleanWithConstantsIntention.kt':[
-110,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SimplifyBooleanWithConstantsIntention.kt": [
+110
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinInlayParameterHintsProvider.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinInlayParameterHintsProvider.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddConstModifierFix.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddConstModifierFix.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt':[
-122,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt": [
+122
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixActionBase.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixActionBase.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt':[
-248,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt": [
+248
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ReplaceObsoleteLabelSyntaxFix.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ReplaceObsoleteLabelSyntaxFix.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/TypeOfAnnotationMemberFix.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/TypeOfAnnotationMemberFix.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
 478,
-981,
+981
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableFromUsageFix.kt':[
-167,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableFromUsageFix.kt": [
+167
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createTypeParameter/CreateTypeParameterByUnresolvedRefActionFactory.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createTypeParameter/CreateTypeParameterByUnresolvedRefActionFactory.kt": [
 108,
-108,
+108
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createVariable/CreateParameterByRefActionFactory.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createVariable/CreateParameterByRefActionFactory.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/migration/MigrateExternalExtensionFix.kt':[
-212,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/migration/MigrateExternalExtensionFix.kt": [
+212
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/AbstractPullPushMembersHandler.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/AbstractPullPushMembersHandler.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureHandler.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureHandler.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt": [
 282,
-288,
+288
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/changeSignatureUtils.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/changeSignatureUtils.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt": [
 353,
-417,
+417
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementSelectionUtils.kt':[
-99,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementSelectionUtils.kt": [
+99
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractClass/ui/KotlinExtractInterfaceDialog.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractClass/ui/KotlinExtractInterfaceDialog.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/ExtractableCodeDescriptor.kt':[
-412,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/ExtractableCodeDescriptor.kt": [
+412
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt':[
-211,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt": [
+211
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinIntroduceParameterHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinIntroduceParameterHandler.kt": [
 198,
 198,
-300,
+300
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt':[
-188,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt": [
+188
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/memberInfo/KotlinClassMembersRefactoringSupport.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/memberInfo/KotlinClassMembersRefactoringSupport.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/memberInfo/KotlinMemberInfoStorage.kt':[
-95,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/memberInfo/KotlinMemberInfoStorage.kt": [
+95
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsHandler.kt": [
 177,
-192,
+192
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveUtils.kt':[
-161,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveUtils.kt": [
+161
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpDialog.kt':[
-100,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpDialog.kt": [
+100
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/pullUpUtils.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/pullUpUtils.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/KotlinMemberInplaceRenameHandler.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/KotlinMemberInplaceRenameHandler.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinPropertyProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinPropertyProcessor.kt": [
 102,
-311,
+311
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinPsiProcessor.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinPsiProcessor.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/utils.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/utils.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/KotlinSliceProvider.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/KotlinSliceProvider.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/KotlinSliceUsageCellRenderer.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/KotlinSliceUsageCellRenderer.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/actions/AbstractNavigationTest.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/actions/AbstractNavigationTest.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/IdeaModuleInfoTest.kt':[
-409,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/IdeaModuleInfoTest.kt": [
+409
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ClassBodyConverter.kt':[
-136,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ClassBodyConverter.kt": [
+136
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt':[
-452,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt": [
+452
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt':[
-602,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt": [
+602
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/KotlinBuilder.kt':[
-88,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/KotlinBuilder.kt": [
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Context.kt':[
-113,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Context.kt": [
+113
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsNameClashChecker.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsNameClashChecker.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/nativeAnnotationCheckers.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/nativeAnnotationCheckers.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/context/UsageTracker.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/context/UsageTracker.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/ranges/RangesJVM.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/ranges/RangesJVM.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/ranges/Ranges.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/ranges/Ranges.kt": [
 40,
-71,
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/util/KotlinVersion.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/util/KotlinVersion.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/unsigned/src/kotlin/UIntRange.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/unsigned/src/kotlin/UIntRange.kt": [
 26,
 74,
-74,
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/unsigned/src/kotlin/ULongRange.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/unsigned/src/kotlin/ULongRange.kt": [
 26,
 74,
-74,
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/main/kotlin/org.jetbrains.kotlin.tools/kotlinVisibilities.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/main/kotlin/org.jetbrains.kotlin.tools/kotlinVisibilities.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableCodegenExtension.kt':[
-352,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableCodegenExtension.kt": [
+352
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableResolveExtension.kt':[
-95,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableResolveExtension.kt": [
+95
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt": [
 100,
 132,
-160,
+160
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/AbstractAndroidExtensionsExpressionCodegenExtension.kt':[
-167,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/AbstractAndroidExtensionsExpressionCodegenExtension.kt": [
+167
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/parcel/quickfixes/ParcelMigrateToParcelizeQuickFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/parcel/quickfixes/ParcelMigrateToParcelizeQuickFix.kt": [
 70,
 80,
 89,
 132,
 145,
-155,
+155
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt':[
-288,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt": [
+288
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinAbstractUElement.kt':[
-182,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinAbstractUElement.kt": [
+182
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/declarations/KotlinUAnnotation.kt':[
-78,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/declarations/KotlinUAnnotation.kt": [
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/declarations/KotlinUVariable.kt':[
-298,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/declarations/KotlinUVariable.kt": [
+298
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/KotlinUFunctionCallExpression.kt':[
-44,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/KotlinUFunctionCallExpression.kt": [
+44
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S107.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S107.json
@@ -1,103 +1,103 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/modules/KotlinModuleXmlBuilder.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/modules/KotlinModuleXmlBuilder.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/javac/JavacWrapperRegistrar.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/javac/JavacWrapperRegistrar.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt": [
 89,
 160,
-185,
+185
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompileService.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompileService.kt": [
 110,
 123,
-154,
+154
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/frontend/java/di/injection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/frontend/java/di/injection.kt": [
 76,
-128,
+128
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/analyzer/AnalyzerFacade.kt':[
-311,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/analyzer/AnalyzerFacade.kt": [
+311
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/frontend/di/injection.kt':[
-124,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/frontend/di/injection.kt": [
+124
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegatedPropertyResolver.kt':[
-306,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegatedPropertyResolver.kt": [
+306
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegationResolver.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegationResolver.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewCallArguments.kt':[
-282,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewCallArguments.kt": [
+282
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/descriptors/JvmDescriptorWithExtraFlags.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/descriptors/JvmDescriptorWithExtraFlags.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/OverloadingConflictResolver.kt':[
-301,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/OverloadingConflictResolver.kt": [
+301
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/test/MockLibraryUtil.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/test/MockLibraryUtil.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/ValueParameterDescriptorImpl.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/ValueParameterDescriptorImpl.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/test-generator/tests/org/jetbrains/kotlin/generators/tests/generator/TestGenerationDSL.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/test-generator/tests/org/jetbrains/kotlin/generators/tests/generator/TestGenerationDSL.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/analysis/AnalyzerUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/analysis/AnalyzerUtil.kt": [
 39,
-53,
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/codeInsight/ReferenceVariantsHelper.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/codeInsight/ReferenceVariantsHelper.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt':[
-223,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt": [
+223
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractableAnalysisUtil.kt':[
-225,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractableAnalysisUtil.kt": [
+225
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt':[
-151,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt": [
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt':[
-468,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt": [
+468
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixMultiFileTest.kt':[
-292,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixMultiFileTest.kt": [
+292
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/JpsKotlinCompilerRunner.kt':[
-114,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/JpsKotlinCompilerRunner.kt": [
+114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/KotlinBuilder.kt':[
-526,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/KotlinBuilder.kt": [
+526
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt": [
 295,
 340,
 427,
-591,
+591
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.khronos.webgl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.khronos.webgl.kt": [
 54,
 163,
 164,
 165,
 238,
-242,
+242
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.events.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.events.kt": [
 131,
 210,
 268,
-382,
+382
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt": [
 1579,
 1623,
 1686,
@@ -105,19 +105,19 @@
 2061,
 2372,
 2394,
-2700,
+2700
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.fetch.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.fetch.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.notifications.kt':[
-114,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.notifications.kt": [
+114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.workers.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.workers.kt": [
 133,
-361,
+361
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/functions/Functions.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/functions/Functions.kt": [
 53,
 58,
 63,
@@ -132,15 +132,15 @@
 108,
 113,
 118,
-123,
+123
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt':[
-540,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt": [
+540
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/annotationProcessing.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/annotationProcessing.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/SignatureParserVisitor.kt':[
-294,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/SignatureParserVisitor.kt": [
+294
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S108.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S108.json
@@ -1,220 +1,220 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/storage/LazyStorage.kt':[
-90,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/storage/LazyStorage.kt": [
+90
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/RangeCodegenUtil.kt':[
-250,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/RangeCodegenUtil.kt": [
+250
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/processUninitializedStores.kt':[
-238,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/processUninitializedStores.kt": [
+238
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingMethodTransformer.kt':[
-338,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingMethodTransformer.kt": [
+338
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/MethodAnalyzer.kt':[
-131,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/MethodAnalyzer.kt": [
+131
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt':[
-197,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt": [
+197
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/GenericReplCompiler.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/GenericReplCompiler.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplInterpreter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplInterpreter.kt": [
 67,
 68,
 69,
-70,
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Singletons.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Singletons.kt": [
 100,
-102,
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/KotlinCompileDaemon.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/KotlinCompileDaemon.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt':[
-353,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt": [
+353
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt':[
-1549,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt": [
+1549
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/PseudocodeTraverser.kt':[
-196,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/PseudocodeTraverser.kt": [
+196
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/WhenChecker.kt':[
-354,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/WhenChecker.kt": [
+354
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationUseSiteTargetChecker.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationUseSiteTargetChecker.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/ModifiersChecker.kt':[
-270,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/ModifiersChecker.kt": [
+270
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/coroutineCallChecker.kt':[
-119,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/coroutineCallChecker.kt": [
+119
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/JsClassGenerator.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/JsClassGenerator.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt':[
-147,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt": [
+147
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt':[
-883,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt": [
+883
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ClassifierResolver.kt':[
-81,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ClassifierResolver.kt": [
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/kdoc/parser/KDocKnownTag.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/kdoc/parser/KDocKnownTag.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaPackageFragment.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaPackageFragment.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/EffectiveVisibility.kt':[
-301,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/EffectiveVisibility.kt": [
+301
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ReflectionObjectRenderer.kt':[
-111,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ReflectionObjectRenderer.kt": [
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt':[
-217,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt": [
+217
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/jdi/test/jdiTest.kt':[
-92,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/jdi/test/jdiTest.kt": [
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/PerModulePackageCacheService.kt':[
-102,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/PerModulePackageCacheService.kt": [
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt':[
-309,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt": [
+309
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinSourcePositionProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinSourcePositionProvider.kt": [
 132,
-134,
+134
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinEvaluationBuilder.kt':[
-355,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinEvaluationBuilder.kt": [
+355
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinRuntimeTypeEvaluator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinRuntimeTypeEvaluator.kt": [
 54,
-56,
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinStepOverInlinedLinesHint.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinStepOverInlinedLinesHint.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/compile/KtCompilingExecutor.kt':[
-290,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/compile/KtCompilingExecutor.kt": [
+290
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinCopyPasteReferenceProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinCopyPasteReferenceProcessor.kt": [
 88,
-90,
+90
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeParameterInspection.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeParameterInspection.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceArrayEqualityOpWithArraysEqualsInspection.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceArrayEqualityOpWithArraysEqualsInspection.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt':[
-202,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt": [
+202
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTryFinallyToUseCallIntention.kt':[
-110,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTryFinallyToUseCallIntention.kt": [
+110
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinTypeArgumentInfoHandler.kt':[
-175,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinTypeArgumentInfoHandler.kt": [
+175
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/MakeOverriddenMemberOpenFix.kt':[
-117,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/MakeOverriddenMemberOpenFix.kt": [
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveUnusedValueFix.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveUnusedValueFix.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/copy/CopyKotlinDeclarationsHandler.kt':[
-124,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/copy/CopyKotlinDeclarationsHandler.kt": [
+124
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/Slicer.kt':[
-522,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/Slicer.kt": [
+522
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/run/RunConfigurationTest.kt':[
-92,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/run/RunConfigurationTest.kt": [
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt':[
-726,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt": [
+726
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Parameter.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Parameter.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTest.kt':[
-196,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTest.kt": [
+196
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/JpsKotlinCompilerRunner.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/JpsKotlinCompilerRunner.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/ReachabilityTracker.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/ReachabilityTracker.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/encodeSignature.kt':[
-116,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/encodeSignature.kt": [
+116
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt": [
 449,
-457,
+457
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/kotlin-jsr223-local-example/src/test/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223ScriptEngineIT.kt':[
-83,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/kotlin-jsr223-local-example/src/test/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223ScriptEngineIT.kt": [
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/coroutines/src/kotlin/sequences/SequenceBuilder.kt':[
-106,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/coroutines/src/kotlin/sequences/SequenceBuilder.kt": [
+106
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk7/src/kotlin/AutoCloseable.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk7/src/kotlin/AutoCloseable.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jre7/src/kotlin/AutoCloseable.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jre7/src/kotlin/AutoCloseable.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/internal/PlatformImplementations.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/internal/PlatformImplementations.kt": [
 29,
 32,
 38,
-41,
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/Closeable.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/Closeable.kt": [
 31,
-52,
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt':[
-391,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt": [
+391
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/coroutines/experimental/SequenceBuilder.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/coroutines/experimental/SequenceBuilder.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/main/kotlin/org.jetbrains.kotlin.tools/kotlinMetadataVisibilities.kt':[
-171,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/main/kotlin/org.jetbrains.kotlin.tools/kotlinMetadataVisibilities.kt": [
+171
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/render.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/render.kt": [
 41,
-136,
+136
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt':[
-83,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt": [
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/utils.kt": [
 66,
-115,
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/CacheableTasks.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/CacheableTasks.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/tasksUtils.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/tasksUtils.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/resolve.kt':[
-60,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/resolve.kt": [
+60
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1110.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1110.json
@@ -1,14 +1,14 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreter.kt':[
-85,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreter.kt": [
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/facet/facetUtils.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/facet/facetUtils.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/versions/KotlinUpdatePluginComponent.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/versions/KotlinUpdatePluginComponent.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/generate/generateDependenciesUtils.kt':[
-132,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/generate/generateDependenciesUtils.kt": [
+132
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1125.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1125.json
@@ -1,102 +1,102 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/CommonUtil.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/CommonUtil.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt':[
-254,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt": [
+254
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueKindUtils.kt':[
-142,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueKindUtils.kt": [
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/util/PerformanceCounter.kt':[
-200,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/util/PerformanceCounter.kt": [
+200
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/KtLightMemberImpl.kt':[
-108,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/KtLightMemberImpl.kt": [
+108
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/model/visitors/Reducer.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/model/visitors/Reducer.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt':[
-297,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt": [
+297
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/annotations/Annotations.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/annotations/Annotations.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt':[
-436,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt": [
+436
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/codeInsight/ReferenceVariantsHelper.kt':[
-268,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/codeInsight/ReferenceVariantsHelper.kt": [
+268
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt':[
-551,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt": [
+551
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/utils.kt':[
-177,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/utils.kt": [
+177
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/tests/org/jetbrains/kotlin/android/intention/AbstractAndroidResourceIntentionTest.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/tests/org/jetbrains/kotlin/android/intention/AbstractAndroidResourceIntentionTest.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/handlers/CompletionHandlerTestBase.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/handlers/CompletionHandlerTestBase.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GroovyBuildScriptManipulator.kt':[
-290,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GroovyBuildScriptManipulator.kt": [
+290
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/filter/KotlinSyntheticTypeComponentProvider.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/filter/KotlinSyntheticTypeComponentProvider.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/SearchNotPropertyCandidatesAction.kt':[
-112,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/SearchNotPropertyCandidatesAction.kt": [
+112
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt": [
 330,
 331,
-334,
+334
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindUsagesHandler.kt':[
-136,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindUsagesHandler.kt": [
+136
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/BranchedFoldingUtils.kt':[
-103,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/BranchedFoldingUtils.kt": [
+103
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinClassesWithAnnotatedMembersSearcher.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinClassesWithAnnotatedMembersSearcher.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinDefinitionsSearcher.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinDefinitionsSearcher.kt": [
 62,
-144,
+144
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/AnnotationConverter.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/AnnotationConverter.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt':[
-220,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt": [
+220
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt':[
-357,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt": [
+357
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ForConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ForConverter.kt": [
 173,
 174,
 175,
-176,
+176
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ReferenceSearcher.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ReferenceSearcher.kt": [
 69,
-75,
+75
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/propertyDetection.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/propertyDetection.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Ranges.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Ranges.kt": [
 65,
 73,
 81,
@@ -110,14 +110,14 @@
 185,
 193,
 201,
-241,
+241
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt": [
 190,
 333,
-361,
+361
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/properties/delegates.kt':[
-42,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/properties/delegates.kt": [
+42
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1128.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1128.json
@@ -1,980 +1,980 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/storage/LazyStorage.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/storage/LazyStorage.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/test/org/jetbrains/kotlin/incremental/testingUtils/classFilesComparison.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/test/org/jetbrains/kotlin/incremental/testingUtils/classFilesComparison.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/CommonUtil.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/CommonUtil.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/AndroidTestGenerator.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/AndroidTestGenerator.kt": [
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/AbstractAccessorForFunctionDescriptor.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/AbstractAccessorForFunctionDescriptor.kt": [
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ClassNameCollectionClassBuilderFactory.kt':[
-20,
-21,
-23,
-24,
-25,
-26,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/CodegenFactory.kt':[
-19,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/DelegatingClassBuilderFactory.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ClassNameCollectionClassBuilderFactory.kt": [
 20,
 21,
 23,
 24,
 25,
-26,
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/InlineCycleReporter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/CodegenFactory.kt": [
+19
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/DelegatingClassBuilderFactory.kt": [
+19,
 20,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ObjectSuperCallArgumentGenerator.kt':[
-26,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/SamWrapperClasses.kt':[
-19,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/SourceInfo.kt':[
-19,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ieee754.kt':[
-15,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InliningContext.kt':[
 21,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/ArrayConstructor.kt':[
-21,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/pseudoInsns/PseudoInsns.kt':[
 23,
+24,
+25,
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/AbstractBoundedValue.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/InlineCycleReporter.kt": [
+20
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ObjectSuperCallArgumentGenerator.kt": [
+26
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/SamWrapperClasses.kt": [
+19
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/SourceInfo.kt": [
+19
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ieee754.kt": [
+15
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InliningContext.kt": [
+21
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/ArrayConstructor.kt": [
+21
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/pseudoInsns/PseudoInsns.kt": [
+23
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/AbstractBoundedValue.kt": [
 19,
 20,
 21,
 22,
-24,
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/RangeValue.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/RangeValue.kt": [
 9,
-14,
+14
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/SimpleBoundedValue.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/SimpleBoundedValue.kt": [
 20,
-21,
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/argumentUtils.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/argumentUtils.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreProjectEnvironment.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreProjectEnvironment.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinToJVMBytecodeCompiler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinToJVMBytecodeCompiler.kt": [
 54,
-59,
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/TopDownAnalyzerFacadeForJVM.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/TopDownAnalyzerFacadeForJVM.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/compiler-runner/src/org/jetbrains/kotlin/compilerRunner/CompilerEnvironment.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/compiler-runner/src/org/jetbrains/kotlin/compilerRunner/CompilerEnvironment.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/CompilerCallbackServicesFacadeServer.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/CompilerCallbackServicesFacadeServer.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/components/FilesByFacadeFqNameIndexer.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/components/FilesByFacadeFqNameIndexer.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/JvmBindingContextSlices.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/JvmBindingContextSlices.kt": [
 20,
-22,
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmArrayVariableInLoopAssignmentChecker.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmArrayVariableInLoopAssignmentChecker.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/ProtectedSyntheticExtensionCallChecker.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/ProtectedSyntheticExtensionCallChecker.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/jvmConstants.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/jvmConstants.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/contracts/parsing/PsiContractsUtils.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/contracts/parsing/PsiContractsUtils.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/BindingContextUtils.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/BindingContextUtils.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationReturnTypeSanitizer.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationReturnTypeSanitizer.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegatedPropertyResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegatedPropertyResolver.kt": [
 14,
 28,
 34,
-39,
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/ConstructorHeaderCallChecker.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/ConstructorHeaderCallChecker.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/coroutineCallChecker.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/coroutineCallChecker.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/ConstraintError.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/ConstraintError.kt": [
 19,
-20,
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/ConstraintSystemBuilderImpl.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/ConstraintSystemBuilderImpl.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/resolvedCallUtil.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/resolvedCallUtil.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tasks/TracingStrategyForImplicitConstructorDelegationCall.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tasks/TracingStrategyForImplicitConstructorDelegationCall.kt": [
 25,
-26,
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/KotlinResolutionStatelessCallbacksImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/KotlinResolutionStatelessCallbacksImpl.kt": [
 19,
-36,
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/ManyCandidatesResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/ManyCandidatesResolver.kt": [
 16,
-20,
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/PSIKotlinCalls.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/PSIKotlinCalls.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/InlineParameterChecker.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/InlineParameterChecker.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/diagnostics/SimpleDiagnostics.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/diagnostics/SimpleDiagnostics.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/inline/InlineAnalyzerExtension.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/inline/InlineAnalyzerExtension.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LocalDescriptorResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LocalDescriptorResolver.kt": [
 21,
 22,
-23,
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/scopes/LocalRedeclarationChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/scopes/LocalRedeclarationChecker.kt": [
 19,
 21,
 22,
-27,
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/storage/LockBasedLazyResolveStorageManager.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/storage/LockBasedLazyResolveStorageManager.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/SenselessComparisonChecker.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/SenselessComparisonChecker.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/util/PerformanceCounter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/util/PerformanceCounter.kt": [
 19,
 22,
-23,
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/AbstractIncrementalMultiplatformJsCompilerRunnerTest.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/AbstractIncrementalMultiplatformJsCompilerRunnerTest.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/BuildDiffsStorageTest.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/BuildDiffsStorageTest.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/descriptors/utils.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/descriptors/utils.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/PropertiesLowering.kt':[
-18,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/PropertiesLowering.kt": [
+18
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/descriptors/Util.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/descriptors/Util.kt": [
 24,
-25,
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/HashCode.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/HashCode.kt": [
 20,
 21,
 22,
 23,
 28,
-29,
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/UnaryMinus.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/UnaryMinus.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/LoweredFunction.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/LoweredFunction.kt": [
 19,
+20
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrReturnTarget.kt": [
+9
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrCallWithIndexedArgumentsBase.kt": [
+21
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/wrappers/trees/TreeBasedPackage.kt": [
+28
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForLocalDeclaration.kt": [
+25
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/kdoc/psi/impl/KDocLink.kt": [
+24
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/kdoc/psi/impl/KDocSection.kt": [
+21
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtTypeReference.kt": [
+22
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/model/functors/EqualsFunctor.kt": [
+19
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/InferenceSession.kt": [
+9
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/TypeArgumentsToParametersMapper.kt": [
+22
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/NewConstraintSystem.kt": [
+20
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/model/ConstraintStorage.kt": [
+8
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/model/MutableConstraintStorage.kt": [
+8
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/Diagnostics.kt": [
 20,
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrReturnTarget.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/ResolutionCandidate.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrCallWithIndexedArgumentsBase.kt':[
-21,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/wrappers/trees/TreeBasedPackage.kt':[
-28,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForLocalDeclaration.kt':[
-25,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/kdoc/psi/impl/KDocLink.kt':[
-24,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/kdoc/psi/impl/KDocSection.kt':[
-21,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtTypeReference.kt':[
-22,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/model/functors/EqualsFunctor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/testUtils.kt": [
 19,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/InferenceSession.kt':[
-9,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/TypeArgumentsToParametersMapper.kt':[
-22,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/NewConstraintSystem.kt':[
-20,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/model/ConstraintStorage.kt':[
-8,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/model/MutableConstraintStorage.kt':[
-8,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/Diagnostics.kt':[
-20,
 21,
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/ResolutionCandidate.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/resolve/constraintSystem/ConstraintSystemTestData.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/testUtils.kt':[
-19,
-21,
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/specialBuiltinMembers.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/resolve/constraintSystem/ConstraintSystemTestData.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/UnsignedType.kt": [
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/specialBuiltinMembers.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRenderer.kt": [
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/UnsignedType.kt':[
-12,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererOptionsImpl.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRenderer.kt':[
-12,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/StarProjectionImpl.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererOptionsImpl.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/TypeWithEnhancement.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/StarProjectionImpl.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KCallableImpl.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/TypeWithEnhancement.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/test/suiteBuilder.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KCallableImpl.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/builtins/common.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/test/suiteBuilder.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/ShadowedDeclarationsFilter.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/builtins/common.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/PerModulePackageCacheService.kt": [
+20
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/compiler/configuration/KotlinCommonCompilerArgumentsHolder.kt": [
+21
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/navigation/KotlinDeclarationNavigationPolicyImpl.kt": [
 20,
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/ShadowedDeclarationsFilter.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/facet/KotlinFacet.kt": [
+10
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/PerModulePackageCacheService.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/AbstractResultUnusedChecker.kt": [
+10
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/compiler/configuration/KotlinCommonCompilerArgumentsHolder.kt':[
-21,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/navigation/KotlinDeclarationNavigationPolicyImpl.kt':[
-20,
-22,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/facet/KotlinFacet.kt':[
-10,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/AbstractResultUnusedChecker.kt':[
-10,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/modules/IdeJavaModuleResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/modules/IdeJavaModuleResolver.kt": [
 23,
-25,
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ProbablyNothingCallableNamesImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ProbablyNothingCallableNamesImpl.kt": [
 12,
 13,
 14,
-17,
+17
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt": [
 34,
-35,
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/stubindex/resolve/StubBasedPackageMemberDeclarationProvider.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/stubindex/resolve/StubBasedPackageMemberDeclarationProvider.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/ApplicationUtils.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/ApplicationUtils.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/inspection/IllegalIdentifierInspection.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/inspection/IllegalIdentifierInspection.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/intention/AddActivityToManifest.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/intention/AddActivityToManifest.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/intention/AddBroadcastReceiverToManifest.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/intention/AddBroadcastReceiverToManifest.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/intention/AddServiceToManifest.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/intention/AddServiceToManifest.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/intention/KotlinAndroidAddStringResource.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/intention/KotlinAndroidAddStringResource.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KotlinExcludeFromCompletionLookupActionProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KotlinExcludeFromCompletionLookupActionProvider.kt": [
 18,
 26,
-30,
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ImportableFqNameClassifier.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ImportableFqNameClassifier.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/SmartCastCalculator.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/SmartCastCalculator.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDefinitionsManager.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDefinitionsManager.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jps-common/src/org/jetbrains/kotlin/config/facetSerialization.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jps-common/src/org/jetbrains/kotlin/config/facetSerialization.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/KotlinWithLibraryConfigurator.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/KotlinWithLibraryConfigurator.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinPositionManager.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinPositionManager.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/KotlinFieldBreakpoint.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/KotlinFieldBreakpoint.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/FrameVisitor.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/FrameVisitor.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/render/KotlinClassWithDelegatedPropertyRenderer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/render/KotlinClassWithDelegatedPropertyRenderer.kt": [
 37,
-38,
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinStepOverInlinedLinesHint.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinStepOverInlinedLinesHint.kt": [
 19,
 22,
 24,
-26,
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/surroundWith/KotlinRuntimeTypeCastSurrounder.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/surroundWith/KotlinRuntimeTypeCastSurrounder.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/run/script/standalone/KotlinStandaloneScriptRunConfiguration.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/run/script/standalone/KotlinStandaloneScriptRunConfiguration.kt": [
 27,
-28,
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/KtScratchFileLanguageProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/KtScratchFileLanguageProvider.kt": [
 21,
-25,
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/src/org/jetbrains/kotlin/idea/liveTemplates/macro/AnonymousSuperMacro.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/src/org/jetbrains/kotlin/idea/liveTemplates/macro/AnonymousSuperMacro.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/KotlinMavenImporter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/KotlinMavenImporter.kt": [
 32,
-53,
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/ReplOutputHandler.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/ReplOutputHandler.kt": [
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-test-framework/test/org/jetbrains/kotlin/idea/test/KotlinLightCodeInsightFixtureTestCase.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-test-framework/test/org/jetbrains/kotlin/idea/test/KotlinLightCodeInsightFixtureTestCase.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinFoldingBuilder.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinFoldingBuilder.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/benchmark/TopLevelCompletionBenchmark.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/benchmark/TopLevelCompletionBenchmark.kt": [
 22,
-25,
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinRefactoringHelperForDelayedRequests.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinRefactoringHelperForDelayedRequests.kt": [
 22,
-23,
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/facet/facetUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/facet/facetUtils.kt": [
 20,
 28,
 31,
 32,
 33,
-37,
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinReferenceUsageInfo.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinReferenceUsageInfo.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/hierarchy/KotlinTypeHierarchyProvider.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/hierarchy/KotlinTypeHierarchyProvider.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/hierarchy/calls/callHierarchyUtils.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/hierarchy/calls/callHierarchyUtils.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ImplicitThisInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ImplicitThisInspection.kt": [
 24,
-30,
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MainFunctionReturnUnitInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MainFunctionReturnUnitInspection.kt": [
 13,
 22,
 24,
-25,
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceToWithInfixFormInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceToWithInfixFormInspection.kt": [
 15,
 23,
-24,
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedReceiverParameterInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedReceiverParameterInspection.kt": [
 31,
-44,
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/AbstractUselessCallInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/AbstractUselessCallInspection.kt": [
+29
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertRangeCheckToTwoComparisonsIntention.kt": [
+22
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/IntroduceVariableIntention.kt": [
+23
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveEmptyClassBodyIntention.kt": [
+23
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveEmptyParenthesesFromLambdaCallIntention.kt": [
+27
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ValToObjectIntention.kt": [
+25
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessings.kt": [
+27
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/joinLines/JoinDeclarationAndAssignmentHandler.kt": [
+20
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AssignToPropertyFix.kt": [
+31
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeVariableMutabilityFix.kt": [
+26
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ImportFix.kt": [
+59
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveUselessIsCheckFixForWhen.kt": [
+21
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RenameUnresolvedReferenceFix.kt": [
+27
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableMemberFromUsageFactory.kt": [
+25
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageInWholeProjectFix.kt": [
+22
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt": [
+39
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractClass/KotlinExtractInterfaceHandler.kt": [
+22
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractClass/KotlinExtractSuperclassHandler.kt": [
+22,
+24
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsProcessor.kt": [
+28
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveFilesOrDirectories/KotlinMoveDirectoryWithClassesHelper.kt": [
+36
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameUtil.kt": [
+33
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/KotlinSliceProvider.kt": [
+27,
+29
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/Java9MultiModuleHighlightingTest.kt": [
+20
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractInsertImportOnPasteTest.kt": [
+21
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinInTempDirTest.kt": [
+21,
 29,
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertRangeCheckToTwoComparisonsIntention.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/editor/LazyElementTypeTest.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/IntroduceVariableIntention.kt':[
-23,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveEmptyClassBodyIntention.kt':[
-23,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveEmptyParenthesesFromLambdaCallIntention.kt':[
-27,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ValToObjectIntention.kt':[
-25,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessings.kt':[
-27,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/joinLines/JoinDeclarationAndAssignmentHandler.kt':[
-20,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AssignToPropertyFix.kt':[
-31,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeVariableMutabilityFix.kt':[
-26,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ImportFix.kt':[
-59,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveUselessIsCheckFixForWhen.kt':[
-21,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RenameUnresolvedReferenceFix.kt':[
-27,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableMemberFromUsageFactory.kt':[
-25,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageInWholeProjectFix.kt':[
-22,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt':[
-39,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractClass/KotlinExtractInterfaceHandler.kt':[
-22,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractClass/KotlinExtractSuperclassHandler.kt':[
-22,
-24,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsProcessor.kt':[
-28,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveFilesOrDirectories/KotlinMoveDirectoryWithClassesHelper.kt':[
-36,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameUtil.kt':[
-33,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/KotlinSliceProvider.kt':[
-27,
-29,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/Java9MultiModuleHighlightingTest.kt':[
-20,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractInsertImportOnPasteTest.kt':[
-21,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinInTempDirTest.kt':[
-21,
-29,
-31,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/editor/LazyElementTypeTest.kt':[
-21,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/editor/quickDoc/QuickDocInHierarchyTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/editor/quickDoc/QuickDocInHierarchyTest.kt": [
 32,
-34,
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/folding/FoldingAfterOptimizeImportsTest.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/folding/FoldingAfterOptimizeImportsTest.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/highlighter/Jsr305HighlightingTest.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/highlighter/Jsr305HighlightingTest.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocSampleTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocSampleTest.kt": [
 22,
-33,
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/lightClasses/LightElementsEqualsTest.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/lightClasses/LightElementsEqualsTest.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/navigation/GotoCheck.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/navigation/GotoCheck.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AddRequireModuleTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AddRequireModuleTest.kt": [
 20,
-21,
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/KotlinNamesValidatorTest.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/KotlinNamesValidatorTest.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/resolve/AbstractPartialBodyResolveTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/resolve/AbstractPartialBodyResolveTest.kt": [
 37,
-38,
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/psi/patternMatching/AbstractPsiUnifierTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/psi/patternMatching/AbstractPsiUnifierTest.kt": [
+22
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeVisitor.kt": [
+25
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalJpsTest.kt": [
+53
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalLazyCachesTest.kt": [
+23
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTest.kt": [
+64
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTestIncremental.kt": [
+25
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/FSOperationsHelper.kt": [
 22,
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeVisitor.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/KotlinBuilder.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalJpsTest.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/platforms/KotlinCommonModuleBuildTarget.kt": [
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalLazyCachesTest.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/platforms/TargetPlatform.kt": [
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTest.kt':[
-64,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTestIncremental.kt':[
-25,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/FSOperationsHelper.kt':[
-22,
-24,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/KotlinBuilder.kt':[
-37,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/platforms/KotlinCommonModuleBuildTarget.kt':[
-12,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/platforms/TargetPlatform.kt':[
-13,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/frontend/js/di/injection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/frontend/js/di/injection.kt": [
 36,
 37,
-38,
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/analyzer/JsAnalysisResult.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/analyzer/JsAnalysisResult.kt": [
 22,
-23,
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsCodePositioningStrategy.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsCodePositioningStrategy.kt": [
 23,
 25,
-26,
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/FunctionReader.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/FunctionReader.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/context/FunctionContext.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/context/FunctionContext.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/expression/LoopTranslator.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/expression/LoopTranslator.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/intrinsic/operation/CompareToBOIF.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/intrinsic/operation/CompareToBOIF.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/browser-example-with-library/src/main/kotlin/sample/Hello.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/browser-example-with-library/src/main/kotlin/sample/Hello.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm-host/src/kotlin/script/experimental/jvmhost/impl/KJVMCompilerImpl.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm-host/src/kotlin/script/experimental/jvmhost/impl/KJVMCompilerImpl.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Arrays.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Arrays.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Comparisons.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Comparisons.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Maps.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Maps.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Ranges.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Ranges.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sets.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sets.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Strings.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Strings.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/kotlin/KotlinH.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/kotlin/KotlinH.kt": [
 8,
-9,
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/coroutines/jvm/src/kotlin/coroutines/SafeContinuationJvm.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/coroutines/jvm/src/kotlin/coroutines/SafeContinuationJvm.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/coroutines/src/kotlin/sequences/SequenceBuilder.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/coroutines/src/kotlin/sequences/SequenceBuilder.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk7/test/TryWithResourcesCloseableTest.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk7/test/TryWithResourcesCloseableTest.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk8/src/kotlin/internal/jdk8/JDK8PlatformImplementations.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk8/src/kotlin/internal/jdk8/JDK8PlatformImplementations.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jre7/test/TryWithResourcesCloseableTest.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jre7/test/TryWithResourcesCloseableTest.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/generated/_ArraysJs.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/generated/_ArraysJs.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/generated/_CollectionsJs.kt':[
-17,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/generated/_CollectionsJs.kt": [
+17
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/generated/_ComparisonsJs.kt':[
-17,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/generated/_ComparisonsJs.kt": [
+17
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/generated/_ArraysJvm.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/generated/_ArraysJvm.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/generated/_CollectionsJvm.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/generated/_CollectionsJvm.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/generated/_ComparisonsJvm.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/generated/_ComparisonsJvm.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/generated/_SequencesJvm.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/generated/_SequencesJvm.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/generated/_StringsJvm.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/generated/_StringsJvm.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/collections/CollectionsJVM.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/collections/CollectionsJVM.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/collections/MapsJVM.kt':[
-12,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/collections/MapsJVM.kt": [
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/collections/SequencesJVM.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/collections/SequencesJVM.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/concurrent/Locks.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/concurrent/Locks.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/coroutines/experimental/SafeContinuationJvm.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/coroutines/experimental/SafeContinuationJvm.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/internal/PlatformImplementations.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/internal/PlatformImplementations.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/FilePathComponents.kt':[
-12,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/FilePathComponents.kt": [
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/FileTreeWalk.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/FileTreeWalk.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt':[
-13,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt": [
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/jvm/internal/unsafe/monitor.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/jvm/internal/unsafe/monitor.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/ranges/RangesJVM.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/ranges/RangesJVM.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/system/Process.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/system/Process.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/CharCategory.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/CharCategory.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/CharDirectionality.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/CharDirectionality.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/CharJVM.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/CharJVM.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/StringNumberConversionsJVM.kt':[
-12,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/StringNumberConversionsJVM.kt": [
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/util/MathJVM.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/util/MathJVM.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/collections/MapJVMTest.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/collections/MapJVMTest.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/numbers/NumbersJVMTest.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/numbers/NumbersJVMTest.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/utils/LazyJVMTest.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/utils/LazyJVMTest.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/AbstractList.kt':[
-12,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/AbstractList.kt": [
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Collections.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Collections.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/ReversedViews.kt':[
-10,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/ReversedViews.kt": [
+10
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Sequences.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Sequences.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/coroutines/experimental/SequenceBuilder.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/coroutines/experimental/SequenceBuilder.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/properties/Delegates.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/properties/Delegates.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/ranges/Ranges.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/ranges/Ranges.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/StringNumberConversions.kt':[
-12,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/StringNumberConversions.kt": [
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/Strings.kt':[
-12,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/Strings.kt": [
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/ReversedViewsTest.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/ReversedViewsTest.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/utils/LazyTest.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/utils/LazyTest.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/utils/TODOTest.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/utils/TODOTest.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-allopen/src/main/kotlin/org/jetbrains/kotlin/allopen/gradle/AllOpenSubplugin.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-allopen/src/main/kotlin/org/jetbrains/kotlin/allopen/gradle/AllOpenSubplugin.kt": [
 21,
-22,
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt':[
-7,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt": [
+7
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3AndroidIT.kt':[
-6,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3AndroidIT.kt": [
+6
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/UpToDatenessIT.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/UpToDatenessIT.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/sample/icepick/lib/BaseActivity.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/sample/icepick/lib/BaseActivity.kt": [
 5,
-8,
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidJackProject/Android/root/kotlin/org/jetbrains/kotlin/gradle/test/androidalfa/MainActivity2.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidJackProject/Android/root/kotlin/org/jetbrains/kotlin/gradle/test/androidalfa/MainActivity2.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/root/kotlin/org/jetbrains/kotlin/gradle/test/androidalfa/MainActivity2.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/root/kotlin/org/jetbrains/kotlin/gradle/test/androidalfa/MainActivity2.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/additionalJavaSrc/src/main/kotlin/helloWorld.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/additionalJavaSrc/src/main/kotlin/helloWorld.kt": [
+3
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/src/deploy/kotlin/kotlinSrc.kt": [
 3,
+4
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/src/deploy/kotlin/kotlinSrc.kt':[
-3,
-4,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/src/main/kotlin/helloWorld.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/src/main/kotlin/helloWorld.kt':[
-3,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/src/test/kotlin/tests.kt':[
-3,
-4,
-6,
-7,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/src/deploy/kotlin/kotlinSrc.kt':[
-3,
-4,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/src/main/kotlin/helloWorld.kt':[
-3,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/src/test/kotlin/tests.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/src/test/kotlin/tests.kt": [
 3,
 4,
 6,
-7,
+7
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressWarnings/src/helloWorld.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/src/deploy/kotlin/kotlinSrc.kt": [
 3,
+4
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinCompile.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/src/main/kotlin/helloWorld.kt": [
+3
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/src/test/kotlin/tests.kt": [
+3,
+4,
+6,
+7
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressWarnings/src/helloWorld.kt": [
+3
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinCompile.kt": [
 21,
 23,
-24,
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/CompilerArgumentsGradleInput.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/CompilerArgumentsGradleInput.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/KaptGenerateStubsTask.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/KaptGenerateStubsTask.kt": [
 26,
-27,
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/gradleUtils.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/gradleUtils.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/CompilerPluginOptions.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/CompilerPluginOptions.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompileCommon.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompileCommon.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/tasksUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/tasksUtils.kt": [
 5,
 10,
 11,
-12,
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-generateKotlinCode/annotation-processor/src/main/kotlin/ExampleAnnotationProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-generateKotlinCode/annotation-processor/src/main/kotlin/ExampleAnnotationProcessor.kt": [
 14,
-15,
+15
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-noarg/src/main/kotlin/org/jetbrains/kotlin/noarg/gradle/NoArgSubplugin.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-noarg/src/main/kotlin/org/jetbrains/kotlin/noarg/gradle/NoArgSubplugin.kt": [
 21,
 22,
-23,
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-sam-with-receiver/src/main/kotlin/org/jetbrains/kotlin/noarg/gradle/SamWithReceiverSubplugin.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-sam-with-receiver/src/main/kotlin/org/jetbrains/kotlin/noarg/gradle/SamWithReceiverSubplugin.kt": [
 21,
 22,
-23,
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/CliAndroidPackageFragmentProviderExtension.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/CliAndroidPackageFragmentProviderExtension.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/parcel/AbstractParcelBytecodeListingTest.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/parcel/AbstractParcelBytecodeListingTest.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/synthetic/test/CompilerTestUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/synthetic/test/CompilerTestUtils.kt": [
 38,
-39,
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/parcel/quickfixes/ParcelMigrateToParcelizeQuickFix.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/parcel/quickfixes/ParcelMigrateToParcelizeQuickFix.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/ExperimentalUtils.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/ExperimentalUtils.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-runtime/src/kotlinx/android/parcel/Parceler.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-runtime/src/kotlinx/android/parcel/Parceler.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Extension.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Extension.kt": [
 26,
 54,
-60,
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/javac/KaptJavaFileObject.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/javac/KaptJavaFileObject.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/javac/KaptJavaLog.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/javac/KaptJavaLog.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/AbstractKotlinKapt3IntegrationTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/AbstractKotlinKapt3IntegrationTest.kt": [
 20,
-51,
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/noarg/noarg-ide/src/NoArgGradleProjectImportHandler.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/noarg/noarg-ide/src/NoArgGradleProjectImportHandler.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/sam-with-receiver/sam-with-receiver-ide/src/SamWithReceiverGradleProjectImportHandler.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/sam-with-receiver/sam-with-receiver-ide/src/SamWithReceiverGradleProjectImportHandler.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/sam-with-receiver/sam-with-receiver-ide/src/SamWithReceiverMavenProjectImportHandler.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/sam-with-receiver/sam-with-receiver-ide/src/SamWithReceiverMavenProjectImportHandler.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/tests/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptingCompilerPluginTest.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/tests/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptingCompilerPluginTest.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/src/org/jetbrains/kotlin/sourceSections/SourceSectionsPlugin.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/src/org/jetbrains/kotlin/sourceSections/SourceSectionsPlugin.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/internal/kotlinInternalUastUtils.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/internal/kotlinInternalUastUtils.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/nodejs/cli/KotlinNodeJsRunConfigurationProducer.kt':[
-15,
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/nodejs/cli/KotlinNodeJsRunConfigurationProducer.kt": [
+15
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/diagram/KotlinSpringLocalModelDependenciesDiagramProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/diagram/KotlinSpringLocalModelDependenciesDiagramProvider.kt": [
 24,
-25,
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/tests/org/jetbrains/kotlin/idea/spring/tests/gutter/AbstractSpringClassAnnotatorTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/tests/org/jetbrains/kotlin/idea/spring/tests/gutter/AbstractSpringClassAnnotatorTest.kt": [
 22,
-29,
-],
+29
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1134.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1134.json
@@ -1,11 +1,11 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt':[
-699,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt": [
+699
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinAlternativeSourceNotificationProvider.kt':[
-166,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinAlternativeSourceNotificationProvider.kt": [
+166
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/NoStrataPositionManagerHelper.kt':[
-165,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/NoStrataPositionManagerHelper.kt": [
+165
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1135.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1135.json
@@ -1,88 +1,88 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/ant/src/org/jetbrains/kotlin/ant/Kotlin2JsTask.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/ant/src/org/jetbrains/kotlin/ant/Kotlin2JsTask.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/compilerRunner/MessageCollectorToOutputItemsCollectorAdapter.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/compilerRunner/MessageCollectorToOutputItemsCollectorAdapter.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/IncrementalJvmCache.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/IncrementalJvmCache.kt": [
 70,
 144,
 351,
-511,
+511
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/protoDifferenceUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/protoDifferenceUtils.kt": [
 224,
 228,
 241,
-296,
+296
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/artifacts.kt':[
-17,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/artifacts.kt": [
+17
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/dependencies.kt':[
-92,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/dependencies.kt": [
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/embeddable.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/embeddable.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/render.kt':[
-172,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/render.kt": [
+172
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/sourceSets.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/sourceSets.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/AndroidTestGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/AndroidTestGenerator.kt": [
 40,
-119,
+119
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/CodegenTestsOnAndroidGenerator.kt':[
-210,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/CodegenTestsOnAndroidGenerator.kt": [
+210
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend-common/src/org/jetbrains/kotlin/backend/common/DataClassMethodGenerator.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend-common/src/org/jetbrains/kotlin/backend/common/DataClassMethodGenerator.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/CollectionStubMethodGenerator.kt':[
-281,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/CollectionStubMethodGenerator.kt": [
+281
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/PropertyReferenceCodegen.kt':[
-100,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/PropertyReferenceCodegen.kt": [
+100
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ScriptCodegen.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ScriptCodegen.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/SourceInfo.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/SourceInfo.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/callableReferenceUtil.kt':[
-91,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/callableReferenceUtil.kt": [
+91
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/codegenUtil.kt':[
-157,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/codegenUtil.kt": [
+157
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/processUninitializedStores.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/processUninitializedStores.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt": [
 348,
 446,
 473,
 542,
-560,
+560
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AsmTypeRemapper.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AsmTypeRemapper.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt": [
 67,
 330,
 596,
-714,
+714
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/LocalVarRemapper.kt':[
-111,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/LocalVarRemapper.kt": [
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt": [
 88,
 159,
 207,
@@ -92,392 +92,392 @@
 318,
 482,
 488,
-692,
+692
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/ObjectTransformer.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/ObjectTransformer.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/ParametersBuilder.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/ParametersBuilder.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/RegeneratedLambdaFieldRemapper.kt':[
-79,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/RegeneratedLambdaFieldRemapper.kt": [
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/ReifiedTypeInliner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/ReifiedTypeInliner.kt": [
 176,
-196,
+196
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt": [
 27,
 84,
 232,
 321,
-343,
+343
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAPAndMethodNode.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAPAndMethodNode.kt": [
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SamWrapperTransformer.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SamWrapperTransformer.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SourceCompilerForInline.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SourceCompilerForInline.kt": [
 241,
-328,
+328
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt": [
 153,
 197,
-251,
+251
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/Concat.kt':[
-94,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/Concat.kt": [
+94
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/IntrinsicArrayConstructors.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/IntrinsicArrayConstructors.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/KClassJavaPrimitiveTypeProperty.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/KClassJavaPrimitiveTypeProperty.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InFloatingPointRangeLiteralExpressionGenerator.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InFloatingPointRangeLiteralExpressionGenerator.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/BuilderFactoryForDuplicateSignatureDiagnostics.kt':[
-190,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/BuilderFactoryForDuplicateSignatureDiagnostics.kt": [
+190
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/GenerationState.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/GenerationState.kt": [
 83,
-199,
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/SignatureDumpingBuilderFactory.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/SignatureDumpingBuilderFactory.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/typeMappingUtil.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/typeMappingUtil.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/argumentUtils.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/argumentUtils.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/BasicReplState.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/BasicReplState.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplCompilingEvaluator.kt':[
-85,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplCompilingEvaluator.kt": [
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplEvaluator.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplEvaluator.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/KotlinJsr223JvmInvocableScriptEngine.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/KotlinJsr223JvmInvocableScriptEngine.kt": [
 61,
-104,
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/KotlinJsr223JvmScriptEngineBase.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/KotlinJsr223JvmScriptEngineBase.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/ReplState.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/ReplState.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-runner/src/org/jetbrains/kotlin/runner/runners.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-runner/src/org/jetbrains/kotlin/runner/runners.kt": [
 95,
 103,
 110,
-117,
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/JvmRuntimeVersionsConsistencyChecker.kt':[
-252,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/JvmRuntimeVersionsConsistencyChecker.kt": [
+252
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CliTrace.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CliTrace.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CliVirtualFileFinderFactory.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CliVirtualFileFinderFactory.kt": [
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCliJavaFileManagerImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCliJavaFileManagerImpl.kt": [
 43,
-249,
+249
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt':[
-341,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt": [
+341
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinToJVMBytecodeCompiler.kt':[
-327,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinToJVMBytecodeCompiler.kt": [
+327
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/TopDownAnalyzerFacadeForJVM.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/TopDownAnalyzerFacadeForJVM.kt": [
 200,
 225,
 230,
-250,
+250
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/modules/CoreJrtVirtualFile.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/modules/CoreJrtVirtualFile.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/GenericReplChecker.kt':[
-100,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/GenericReplChecker.kt": [
+100
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplCodeAnalyzer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplCodeAnalyzer.kt": [
 170,
-171,
+171
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplInterpreter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplInterpreter.kt": [
 46,
 67,
-78,
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/metadata/K2MetadataCompiler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/metadata/K2MetadataCompiler.kt": [
 75,
-102,
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/metadata/MetadataSerializer.kt':[
-129,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/metadata/MetadataSerializer.kt": [
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Cache.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Cache.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/CompilerCallbackServicesFacadeServer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/CompilerCallbackServicesFacadeServer.kt": [
 51,
-68,
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt':[
-444,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt": [
+444
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinRemoteReplCompilerClient.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinRemoteReplCompilerClient.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/RemoteReplCompilerState.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/RemoteReplCompilerState.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/ClientUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/ClientUtils.kt": [
 47,
-48,
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompileService.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompileService.kt": [
 70,
 89,
-106,
+106
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt": [
 218,
 227,
 270,
-310,
+310
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/NetworkUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/NetworkUtils.kt": [
 53,
-60,
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/PerfUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/PerfUtils.kt": [
 91,
 103,
-121,
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/KotlinCompileDaemon.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/KotlinCompileDaemon.kt": [
 122,
 168,
-180,
+180
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/KotlinRemoteReplService.kt':[
-88,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/KotlinRemoteReplService.kt": [
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/LazyClasspathWatcher.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/LazyClasspathWatcher.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/components/FilesByFacadeFqNameIndexer.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/components/FilesByFacadeFqNameIndexer.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/annotationArgumentsImpl.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/annotationArgumentsImpl.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/classFiles/Annotations.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/classFiles/Annotations.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/classFiles/Other.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/classFiles/Other.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/classFiles/Types.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/classFiles/Types.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/kotlin/incremental/IncrementalPackagePartProvider.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/kotlin/incremental/IncrementalPackagePartProvider.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/JvmAnalyzerFacade.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/JvmAnalyzerFacade.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/RuntimeAssertions.kt':[
-191,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/RuntimeAssertions.kt": [
+191
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/InlinePlatformCompatibilityChecker.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/InlinePlatformCompatibilityChecker.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/ProtectedSyntheticExtensionCallChecker.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/ProtectedSyntheticExtensionCallChecker.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/UnsupportedSyntheticCallableReferenceChecker.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/UnsupportedSyntheticCallableReferenceChecker.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/extensions/PartialAnalysisHandlerExtension.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/extensions/PartialAnalysisHandlerExtension.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/synthetic/SamAdapterFunctionsScope.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/synthetic/SamAdapterFunctionsScope.kt": [
 93,
-174,
+174
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/KotlinScriptDefinitionFromAnnotatedTemplate.kt':[
-148,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/KotlinScriptDefinitionFromAnnotatedTemplate.kt": [
+148
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/ScriptContentLoader.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/ScriptContentLoader.kt": [
 40,
-44,
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/reflectionUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/reflectionUtil.kt": [
 36,
-83,
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/scriptAnnotationsPreprocessing.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/scriptAnnotationsPreprocessing.kt": [
 45,
-63,
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/scriptTemplate.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/scriptTemplate.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/scriptTypeUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/scriptTypeUtil.kt": [
 50,
 51,
-52,
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/analyzer/AnalyzerFacade.kt':[
-289,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/analyzer/AnalyzerFacade.kt": [
+289
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt": [
 155,
 745,
 939,
 1064,
 1323,
-1523,
+1523
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/PseudocodeVariablesData.kt':[
-419,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/PseudocodeVariablesData.kt": [
+419
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/ControlFlowInstructionsGenerator.kt':[
-313,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/ControlFlowInstructionsGenerator.kt": [
+313
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/TypePredicate.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/TypePredicate.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/Renderers.kt':[
-403,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/Renderers.kt": [
+403
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationChecker.kt": [
 47,
-132,
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/BindingContextUtils.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/BindingContextUtils.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationResolver.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationResolver.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt": [
 227,
-503,
+503
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegatedPropertyResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegatedPropertyResolver.kt": [
 55,
 298,
-435,
+435
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DescriptorToSourceUtils.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DescriptorToSourceUtils.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverloadResolver.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverloadResolver.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/QualifiedExpressionResolveUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/QualifiedExpressionResolveUtil.kt": [
 91,
-96,
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/QualifiedExpressionResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/QualifiedExpressionResolver.kt": [
 236,
-438,
+438
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeAliasExpander.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeAliasExpander.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeBinding.kt':[
-92,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeBinding.kt": [
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt": [
 169,
-548,
+548
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallCompleter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallCompleter.kt": [
 162,
 192,
-193,
+193
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallExpressionResolver.kt':[
-373,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallExpressionResolver.kt": [
+373
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt": [
 182,
 679,
 693,
-696,
+696
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/DiagnosticReporterByTrackingStrategy.kt':[
-195,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/DiagnosticReporterByTrackingStrategy.kt": [
+195
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/GenericCandidateResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/GenericCandidateResolver.kt": [
 88,
-449,
+449
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/ApiVersionCallChecker.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/ApiVersionCallChecker.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/DslScopeViolationCallChecker.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/DslScopeViolationCallChecker.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/LateinitIntrinsicApplicabilityChecker.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/LateinitIntrinsicApplicabilityChecker.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/ConstraintSystemBuilderImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/ConstraintSystemBuilderImpl.kt": [
 102,
-417,
+417
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/CoroutineInferenceUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/CoroutineInferenceUtil.kt": [
 143,
-164,
+164
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/TypeBoundsImpl.kt':[
-111,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/TypeBoundsImpl.kt": [
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/constraintIncorporation.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/constraintIncorporation.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/model/ArgumentMapping.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/model/ArgumentMapping.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/DelegatingDataFlowInfo.kt':[
-96,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/DelegatingDataFlowInfo.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/IdentifierInfo.kt':[
-193,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/IdentifierInfo.kt": [
+193
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/SmartCastManager.kt':[
-146,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/SmartCastManager.kt": [
+146
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/KotlinResolutionCallbacksImpl.kt':[
-179,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/KotlinResolutionCallbacksImpl.kt": [
+179
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/KotlinToResolvedCallTransformer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/KotlinToResolvedCallTransformer.kt": [
 202,
 228,
-584,
+584
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewCallArguments.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewCallArguments.kt": [
 93,
-297,
+297
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewResolutionOldInference.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewResolutionOldInference.kt": [
 133,
 237,
 275,
@@ -486,160 +486,160 @@
 439,
 519,
 529,
-537,
+537
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/PSICallResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/PSICallResolver.kt": [
 349,
 413,
 419,
 441,
-551,
+551
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/ResolvedAtomCompleter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/ResolvedAtomCompleter.kt": [
 165,
-227,
+227
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/ExpectedActualDeclarationChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/ExpectedActualDeclarationChecker.kt": [
 123,
 151,
-229,
+229
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt": [
 158,
 699,
-720,
+720
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/extensions/SyntheticResolveExtension.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/extensions/SyntheticResolveExtension.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/FileScopeFactory.kt':[
-126,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/FileScopeFactory.kt": [
+126
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyDeclarationResolver.kt':[
-164,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyDeclarationResolver.kt": [
+164
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyClassMemberScope.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyClassMemberScope.kt": [
 188,
 316,
-361,
+361
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyScriptDescriptor.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyScriptDescriptor.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/scopes/receivers/ExpressionReceiver.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/scopes/receivers/ExpressionReceiver.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/sinceKotlinUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/sinceKotlinUtil.kt": [
 61,
 73,
-78,
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt": [
 197,
 417,
 453,
-755,
+755
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/LabelResolver.kt':[
-147,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/LabelResolver.kt": [
+147
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/PatternMatchingTypingVisitor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/PatternMatchingTypingVisitor.kt": [
 98,
-529,
+529
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/BuildDiffsStorage.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/BuildDiffsStorage.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt": [
 107,
 212,
-233,
+233
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJsCompilerRunner.kt':[
-96,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJsCompilerRunner.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunner.kt": [
 171,
 210,
 275,
 359,
-363,
+363
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/InputsCache.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/InputsCache.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/AbstractIncrementalCompilerRunnerTestBase.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/AbstractIncrementalCompilerRunnerTestBase.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/CheckIrElementVisitor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/CheckIrElementVisitor.kt": [
 88,
-168,
+168
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/CommonBackendContext.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/CommonBackendContext.kt": [
 28,
-33,
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/IrValidator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/IrValidator.kt": [
 32,
 35,
 45,
-59,
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/TailRecursionCallsCollector.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/TailRecursionCallsCollector.kt": [
 104,
-131,
+131
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/Ir.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/Ir.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/AbstractClosureAnnotator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/AbstractClosureAnnotator.kt": [
 32,
 33,
-74,
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/InitializersLowering.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/InitializersLowering.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/InnerClassesLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/InnerClassesLowering.kt": [
 51,
 97,
 144,
 208,
-241,
+241
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/KCallableNamePropertyLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/KCallableNamePropertyLowering.kt": [
 51,
-82,
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt": [
 72,
 78,
 322,
 480,
-494,
+494
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalFunctionsLowering.kt':[
-163,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalFunctionsLowering.kt": [
+163
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/StringConcatenationLowering.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/StringConcatenationLowering.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsIntrinsics.kt':[
-96,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsIntrinsics.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsIrBackendContext.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsIrBackendContext.kt": [
 46,
 120,
-125,
+125
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/BlockDecomposerLowering.kt':[
-505,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/BlockDecomposerLowering.kt": [
+505
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/CallableReferenceLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/CallableReferenceLowering.kt": [
 160,
-226,
+226
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/IntrinsicifyCallsLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/IntrinsicifyCallsLowering.kt": [
 32,
 86,
 88,
@@ -648,51 +648,51 @@
 154,
 176,
 193,
-216,
+216
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/SecondaryCtorLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/SecondaryCtorLowering.kt": [
 55,
-199,
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/IrElementToJsExpressionTransformer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/IrElementToJsExpressionTransformer.kt": [
 23,
 94,
 114,
 178,
-186,
+186
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/IrElementToJsStatementTransformer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/IrElementToJsStatementTransformer.kt": [
 17,
 34,
 72,
 81,
-88,
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/JsIntrinsicTransformers.kt':[
-96,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/JsIntrinsicTransformers.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/jsCode.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/jsCode.kt": [
 16,
-39,
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/JsStaticContext.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/JsStaticContext.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt": [
 125,
-130,
+130
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendFacade.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendFacade.kt": [
 46,
-57,
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt':[
-142,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt": [
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt": [
 101,
 339,
 530,
@@ -704,19 +704,19 @@
 1051,
 1055,
 1064,
-1068,
+1068
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt": [
 88,
 92,
-112,
+112
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt": [
 68,
 99,
-117,
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrSourceCompilerForInline.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrSourceCompilerForInline.kt": [
 49,
 53,
 77,
@@ -727,725 +727,725 @@
 145,
 150,
 161,
-166,
+166
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/descriptors/JvmDescriptorsFactory.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/descriptors/JvmDescriptorsFactory.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Concat.kt':[
-128,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Concat.kt": [
+128
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Equals.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Equals.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Inv.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Inv.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IsArrayOf.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IsArrayOf.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/MonitorInstruction.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/MonitorInstruction.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/UnaryMinus.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/UnaryMinus.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt": [
 87,
 195,
-213,
+213
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/EnumClassLowering.kt':[
-399,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/EnumClassLowering.kt": [
+399
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/InterfaceLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/InterfaceLowering.kt": [
 69,
-141,
+141
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/ObjectClassLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/ObjectClassLowering.kt": [
 66,
-70,
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt": [
 178,
 192,
-319,
+319
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/descriptorUtils.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/descriptorUtils.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/AssignmentGenerator.kt':[
-179,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/AssignmentGenerator.kt": [
+179
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/BranchingExpressionGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/BranchingExpressionGenerator.kt": [
 93,
 132,
-143,
+143
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ClassGenerator.kt':[
-252,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ClassGenerator.kt": [
+252
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/DataClassMembersGenerator.kt':[
-177,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/DataClassMembersGenerator.kt": [
+177
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ErrorExpressionGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ErrorExpressionGenerator.kt": [
 48,
-69,
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/GeneratorContext.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/GeneratorContext.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/OperatorExpressionGenerator.kt':[
-315,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/OperatorExpressionGenerator.kt": [
+315
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/intermediate/CallBuilder.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/intermediate/CallBuilder.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/types/TypeTranslator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/types/TypeTranslator.kt": [
 86,
-92,
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrAnonymousInitializer.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrAnonymousInitializer.kt": [
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/impl/IrModuleFragmentImpl.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/impl/IrModuleFragmentImpl.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrPropertyAccessorCall.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrPropertyAccessorCall.kt": [
 112,
-194,
+194
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeclarationStubGenerator.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeclarationStubGenerator.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeepCopyIrTree.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeepCopyIrTree.kt": [
 240,
-241,
+241
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeepCopyIrTreeWithSymbols.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeepCopyIrTreeWithSymbols.kt": [
 358,
-418,
+418
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrUtils.kt": [
 36,
 182,
-218,
+218
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/wrappers/symbols/symbolBasedAnnotationArguments.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/wrappers/symbols/symbolBasedAnnotationArguments.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/wrappers/trees/TreeBasedAnnotation.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/wrappers/trees/TreeBasedAnnotation.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/builder/LightClassDataProvider.kt':[
-186,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/builder/LightClassDataProvider.kt": [
+186
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForFacade.kt':[
-268,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForFacade.kt": [
+268
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForSourceDeclaration.kt':[
-172,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForSourceDeclaration.kt": [
+172
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/duplicateJvmSignatureUtil.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/duplicateJvmSignatureUtil.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/FakeFileForLightClass.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/FakeFileForLightClass.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/KtLightPsiReferenceList.kt':[
-85,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/KtLightPsiReferenceList.kt": [
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt':[
-830,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt": [
+830
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/createByPattern.kt':[
-131,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/createByPattern.kt": [
+131
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/script/KotlinScriptDefinition.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/script/KotlinScriptDefinition.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/script/KotlinScriptDefinitionProvider.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/script/KotlinScriptDefinitionProvider.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/model/functors/EqualsFunctor.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/model/functors/EqualsFunctor.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/KotlinCallResolver.kt':[
-139,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/KotlinCallResolver.kt": [
+139
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/AdditionalDiagnosticReporter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/AdditionalDiagnosticReporter.kt": [
 27,
-63,
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/CallableReferenceResolution.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/CallableReferenceResolution.kt": [
 53,
-204,
+204
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/CallableReferenceResolver.kt':[
-94,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/CallableReferenceResolver.kt": [
+94
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/NewOverloadingConflictResolver.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/NewOverloadingConflictResolver.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/PostponeArgumentsChecks.kt':[
-154,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/PostponeArgumentsChecks.kt": [
+154
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/SimpleArgumentsChecks.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/SimpleArgumentsChecks.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/ConstraintIncorporator.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/ConstraintIncorporator.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/ConstraintInjector.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/ConstraintInjector.kt": [
 129,
-170,
+170
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/NewTypeSubstitutor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/NewTypeSubstitutor.kt": [
 34,
-129,
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/TypeCheckerContextForConstraintSystem.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/TypeCheckerContextForConstraintSystem.kt": [
 33,
 195,
 201,
-220,
+220
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/model/TypeVariable.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/model/TypeVariable.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/KotlinCallArguments.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/KotlinCallArguments.kt": [
 25,
 106,
-125,
+125
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/KotlinResolverContext.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/KotlinResolverContext.kt": [
 73,
-79,
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/ResolutionAtoms.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/ResolutionAtoms.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/ResolutionCandidate.kt':[
-73,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/ResolutionCandidate.kt": [
+73
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/FlatSignature.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/FlatSignature.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/OverloadingConflictResolver.kt':[
-403,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/OverloadingConflictResolver.kt": [
+403
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ImplicitScopeTower.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ImplicitScopeTower.kt": [
 89,
-101,
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/InvokeProcessors.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/InvokeProcessors.kt": [
 32,
 98,
 114,
 204,
 209,
-240,
+240
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/TowerLevels.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/TowerLevels.kt": [
 80,
-81,
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt": [
 50,
 74,
 86,
 90,
-481,
+481
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/scopes/LexicalScopeStorage.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/scopes/LexicalScopeStorage.kt": [
 66,
-77,
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/scopes/SubpackagesImportingScope.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/scopes/SubpackagesImportingScope.kt": [
 42,
-51,
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/scopes/utils/ScopeUtils.kt':[
-79,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/scopes/utils/ScopeUtils.kt": [
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/types/TypeApproximator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/types/TypeApproximator.kt": [
 138,
 256,
-281,
+281
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/ContractSerializer.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/ContractSerializer.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractDiagnosticsTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractDiagnosticsTest.kt": [
 110,
 307,
 332,
 336,
-379,
+379
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractDiagnosticsTestWithJsStdLib.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractDiagnosticsTestWithJsStdLib.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/BaseDiagnosticsTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/BaseDiagnosticsTest.kt": [
 151,
 218,
-223,
+223
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/ir/AbstractIrBlackBoxCodegenTest.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/ir/AbstractIrBlackBoxCodegenTest.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/codegen/AbstractCustomScriptCodegenTest.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/codegen/AbstractCustomScriptCodegenTest.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/codegen/BridgeTest.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/codegen/BridgeTest.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt": [
 240,
 256,
 365,
-420,
+420
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/multiplatform/AbstractMultiPlatformIntegrationTest.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/multiplatform/AbstractMultiPlatformIntegrationTest.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTemplateTest.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTemplateTest.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/util/src/org/jetbrains/kotlin/config/LanguageVersionSettings.kt':[
-109,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/util/src/org/jetbrains/kotlin/config/LanguageVersionSettings.kt": [
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/util/src/org/jetbrains/kotlin/utils/KotlinJavascriptMetadataUtils.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/util/src/org/jetbrains/kotlin/utils/KotlinJavascriptMetadataUtils.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/builtins/JvmBuiltInsPackageFragmentProvider.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/builtins/JvmBuiltInsPackageFragmentProvider.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/JavaIncompatibilityRulesOverridabilityCondition.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/JavaIncompatibilityRulesOverridabilityCondition.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaClassDescriptor.kt':[
-234,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaClassDescriptor.kt": [
+234
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaScope.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaScope.kt": [
 198,
-205,
+205
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/typeEnhancement/signatureEnhancement.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/typeEnhancement/signatureEnhancement.kt": [
 114,
 115,
 116,
 340,
-408,
+408
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/AbstractBinaryClassAnnotationAndConstantLoader.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/AbstractBinaryClassAnnotationAndConstantLoader.kt": [
 108,
-218,
+218
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/DeserializedDescriptorResolver.kt':[
-107,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/DeserializedDescriptorResolver.kt": [
+107
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/KotlinJvmBinaryClass.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/KotlinJvmBinaryClass.kt": [
 39,
-57,
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/header/KotlinClassHeader.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/header/KotlinClassHeader.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/platform/JavaToKotlinClassMap.kt':[
-91,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/platform/JavaToKotlinClassMap.kt": [
+91
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/components/ReflectKotlinClassFinder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/components/ReflectKotlinClassFinder.kt": [
 34,
 38,
 41,
-44,
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/components/RuntimeErrorReporter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/components/RuntimeErrorReporter.kt": [
 24,
-30,
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/components/RuntimePackagePartProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/components/RuntimePackagePartProvider.kt": [
 36,
 46,
-50,
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/structure/ReflectJavaClassifierType.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/structure/ReflectJavaClassifierType.kt": [
 54,
-58,
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/structure/ReflectJavaConstructor.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/structure/ReflectJavaConstructor.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/structure/ReflectJavaPackage.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/structure/ReflectJavaPackage.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/functionTypes.kt':[
-201,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/functionTypes.kt": [
+201
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/functions/BuiltInFictitiousFunctionClassFactory.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/functions/BuiltInFictitiousFunctionClassFactory.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/suspendFunctionTypes.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/suspendFunctionTypes.kt": [
 77,
-102,
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/findClassInModule.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/findClassInModule.kt": [
 46,
-47,
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/AbstractTypeAliasDescriptor.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/AbstractTypeAliasDescriptor.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/ValueParameterDescriptorImpl.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/ValueParameterDescriptorImpl.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/incremental/components/LookupLocation.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/incremental/components/LookupLocation.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererImpl.kt':[
-127,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererImpl.kt": [
+127
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererOptionsImpl.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererOptionsImpl.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/DescriptorUtils.kt':[
-370,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/DescriptorUtils.kt": [
+370
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/calls/inference/CapturedTypeConstructor.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/calls/inference/CapturedTypeConstructor.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/constants/constantValues.kt':[
-85,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/constants/constantValues.kt": [
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/scopes/StaticScopeForKotlinEnum.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/scopes/StaticScopeForKotlinEnum.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/AbstractTypeConstructor.kt':[
-73,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/AbstractTypeConstructor.kt": [
+73
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/CapturedTypeApproximation.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/CapturedTypeApproximation.kt": [
 87,
-108,
+108
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/KotlinType.kt':[
-108,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/KotlinType.kt": [
+108
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/IntersectionType.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/IntersectionType.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewCapturedType.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewCapturedType.kt": [
 42,
 88,
 122,
 129,
-138,
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewKotlinTypeChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewKotlinTypeChecker.kt": [
 91,
 207,
 234,
 255,
 282,
 371,
-381,
+381
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/builtins/BuiltInsPackageFragmentImpl.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/builtins/BuiltInsPackageFragmentImpl.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/AnnotationAndConstantLoader.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/AnnotationAndConstantLoader.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/AnnotationDeserializer.kt':[
-150,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/AnnotationDeserializer.kt": [
+150
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/MemberDeserializer.kt':[
-288,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/MemberDeserializer.kt": [
+288
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/MetadataPackageFragmentProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/MetadataPackageFragmentProvider.kt": [
 50,
 119,
-127,
+127
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/TypeDeserializer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/TypeDeserializer.kt": [
 50,
-179,
+179
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedClassDescriptor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedClassDescriptor.kt": [
 196,
 250,
-257,
+257
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedMemberDescriptor.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedMemberDescriptor.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/deserialization/ModuleMapping.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/deserialization/ModuleMapping.kt": [
 83,
-89,
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/serialization/JvmStringTable.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/serialization/JvmStringTable.kt": [
 14,
-81,
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata/src/org/jetbrains/kotlin/metadata/deserialization/protoTypeTableUtil.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata/src/org/jetbrains/kotlin/metadata/deserialization/protoTypeTableUtil.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/full/KClasses.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/full/KClasses.kt": [
 205,
-279,
+279
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/full/KClassifiers.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/full/KClassifiers.kt": [
 53,
 57,
-94,
+94
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/ReflectJvmMapping.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/ReflectJvmMapping.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/AnnotationConstructorCaller.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/AnnotationConstructorCaller.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/FunctionCaller.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/FunctionCaller.kt": [
 70,
-278,
+278
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KClassImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KClassImpl.kt": [
 202,
-229,
+229
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KDeclarationContainerImpl.kt':[
-125,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KDeclarationContainerImpl.kt": [
+125
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPackageImpl.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPackageImpl.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt": [
 152,
-165,
+165
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KTypeImpl.kt':[
-88,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KTypeImpl.kt": [
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ReflectionObjectRenderer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ReflectionObjectRenderer.kt": [
 55,
-74,
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/RuntimeTypeMapper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/RuntimeTypeMapper.kt": [
 168,
-257,
+257
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/kClassCache.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/kClassCache.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/moduleByClassLoader.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/moduleByClassLoader.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/util.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/util.kt": [
 112,
-139,
+139
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreter.kt": [
 146,
-196,
+196
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt':[
-164,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt": [
+164
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/test/main.kt':[
-285,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/test/main.kt": [
+285
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/builtins/unsignedTypes.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/builtins/unsignedTypes.kt": [
 234,
-242,
+242
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt':[
-896,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt": [
+896
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt": [
 229,
-436,
+436
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinSpacingBuilder.kt':[
-141,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinSpacingBuilder.kt": [
+141
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt':[
-544,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt": [
+544
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/caches/resolve/resolutionApi.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/caches/resolve/resolutionApi.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/codeInsight/ReferenceVariantsHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/codeInsight/ReferenceVariantsHelper.kt": [
 172,
-407,
+407
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/kdoc/resolveKDocLink.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/kdoc/resolveKDocLink.kt": [
 63,
-138,
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/ImportInsertHelper.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/ImportInsertHelper.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/OptimizedImportsBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/OptimizedImportsBuilder.kt": [
 88,
 112,
 113,
-319,
+319
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/ShadowedDeclarationsFilter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/ShadowedDeclarationsFilter.kt": [
 62,
-175,
+175
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/Utils.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/Utils.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/scopeUtils.kt':[
-83,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/scopeUtils.kt": [
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt": [
 30,
 74,
 115,
 256,
 481,
 536,
-542,
+542
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/util/TypeIndexUtil.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/util/TypeIndexUtil.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/KotlinIconProvider.kt':[
-106,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/KotlinIconProvider.kt": [
+106
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/MapPsiToAsmDesc.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/MapPsiToAsmDesc.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/IdeaModuleInfos.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/IdeaModuleInfos.kt": [
 189,
 332,
 352,
-380,
+380
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/ScriptModuleInfos.kt':[
-138,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/ScriptModuleInfos.kt": [
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/moduleInfosFromIdeaModel.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/moduleInfosFromIdeaModel.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/CodeFragmentAnalyzer.kt':[
-83,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/CodeFragmentAnalyzer.kt": [
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/IDEKotlinAsJavaSupport.kt':[
-192,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/IDEKotlinAsJavaSupport.kt": [
+192
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/KotlinCacheServiceImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/KotlinCacheServiceImpl.kt": [
 91,
 115,
-308,
+308
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/KtFileClassProviderImpl.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/KtFileClassProviderImpl.kt": [
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/ModuleResolutionFacadeImpl.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/ModuleResolutionFacadeImpl.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/PerFileAnalysisCache.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/PerFileAnalysisCache.kt": [
 131,
 188,
-218,
+218
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/ProjectResolutionFacade.kt':[
-189,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/ProjectResolutionFacade.kt": [
+189
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/codeInsight/shorten/delayedRequestsWaitingSet.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/codeInsight/shorten/delayedRequestsWaitingSet.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/compiler/IDELanguageSettingsProvider.kt':[
-83,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/compiler/IDELanguageSettingsProvider.kt": [
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/compiler/IdeModuleAnnotationsResolver.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/compiler/IdeModuleAnnotationsResolver.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/classFile/DeserializerForClassfileDecompiler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/classFile/DeserializerForClassfileDecompiler.kt": [
 119,
 122,
+125
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/navigation/findDecompiledDeclaration.kt": [
+51
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/stubBuilder/CallableClsStubBuilder.kt": [
+86
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/stubBuilder/ClassClsStubBuilder.kt": [
+130
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/stubBuilder/TypeClsStubBuilder.kt": [
+35
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/textBuilder/buildDecompiledText.kt": [
+141
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/DebugInfoAnnotator.kt": [
+66
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/AbstractResultUnusedChecker.kt": [
+30
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/intentions/OperatorToFunctionIntention.kt": [
 125,
+208
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/navigation/findDecompiledDeclaration.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/IdeSampleResolutionService.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/stubBuilder/CallableClsStubBuilder.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/Platform.kt": [
+183
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/stubBuilder/ClassClsStubBuilder.kt':[
-130,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt": [
+234
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/stubBuilder/TypeClsStubBuilder.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/KtDestructuringDeclarationReference.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/textBuilder/buildDecompiledText.kt':[
-141,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/KtSimpleNameReference.kt": [
+177
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/DebugInfoAnnotator.kt':[
-66,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/AbstractResultUnusedChecker.kt':[
-30,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/intentions/OperatorToFunctionIntention.kt':[
-125,
-208,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/IdeSampleResolutionService.kt':[
-53,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/Platform.kt':[
-183,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt':[
-234,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/KtDestructuringDeclarationReference.kt':[
-38,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/KtSimpleNameReference.kt':[
-177,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/SyntheticPropertyAccessorReference.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/SyntheticPropertyAccessorReference.kt": [
 81,
 82,
-85,
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/referenceUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/referenceUtil.kt": [
 144,
-282,
+282
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinReadWriteAccessDetector.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinReadWriteAccessDetector.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt": [
 64,
 480,
 556,
 665,
 824,
-884,
+884
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/OperatorReferenceSearcher.kt':[
-224,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/OperatorReferenceSearcher.kt": [
+224
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/utils.kt':[
-156,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/utils.kt": [
+156
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/structureView/KtClsStructureViewBuilderProvider.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/structureView/KtClsStructureViewBuilderProvider.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/stubindex/StaticFacadeIndexUtil.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/stubindex/StaticFacadeIndexUtil.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/CommentSaver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/CommentSaver.kt": [
 30,
 31,
 341,
@@ -1453,374 +1453,374 @@
 389,
 410,
 439,
-473,
+473
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/expectActualUtil.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/expectActualUtil.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/vfilefinder/IDEVirtualFileFinder.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/vfilefinder/IDEVirtualFileFinder.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/ParcelableUtil.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/ParcelableUtil.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/AllClassesCompletion.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/AllClassesCompletion.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt':[
-269,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt": [
+269
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt':[
-327,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt": [
+327
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionBindingContextProvider.kt':[
-129,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionBindingContextProvider.kt": [
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionUtils.kt':[
-293,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionUtils.kt": [
+293
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/LambdaSignatureTemplates.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/LambdaSignatureTemplates.kt": [
 152,
-161,
+161
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/LookupElementFactory.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/LookupElementFactory.kt": [
 154,
 155,
-216,
+216
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/ReferenceVariantsCollector.kt':[
-210,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/ReferenceVariantsCollector.kt": [
+210
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/StaticMembersCompletion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/StaticMembersCompletion.kt": [
 93,
 94,
 95,
-96,
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/ToFromOriginalFileMapper.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/ToFromOriginalFileMapper.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinFunctionInsertHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinFunctionInsertHandler.kt": [
 55,
-86,
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/WithTailInsertHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/WithTailInsertHandler.kt": [
 44,
 57,
 100,
-105,
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/MultipleArgumentsItemProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/MultipleArgumentsItemProvider.kt": [
 92,
-109,
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt": [
 101,
-367,
+367
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/TypeInstantiationItems.kt':[
-220,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/TypeInstantiationItems.kt": [
+220
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/Utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/Utils.kt": [
 250,
-322,
+322
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/KotlinFixtureCompletionBaseTestCase.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/KotlinFixtureCompletionBaseTestCase.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ExpectedInfos.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ExpectedInfos.kt": [
 111,
-203,
+203
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ImportableFqNameClassifier.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ImportableFqNameClassifier.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt':[
-481,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt": [
+481
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/OptionalParametersHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/OptionalParametersHelper.kt": [
 54,
 73,
 87,
 125,
 126,
 131,
-132,
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ShortenReferences.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ShortenReferences.kt": [
 46,
 140,
 481,
 639,
-661,
+661
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt": [
 187,
 235,
-247,
+247
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/IdeScriptReportSink.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/IdeScriptReportSink.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDefinitionsManager.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDefinitionsManager.kt": [
 132,
 140,
 159,
-174,
+174
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDependenciesManager.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDependenciesManager.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptTemplatesProvider.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptTemplatesProvider.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/dependencies/KotlinScriptResolveScopeProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/dependencies/KotlinScriptResolveScopeProvider.kt": [
 36,
-42,
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/templates.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/templates.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinDslGradleKotlinFrameworkSupportProvider.kt':[
-90,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinDslGradleKotlinFrameworkSupportProvider.kt": [
+90
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/gradleModuleBuilderUtils.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/gradleModuleBuilderUtils.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/core/script/GradleScriptTemplateProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/core/script/GradleScriptTemplateProvider.kt": [
 92,
 137,
 150,
-200,
+200
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jps-common/src/org/jetbrains/kotlin/config/KotlinFacetSettings.kt':[
-128,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jps-common/src/org/jetbrains/kotlin/config/KotlinFacetSettings.kt": [
+128
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/compiler/configuration/KotlinBuildProcessParametersProvider.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/compiler/configuration/KotlinBuildProcessParametersProvider.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinInProjectUtils.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinInProjectUtils.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/coverage/KotlinCoverageExtension.kt':[
-71,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/coverage/KotlinCoverageExtension.kt": [
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/NoStrataPositionManagerHelper.kt':[
-335,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/NoStrataPositionManagerHelper.kt": [
+335
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/KotlinFieldBreakpoint.kt':[
-256,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/KotlinFieldBreakpoint.kt": [
+256
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinEvaluationBuilder.kt':[
-625,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinEvaluationBuilder.kt": [
+625
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/filter/KotlinSyntheticTypeComponentProvider.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/filter/KotlinSyntheticTypeComponentProvider.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinBasicStepMethodFilter.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinBasicStepMethodFilter.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSmartStepIntoHandler.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSmartStepIntoHandler.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinStepActionFactory.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinStepActionFactory.kt": [
 49,
 53,
 61,
-129,
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/facet/FrameworkLibraryValidatorWithDynamicDescription.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/facet/FrameworkLibraryValidatorWithDynamicDescription.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/framework/CommonStandardLibraryDescription.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/framework/CommonStandardLibraryDescription.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/internal/KotlinBytecodeToolWindow.kt':[
-194,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/internal/KotlinBytecodeToolWindow.kt": [
+194
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/run/KotlinJUnitRunConfigurationProducer.kt':[
-140,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/run/KotlinJUnitRunConfigurationProducer.kt": [
+140
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/KtScratchFile.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/KtScratchFile.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/versions/KotlinJVMRuntimeLibraryUtil.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/versions/KotlinJVMRuntimeLibraryUtil.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/src/org/jetbrains/kotlin/idea/liveTemplates/macro/AnonymousTemplateEditingListener.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/src/org/jetbrains/kotlin/idea/liveTemplates/macro/AnonymousTemplateEditingListener.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/KotlinMavenImporter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/KotlinMavenImporter.kt": [
 127,
-297,
+297
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/PomFile.kt':[
-278,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/PomFile.kt": [
+278
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/configuration/KotlinMavenConfigurator.kt':[
-159,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/configuration/KotlinMavenConfigurator.kt": [
+159
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/jsr223/KotlinJsr223JvmScriptEngine4Idea.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/jsr223/KotlinJsr223JvmScriptEngine4Idea.kt": [
 36,
-86,
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-test-framework/test/org/jetbrains/kotlin/idea/test/DirectiveBasedActionUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-test-framework/test/org/jetbrains/kotlin/idea/test/DirectiveBasedActionUtils.kt": [
+52
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/FindImplicitNothingAction.kt": [
+84
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CallableUsageReplacementStrategy.kt": [
+46
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/ClassUsageReplacementStrategy.kt": [
 52,
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/FindImplicitNothingAction.kt':[
-84,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CallableUsageReplacementStrategy.kt':[
-46,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/ClassUsageReplacementStrategy.kt':[
-52,
-64,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt": [
 200,
 255,
 381,
 425,
 488,
-549,
+549
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeToInlineBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeToInlineBuilder.kt": [
 51,
-152,
+152
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/ReplacementPerformer.kt':[
-187,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/ReplacementPerformer.kt": [
+187
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/UsageReplacementStrategy.kt':[
-131,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/UsageReplacementStrategy.kt": [
+131
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt": [
 124,
 289,
 372,
-455,
+455
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinCopyPasteReferenceProcessor.kt':[
-345,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinCopyPasteReferenceProcessor.kt": [
+345
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinMoveLeftRightHandler.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinMoveLeftRightHandler.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/ConvertTextJavaCopyPasteProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/ConvertTextJavaCopyPasteProcessor.kt": [
 92,
-231,
+231
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/DataForConversion.kt':[
-256,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/DataForConversion.kt": [
+256
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindMemberUsagesHandler.kt':[
-151,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindMemberUsagesHandler.kt": [
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinFormattingModelBuilder.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinFormattingModelBuilder.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/imports/KotlinImportOptimizer.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/imports/KotlinImportOptimizer.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ConflictingExtensionPropertyInspection.kt':[
-222,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ConflictingExtensionPropertyInspection.kt": [
+222
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/DeprecatedCallableAddReplaceWithInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/DeprecatedCallableAddReplaceWithInspection.kt": [
 90,
 117,
 137,
-175,
+175
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceWithOperatorAssignmentInspection.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceWithOperatorAssignmentInspection.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedLambdaExpressionBodyInspection.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedLambdaExpressionBodyInspection.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UseExpressionBodyInspection.kt':[
-117,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UseExpressionBodyInspection.kt": [
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ChangeVisibilityModifierIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ChangeVisibilityModifierIntention.kt": [
 81,
-109,
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ChooseValueExpression.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ChooseValueExpression.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertForEachToForLoopIntention.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertForEachToForLoopIntention.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertSealedClassToEnumIntention.kt':[
-146,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertSealedClassToEnumIntention.kt": [
+146
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/CreateKotlinSubClassIntention.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/CreateKotlinSubClassIntention.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/DestructureIntention.kt':[
-256,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/DestructureIntention.kt": [
+256
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ImportAllMembersIntention.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ImportAllMembersIntention.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ImportMemberIntention.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ImportMemberIntention.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/InvertIfConditionIntention.kt':[
-133,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/InvertIfConditionIntention.kt": [
+133
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SpecifyTypeExplicitlyIntention.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SpecifyTypeExplicitlyIntention.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/UsePropertyAccessSyntaxIntention.kt':[
-258,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/UsePropertyAccessSyntaxIntention.kt": [
+258
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/IfThenUtils.kt':[
-245,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/IfThenUtils.kt": [
+245
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/IfThenToDoubleBangIntention.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/IfThenToDoubleBangIntention.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/declarations/ConvertMemberToExtensionIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/declarations/ConvertMemberToExtensionIntention.kt": [
 67,
-181,
+181
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/commonUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/commonUtils.kt": [
 79,
 99,
-142,
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt": [
 61,
-241,
+241
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/AddToCollectionTransformation.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/AddToCollectionTransformation.kt": [
 100,
 112,
 127,
 368,
-402,
+402
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt':[
-242,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt": [
+242
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/ForEachTransformation.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/ForEachTransformation.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/Condition.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/Condition.kt": [
 33,
-45,
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/FilterTransformation.kt':[
-358,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/FilterTransformation.kt": [
+358
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/IntroduceIndexMatcher.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/IntroduceIndexMatcher.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/MapTransformation.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/MapTransformation.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/utils.kt": [
 154,
 205,
 306,
@@ -1828,231 +1828,231 @@
 348,
 366,
 370,
-371,
+371
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/joinLines/JoinDeclarationAndAssignmentHandler.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/joinLines/JoinDeclarationAndAssignmentHandler.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinFunctionParameterInfoHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinFunctionParameterInfoHandler.kt": [
 114,
-245,
+245
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/presentation/KtLightClassListCellRenderer.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/presentation/KtLightClassListCellRenderer.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionToSupertypeFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionToSupertypeFix.kt": [
 165,
-195,
+195
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddGenericUpperBoundFix.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddGenericUpperBoundFix.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddLoopLabelFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddLoopLabelFix.kt": [
 48,
-55,
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeMemberFunctionSignatureFix.kt':[
-264,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeMemberFunctionSignatureFix.kt": [
+264
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/CleanupFix.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/CleanupFix.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ImportFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ImportFix.kt": [
 381,
-599,
+599
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/InitializePropertyQuickFixFactory.kt':[
-160,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/InitializePropertyQuickFixFactory.kt": [
+160
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/KotlinReferenceImporter.kt':[
-79,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/KotlinReferenceImporter.kt": [
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt": [
 49,
-228,
+228
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveModifierFix.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveModifierFix.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/SuperClassNotInitialized.kt':[
-119,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/SuperClassNotInitialized.kt": [
+119
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
 487,
 952,
-1030,
+1030
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableFromUsageFix.kt':[
-156,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableFromUsageFix.kt": [
+156
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateDataClassPropertyFromDestructuringActionFactory.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateDataClassPropertyFromDestructuringActionFactory.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createVariable/CreateParameterByRefActionFactory.kt':[
-78,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createVariable/CreateParameterByRefActionFactory.kt": [
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/crossLanguage/KotlinElementActionsFactory.kt':[
-251,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/crossLanguage/KotlinElementActionsFactory.kt": [
+251
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageFixBase.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageFixBase.kt": [
 55,
-185,
+185
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageInWholeProjectFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageInWholeProjectFix.kt": [
 61,
-67,
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/ReplaceWithAnnotationAnalyzer.kt':[
-144,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/ReplaceWithAnnotationAnalyzer.kt": [
+144
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt':[
-427,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt": [
+427
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignature.kt':[
-170,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignature.kt": [
+170
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt": [
 514,
-641,
+641
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt": [
 99,
 103,
-395,
+395
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/cutPaste/MoveDeclarationsProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/cutPaste/MoveDeclarationsProcessor.kt": [
 96,
-102,
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementSelectionUtils.kt':[
-258,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementSelectionUtils.kt": [
+258
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/inline/KotlinInlineFunctionHandler.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/inline/KotlinInlineFunctionHandler.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/inline/KotlinInlineValHandler.kt':[
-132,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/inline/KotlinInlineValHandler.kt": [
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractorUtil.kt':[
-567,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractorUtil.kt": [
+567
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt':[
-621,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt": [
+621
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt':[
-642,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt": [
+642
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsHandler.kt": [
 88,
-142,
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/JavaToKotlinPostconversionPullUpHelper.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/JavaToKotlinPostconversionPullUpHelper.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt": [
 85,
-383,
+383
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/pullUpUtils.kt':[
-99,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/pullUpUtils.kt": [
+99
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinPropertyProcessor.kt':[
-376,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinPropertyProcessor.kt": [
+376
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameConflictUtils.kt':[
-214,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameConflictUtils.kt": [
+214
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/utils.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/utils.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/script/scriptsTemplatesFromDependencies.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/script/scriptsTemplatesFromDependencies.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/Slicer.kt':[
-455,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/Slicer.kt": [
+455
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/testIntegration/KotlinCreateTestIntention.kt':[
-138,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/testIntegration/KotlinCreateTestIntention.kt": [
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/testIntegration/KotlinTestFinder.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/testIntegration/KotlinTestFinder.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ImportInsertHelperImpl.kt':[
-381,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ImportInsertHelperImpl.kt": [
+381
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/versions/KotlinRuntimeLibraryUtil.kt':[
-273,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/versions/KotlinRuntimeLibraryUtil.kt": [
+273
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/findUsages/AbstractFindUsagesTest.kt':[
-315,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/findUsages/AbstractFindUsagesTest.kt": [
+315
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/smartEnter/SmartEnterTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/smartEnter/SmartEnterTest.kt": [
 151,
-243,
+243
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinInTempDirTest.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinInTempDirTest.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/evaluate/AbstractKotlinEvaluateExpressionTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/evaluate/AbstractKotlinEvaluateExpressionTest.kt": [
 231,
-307,
+307
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/filters/AbstractKotlinExceptionFilterTest.kt':[
-133,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/filters/AbstractKotlinExceptionFilterTest.kt": [
+133
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/highlighter/NoErrorsInStdlibTest.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/highlighter/NoErrorsInStdlibTest.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/navigation/GotoCheck.kt':[
-75,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/navigation/GotoCheck.kt": [
+75
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/psi/KotlinInjectionTest.kt':[
-196,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/psi/KotlinInjectionTest.kt": [
+196
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/AnnotationConverter.kt':[
-139,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/AnnotationConverter.kt": [
+139
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ConstructorConverter.kt':[
-249,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ConstructorConverter.kt": [
+249
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt": [
 355,
 362,
 384,
-635,
+635
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt':[
-815,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt": [
+815
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ForConverter.kt':[
-194,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ForConverter.kt": [
+194
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/JavaToKotlinTranslator.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/JavaToKotlinTranslator.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/SwitchConverter.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/SwitchConverter.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt": [
 401,
 430,
-432,
+432
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeVisitor.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeVisitor.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Utils.kt": [
 71,
-131,
+131
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Types.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Types.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/importConversion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/importConversion.kt": [
 71,
-165,
+165
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/propertyDetection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/propertyDetection.kt": [
 59,
 71,
 114,
@@ -2063,342 +2063,342 @@
 340,
 352,
 376,
-428,
+428
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/usageProcessing/FieldToPropertyProcessing.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/usageProcessing/FieldToPropertyProcessing.kt": [
 57,
 76,
 106,
-124,
+124
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/tests/org/jetbrains/kotlin/j2k/AbstractJavaToKotlinConverterMultiFileTest.kt':[
-81,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/tests/org/jetbrains/kotlin/j2k/AbstractJavaToKotlinConverterMultiFileTest.kt": [
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTest.kt':[
-1137,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTest.kt": [
+1137
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/SimpleKotlinJpsBuildTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/SimpleKotlinJpsBuildTest.kt": [
 67,
-90,
+90
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/JpsKotlinCompilerRunner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/JpsKotlinCompilerRunner.kt": [
 55,
-210,
+210
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/KotlinBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/KotlinBuilder.kt": [
 155,
 879,
-891,
+891
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/KotlinSourceFileCollector.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/KotlinSourceFileCollector.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/platforms/TargetPlatform.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/platforms/TargetPlatform.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.ast/src/org/jetbrains/kotlin/js/backend/ast/metadata/metadataProperties.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.ast/src/org/jetbrains/kotlin/js/backend/ast/metadata/metadataProperties.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/patterns/typePredicates/typePredicates.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/patterns/typePredicates/typePredicates.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/ExpressionDecomposer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/ExpressionDecomposer.kt": [
 79,
 151,
-424,
+424
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/FunctionReader.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/FunctionReader.kt": [
 43,
-213,
+213
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/DeadCodeElimination.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/DeadCodeElimination.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/FunctionPostProcessor.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/FunctionPostProcessor.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt':[
-180,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt": [
+180
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryAssignmentElimination.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryAssignmentElimination.kt": [
 90,
-97,
+97
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/KotlinJavascriptPackageFragment.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/KotlinJavascriptPackageFragment.kt": [
 76,
-80,
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/KotlinJavascriptSerializationUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/KotlinJavascriptSerializationUtil.kt": [
 194,
-292,
+292
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/kotlinJavascriptPackageFragmentProvider.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/kotlinJavascriptPackageFragmentProvider.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/GenerateJsTests.kt':[
-17,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/GenerateJsTests.kt": [
+17
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt':[
-94,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt": [
+94
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicIrBoxTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicIrBoxTest.kt": [
 51,
-79,
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/NashornJsTestChecker.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/NashornJsTestChecker.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/callTranslator/CallInfo.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/callTranslator/CallInfo.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/callTranslator/FunctionCallCases.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/callTranslator/FunctionCallCases.kt": [
 50,
 107,
 231,
-309,
+309
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/DelegationTranslator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/DelegationTranslator.kt": [
 153,
-184,
+184
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/expression/LoopTranslator.kt':[
-106,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/expression/LoopTranslator.kt": [
+106
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/general/ModuleWrapperTranslation.kt':[
-162,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/general/ModuleWrapperTranslation.kt": [
+162
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/intrinsic/functions/factories/LongOperationFIF.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/intrinsic/functions/factories/LongOperationFIF.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/kotlin-jsr223-daemon-local-eval-example/src/test/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223ScriptEngineIT.kt':[
-91,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/kotlin-jsr223-daemon-local-eval-example/src/test/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223ScriptEngineIT.kt": [
+91
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/kotlin-jsr223-local-example/src/test/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223ScriptEngineIT.kt':[
-133,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/kotlin-jsr223-local-example/src/test/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223ScriptEngineIT.kt": [
+133
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/DefaultAsserter.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/DefaultAsserter.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/Utils.kt':[
-13,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/Utils.kt": [
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/JsImpl.kt':[
-15,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/JsImpl.kt": [
+15
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/jvm/src/main/kotlin/CollectionAssertions.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/jvm/src/main/kotlin/CollectionAssertions.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/KotlinModuleMetadata.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/KotlinModuleMetadata.kt": [
 49,
-149,
+149
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/src/kotlinx/metadata/ClassName.kt':[
-18,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/src/kotlinx/metadata/ClassName.kt": [
+18
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/src/kotlinx/metadata/impl/writers.kt':[
-223,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/src/kotlinx/metadata/impl/writers.kt": [
+223
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/api/kotlinType.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/api/kotlinType.kt": [
 17,
-29,
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/definitions/definitionFromAnnotation.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/definitions/definitionFromAnnotation.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm-host/src/kotlin/script/experimental/jvmhost/impl/KJVMCompilerImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm-host/src/kotlin/script/experimental/jvmhost/impl/KJVMCompilerImpl.kt": [
 58,
 129,
 132,
-147,
+147
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/impl/BridgeDependenciesResolver.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/impl/BridgeDependenciesResolver.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/jvmScriptEnvironment.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/jvmScriptEnvironment.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/misc/src/kotlin/script/experimental/misc/propertiesDsl.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/misc/src/kotlin/script/experimental/misc/propertiesDsl.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt':[
-382,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt": [
+382
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/kotlin/ExceptionsH.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/kotlin/ExceptionsH.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/kotlin/KotlinH.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/kotlin/KotlinH.kt": [
 17,
-79,
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/test/jsCollectionFactories.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/test/jsCollectionFactories.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/annotationsJVM.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/annotationsJVM.kt": [
 17,
 23,
-29,
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/AbstractMutableMap.kt':[
-112,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/AbstractMutableMap.kt": [
+112
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/exceptions.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/exceptions.kt": [
 19,
-20,
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/math.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/math.kt": [
 299,
-1023,
+1023
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/reflect/KClassImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/reflect/KClassImpl.kt": [
 50,
-54,
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/regexp.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/regexp.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/string.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/string.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/text/TypeAliases.kt':[
-12,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/text/TypeAliases.kt": [
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/CharJVM.kt':[
-129,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/CharJVM.kt": [
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/Files.kt':[
-71,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/Files.kt": [
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/ReadWrite.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/ReadWrite.kt": [
 32,
-167,
+167
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Grouping.kt':[
-269,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Grouping.kt": [
+269
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt':[
-194,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt": [
+194
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/ArraysTest.kt':[
-425,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/ArraysTest.kt": [
+425
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/GroupingTest.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/GroupingTest.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/numbers/BitwiseOperationsTest.kt':[
-10,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/numbers/BitwiseOperationsTest.kt": [
+10
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/unsigned/src/kotlin/UnsignedUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/unsigned/src/kotlin/UnsignedUtils.kt": [
 14,
-60,
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/inline/inlineExposed.kt':[
-14,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/inline/inlineExposed.kt": [
+14
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/internalPart.kt':[
-7,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/internalPart.kt": [
+7
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/localClasses/lambdas.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/localClasses/lambdas.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/idl.kt':[
-390,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/idl.kt": [
+390
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/render.kt':[
-183,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/render.kt": [
+183
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/typeMappings.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/typeMappings.kt": [
 37,
-89,
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/AbstractKotlinAndroidGradleTests.kt':[
-18,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/AbstractKotlinAndroidGradleTests.kt": [
+18
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt':[
-518,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt": [
+518
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CoroutinesIT.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CoroutinesIT.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/GradleVersionRequired.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/GradleVersionRequired.kt": [
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalIT.kt':[
-117,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalIT.kt": [
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinDaemonIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinDaemonIT.kt": [
 24,
 25,
-26,
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MultiplatformGradleIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MultiplatformGradleIT.kt": [
+127
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/TestRootAffectedIT.kt": [
+39
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/jps/BaseIncrementalGradleIT.kt": [
+35
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/ui/HomeActivity.kt": [
+39
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/ui/HomeActivity.kt": [
+35
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/agp25/kotlin/org/jetbrains/kotlin/gradle/plugin/android/Android25ProjectHandler.kt": [
 127,
+152
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/TestRootAffectedIT.kt':[
-39,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/jps/BaseIncrementalGradleIT.kt':[
-35,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/ui/HomeActivity.kt':[
-39,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/ui/HomeActivity.kt':[
-35,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/agp25/kotlin/org/jetbrains/kotlin/gradle/plugin/android/Android25ProjectHandler.kt':[
-127,
-152,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt": [
 224,
 226,
-319,
+319
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/KotlinSourceSetProviderImpl.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/KotlinSourceSetProviderImpl.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinMultiplatformPlugin.kt':[
-112,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinMultiplatformPlugin.kt": [
+112
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt':[
-562,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt": [
+562
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginWrapper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginWrapper.kt": [
 43,
-47,
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt": [
 53,
 62,
-182,
+182
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/incremental/fileUtils.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/incremental/fileUtils.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223JvmDaemonCompileScriptEngine.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223JvmDaemonCompileScriptEngine.kt": [
 36,
-63,
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223JvmLocalScriptEngine.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223JvmLocalScriptEngine.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/annotations.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/annotations.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/context.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/context.kt": [
 11,
-24,
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/resolvers/basic.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/resolvers/basic.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/resolvers/maven.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/resolvers/maven.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/test/kotlin/org/jetbrains/kotlin/script/util/ScriptUtilContextTests.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/test/kotlin/org/jetbrains/kotlin/script/util/ScriptUtilContextTests.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt": [
 198,
 237,
 247,
@@ -2414,81 +2414,81 @@
 421,
 438,
 478,
-490,
+490
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Comparables.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Comparables.kt": [
 148,
 187,
 262,
-301,
+301
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt':[
-499,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt": [
+499
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Numeric.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Numeric.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/MemberBuilder.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/MemberBuilder.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/Main.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/Main.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt':[
-692,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt": [
+692
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/AndroidConst.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/AndroidConst.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/syntheticDescriptorGeneration.kt':[
-117,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/syntheticDescriptorGeneration.kt": [
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/tests/org/jetbrains/kotlin/android/AbstractAndroidFindUsagesTest.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/tests/org/jetbrains/kotlin/android/AbstractAndroidFindUsagesTest.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt':[
-541,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt": [
+541
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ErrorTypeCorrector.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ErrorTypeCorrector.kt": [
 83,
-131,
+131
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/java9TestUtils.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/java9TestUtils.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-idea/src/org/jetbrains/kotlin/kapt/idea/KaptProjectResolverExtension.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-idea/src/org/jetbrains/kotlin/kapt/idea/KaptProjectResolverExtension.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/KotlinScriptDefinitionAdapterFromNewAPI.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/KotlinScriptDefinitionAdapterFromNewAPI.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptingCommandLineProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptingCommandLineProcessor.kt": [
 115,
-116,
+116
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptingCompilerConfigurationExtension.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptingCompilerConfigurationExtension.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/diagram/KotlinSpringLocalModelDependenciesDiagramProvider.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/diagram/KotlinSpringLocalModelDependenciesDiagramProvider.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/diagram/OpenKotlinSpringModelDependenciesModuleDiagramAction.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/diagram/OpenKotlinSpringModelDependenciesModuleDiagramAction.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/generate/generateAutowiredDependenciesUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/generate/generateAutowiredDependenciesUtils.kt": [
 44,
-65,
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/generate/generateDependenciesUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/generate/generateDependenciesUtils.kt": [
 84,
 87,
 93,
 101,
 110,
 130,
-377,
-],
+377
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1143.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1143.json
@@ -1,8 +1,8 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplFromTerminal.kt':[
-85,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplFromTerminal.kt": [
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/parcel/AbstractParcelBoxTest.kt':[
-169,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/parcel/AbstractParcelBoxTest.kt": [
+169
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1144.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1144.json
@@ -1,20 +1,20 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt':[
-214,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt": [
+214
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/FunctionsTypingVisitor.kt':[
-169,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/FunctionsTypingVisitor.kt": [
+169
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DumpIrTree.kt':[
-288,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DumpIrTree.kt": [
+288
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/psi/patternMatching/KotlinPsiUnifier.kt':[
-575,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/psi/patternMatching/KotlinPsiUnifier.kt": [
+575
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/CommonIntentionActionsTest.kt':[
-411,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/CommonIntentionActionsTest.kt": [
+411
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaUpToDate/src/main/kotlin/foo/MainKotlinClass.kt':[
-13,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaUpToDate/src/main/kotlin/foo/MainKotlinClass.kt": [
+13
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1151.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1151.json
@@ -1,403 +1,403 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/kotlinPluginArtifact.kt':[
-142,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/kotlinPluginArtifact.kt": [
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt": [
 480,
 533,
-558,
+558
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/defaultMethodUtil.kt':[
-153,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/defaultMethodUtil.kt": [
+153
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt':[
-167,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt": [
+167
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt':[
-81,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt": [
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/nullCheck/RedundantNullCheckMethodTransformer.kt':[
-178,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/nullCheck/RedundantNullCheckMethodTransformer.kt": [
+178
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplCompilingEvaluator.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplCompilingEvaluator.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/js/dce/K2JSDce.kt':[
-165,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/js/dce/K2JSDce.kt": [
+165
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt':[
-272,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt": [
+272
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt':[
-143,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt": [
+143
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JavaNullabilityChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JavaNullabilityChecker.kt": [
 53,
-85,
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/reflectionUtil.kt':[
-85,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/reflectionUtil.kt": [
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt':[
-666,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt": [
+666
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/pseudocodeUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/pseudocodeUtils.kt": [
 163,
 181,
-198,
+198
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeAliasExpander.kt':[
-195,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeAliasExpander.kt": [
+195
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/DiagnosticReporterByTrackingStrategy.kt':[
-201,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/DiagnosticReporterByTrackingStrategy.kt": [
+201
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/coroutineCallChecker.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/coroutineCallChecker.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/IdentifierInfo.kt':[
-190,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/IdentifierInfo.kt": [
+190
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/KotlinToResolvedCallTransformer.kt':[
-99,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/KotlinToResolvedCallTransformer.kt": [
+99
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/PSICallResolver.kt':[
-552,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/PSICallResolver.kt": [
+552
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyDeclarationResolver.kt':[
-132,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyDeclarationResolver.kt": [
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt": [
 709,
-731,
+731
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/LabelResolver.kt':[
-141,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/LabelResolver.kt": [
+141
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ArgumentsGenerationUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ArgumentsGenerationUtils.kt": [
 388,
-416,
+416
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/AssignmentGenerator.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/AssignmentGenerator.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/BodyGenerator.kt':[
-219,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/BodyGenerator.kt": [
+219
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt": [
 94,
 112,
 130,
 148,
-166,
+166
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/lightAnnotations.kt':[
-336,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/lightAnnotations.kt": [
+336
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/CallableReferenceResolution.kt':[
-308,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/CallableReferenceResolution.kt": [
+308
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/types/TypeApproximator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/types/TypeApproximator.kt": [
 131,
 374,
-396,
+396
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaPackageScope.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaPackageScope.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/typeEnhancement/typeEnhancement.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/typeEnhancement/typeEnhancement.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/typeSignatureMapping.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/typeSignatureMapping.kt": [
 97,
-128,
+128
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/components/ReflectKotlinClass.kt':[
-202,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/components/ReflectKotlinClass.kt": [
+202
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewKotlinTypeChecker.kt':[
-237,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewKotlinTypeChecker.kt": [
+237
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/AnnotationDeserializer.kt':[
-91,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/AnnotationDeserializer.kt": [
+91
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt": [
 59,
-228,
+228
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/RuntimeTypeMapper.kt':[
-172,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/RuntimeTypeMapper.kt": [
+172
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreter.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreter.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt": [
 150,
-168,
+168
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt": [
 284,
 354,
 505,
-567,
+567
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/CallType.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/CallType.kt": [
 182,
-240,
+240
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt':[
-270,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt": [
+270
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/common/KotlinMetadataStubBuilder.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/common/KotlinMetadataStubBuilder.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinPsiChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinPsiChecker.kt": [
 216,
-246,
+246
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt':[
-161,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt": [
+161
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt": [
 483,
-551,
+551
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/OperatorReferenceSearcher.kt':[
-336,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/OperatorReferenceSearcher.kt": [
+336
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/stubindex/IndexUtils.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/stubindex/IndexUtils.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt':[
-197,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt": [
+197
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/InsertHandlerProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/InsertHandlerProvider.kt": [
 42,
-44,
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt": [
 205,
-346,
+346
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt':[
-128,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt": [
+128
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinNameSuggester.kt':[
-188,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinNameSuggester.kt": [
+188
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt": [
 126,
 151,
-191,
+191
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/KotlinFieldBreakpoint.kt':[
-145,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/KotlinFieldBreakpoint.kt": [
+145
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/FrameVisitor.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/FrameVisitor.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/extractFunctionForDebuggerUtil.kt':[
-286,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/extractFunctionForDebuggerUtil.kt": [
+286
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/internal/KotlinBytecodeToolWindow.kt':[
-134,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/internal/KotlinBytecodeToolWindow.kt": [
+134
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/compile/KtCompilingExecutor.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/compile/KtCompilingExecutor.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/HistoryKeyListener.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/HistoryKeyListener.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt':[
-384,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt": [
+384
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/UsageReplacementStrategy.kt':[
-161,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/UsageReplacementStrategy.kt": [
+161
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt':[
-202,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt": [
+202
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinElementDescriptionProvider.kt':[
-152,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinElementDescriptionProvider.kt": [
+152
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesHandlerFactory.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesHandlerFactory.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinLanguageCodeStyleSettingsProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinLanguageCodeStyleSettingsProvider.kt": [
 22,
 74,
 128,
 178,
-255,
+255
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRainbowVisitor.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRainbowVisitor.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRecursiveCallLineMarkerProvider.kt':[
-156,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRecursiveCallLineMarkerProvider.kt": [
+156
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MayBeConstantInspection.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MayBeConstantInspection.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantExplicitTypeInspection.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantExplicitTypeInspection.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UseExpressionBodyInspection.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UseExpressionBodyInspection.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/conventionNameCalls/ReplaceCallWithBinaryOperatorInspection.kt':[
-131,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/conventionNameCalls/ReplaceCallWithBinaryOperatorInspection.kt": [
+131
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/AddAnnotationUseSiteTargetIntention.kt':[
-95,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/AddAnnotationUseSiteTargetIntention.kt": [
+95
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertArrayParameterToVarargIntention.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertArrayParameterToVarargIntention.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt": [
 233,
-243,
+243
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToStringTemplateIntention.kt':[
-100,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToStringTemplateIntention.kt": [
+100
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MoveMemberToCompanionObjectIntention.kt':[
-312,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MoveMemberToCompanionObjectIntention.kt": [
+312
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SimplifyBooleanWithConstantsIntention.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SimplifyBooleanWithConstantsIntention.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/branchedTransformationUtils.kt':[
-147,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/branchedTransformationUtils.kt": [
+147
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/declarations/ConvertMemberToExtensionIntention.kt':[
-187,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/declarations/ConvertMemberToExtensionIntention.kt": [
+187
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt": [
 91,
-120,
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/AddToCollectionTransformation.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/AddToCollectionTransformation.kt": [
 143,
 145,
-172,
+172
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt':[
-294,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt": [
+294
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ExclExclCallFixes.kt':[
-129,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ExclExclCallFixes.kt": [
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ReplaceInfixOrOperatorCallFix.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ReplaceInfixOrOperatorCallFix.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
 506,
-531,
+531
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/typeUtils.kt':[
-237,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/typeUtils.kt": [
+237
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageFixBase.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageFixBase.kt": [
 157,
-160,
+160
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/ReplaceWithAnnotationAnalyzer.kt':[
-213,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/ReplaceWithAnnotationAnalyzer.kt": [
+213
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignature.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignature.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt": [
 130,
-941,
+941
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/ExtractionEngine.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/ExtractionEngine.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsHandler.kt':[
-140,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsHandler.kt": [
+140
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveUtils.kt':[
-558,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveUtils.kt": [
+558
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt':[
-408,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt": [
+408
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/JavaToKotlinPushDownDelegate.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/JavaToKotlinPushDownDelegate.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/pushDownConflictsUtils.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/pushDownConflictsUtils.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/KotlinSafeDeleteProcessor.kt':[
-174,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/KotlinSafeDeleteProcessor.kt": [
+174
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/Slicer.kt':[
-329,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/Slicer.kt": [
+329
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractInspectionTest.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractInspectionTest.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/slicer/AbstractSlicerTest.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/slicer/AbstractSlicerTest.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt':[
-184,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt": [
+184
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt": [
 364,
 400,
 419,
 771,
-847,
+847
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/importConversion.kt':[
-90,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/importConversion.kt": [
+90
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt": [
 75,
 205,
-300,
+300
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/NameSuggestion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/NameSuggestion.kt": [
+112
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt": [
 112,
+114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt':[
-112,
-114,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstDeserializer.kt": [
+188
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstDeserializer.kt':[
-188,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/reflect/reflection.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/reflect/reflection.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/stringsCode.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/stringsCode.kt':[
-96,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt": [
 132,
-233,
+233
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/AbstractAndroidExtensionsExpressionCodegenExtension.kt':[
-259,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/AbstractAndroidExtensionsExpressionCodegenExtension.kt": [
+259
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt": [
 61,
-89,
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptingCommandLineProcessor.kt':[
-110,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptingCommandLineProcessor.kt": [
+110
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt": [
 184,
-358,
-],
+358
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S117.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S117.json
@@ -1,9 +1,9 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/plugin-api/src/org/jetbrains/kotlin/compiler/plugin/CliOptions.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/plugin-api/src/org/jetbrains/kotlin/compiler/plugin/CliOptions.kt": [
 39,
-40,
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/typeEnhancement/predefinedEnhancementInfo.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/typeEnhancement/predefinedEnhancementInfo.kt": [
 41,
 42,
 43,
@@ -12,66 +12,66 @@
 46,
 47,
 48,
-49,
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/test-generator/tests/org/jetbrains/kotlin/generators/util/coroutines.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/test-generator/tests/org/jetbrains/kotlin/generators/util/coroutines.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt": [
 50,
-339,
+339
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/FrameVisitor.kt':[
-122,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/FrameVisitor.kt": [
+122
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/UsageReplacementStrategy.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/UsageReplacementStrategy.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt": [
 250,
-251,
+251
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/utils.kt": [
 255,
 256,
-257,
+257
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt": [
 177,
-3097,
+3097
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/StringNumberConversionsJVM.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/StringNumberConversionsJVM.kt": [
 247,
 248,
 249,
 251,
-254,
+254
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/numbers/NumbersJVMTest.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/numbers/NumbersJVMTest.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/CollectionTest.kt':[
-426,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/CollectionTest.kt": [
+426
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/SequenceTest.kt':[
-339,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/SequenceTest.kt": [
+339
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/js/MapJsTest.kt':[
-300,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/js/MapJsTest.kt": [
+300
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/numbers/MathTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/numbers/MathTest.kt": [
 12,
-19,
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/numbers/NumbersTest.kt':[
-153,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/numbers/NumbersTest.kt": [
+153
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt": [
 101,
 103,
-104,
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/UseRJavaActivity.kt':[
-7,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/UseRJavaActivity.kt": [
+7
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1172.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1172.json
@@ -1,125 +1,125 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ProtoCompareGenerated.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ProtoCompareGenerated.kt": [
 2048,
 2126,
-2206,
+2206
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InFloatingPointRangeLiteralExpressionGenerator.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InFloatingPointRangeLiteralExpressionGenerator.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/typeMappingUtil.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/typeMappingUtil.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Dsl.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Dsl.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/InlineChecker.kt':[
-95,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/InlineChecker.kt": [
+95
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/OperationsMapGenerated.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/OperationsMapGenerated.kt": [
 24,
-25,
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/inline/InlineAnalyzerExtension.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/inline/InlineAnalyzerExtension.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/compiler.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/compiler.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt':[
-186,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt": [
+186
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/builder/LightClassBuilder.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/builder/LightClassBuilder.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-java8/tests/org/jetbrains/kotlin/generators/tests/GenerateJava8Tests.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-java8/tests/org/jetbrains/kotlin/generators/tests/GenerateJava8Tests.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/generators/tests/GenerateCompilerTests.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/generators/tests/GenerateCompilerTests.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/tests/org/jetbrains/kotlin/generators/tests/GenerateRuntimeDescriptorTests.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/tests/org/jetbrains/kotlin/generators/tests/GenerateRuntimeDescriptorTests.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/AnnotationConstructorCaller.kt':[
-166,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/AnnotationConstructorCaller.kt": [
+166
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/util.runtime/src/org/jetbrains/kotlin/storage/storage.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/util.runtime/src/org/jetbrains/kotlin/storage/storage.kt": [
 42,
-44,
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/builtins/generateBuiltIns.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/builtins/generateBuiltIns.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/arguments/GenerateGradleOptions.kt':[
-146,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/arguments/GenerateGradleOptions.kt": [
+146
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/evaluate/GenerateOperationsMap.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/evaluate/GenerateOperationsMap.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/protobuf/GenerateProtoBuf.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/protobuf/GenerateProtoBuf.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt':[
-165,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt": [
+165
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt": [
 178,
-539,
+539
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/LambdaItems.kt':[
-94,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/LambdaItems.kt": [
+94
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/LambdaSignatureItems.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/LambdaSignatureItems.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/util/CachedValueHelpers.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/util/CachedValueHelpers.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/inspections/gradle/KotlinGradleModelFacade.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/inspections/gradle/KotlinGradleModelFacade.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/ModuleSourceRootMap.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/ModuleSourceRootMap.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinPluginUpdater.kt':[
-214,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinPluginUpdater.kt": [
+214
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/TypeHints.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/TypeHints.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/AbstractParameterInfoTest.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/AbstractParameterInfoTest.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeVisitor.kt':[
-94,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeVisitor.kt": [
+94
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Types.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Types.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/GenerateJsTests.kt':[
-14,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/GenerateJsTests.kt": [
+14
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/generateTestDataForReservedWords.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/generateTestDataForReservedWords.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/intrinsic/functions/factories/ArrayFIF.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/intrinsic/functions/factories/ArrayFIF.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/js-example/src/main/kotlin/sample/Hello.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/js-example/src/main/kotlin/sample/Hello.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/MainTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/MainTest.kt": [
 52,
-66,
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/coroutines/src/kotlin/coroutines/intrinsics/Intrinsics.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/coroutines/src/kotlin/coroutines/intrinsics/Intrinsics.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/generated/_ArraysJs.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/generated/_ArraysJs.kt": [
 109,
 146,
 156,
@@ -129,168 +129,168 @@
 196,
 206,
 216,
-226,
+226
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/builtins.kt':[
-99,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/builtins.kt": [
+99
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections.kt':[
-133,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections.kt": [
+133
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/concurrent.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/concurrent.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/properties/delegates.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/properties/delegates.kt": [
 26,
 41,
-66,
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/MapAccessors.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/MapAccessors.kt": [
 22,
 35,
 42,
-52,
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/coroutines/experimental/intrinsics/Intrinsics.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/coroutines/experimental/intrinsics/Intrinsics.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/internal/contracts/ContractBuilder.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/internal/contracts/ContractBuilder.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/util/Lazy.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/util/Lazy.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/main/kotlin/org.jetbrains.kotlin.tools/kotlinMetadataVisibilities.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/main/kotlin/org.jetbrains.kotlin.tools/kotlinMetadataVisibilities.kt": [
 49,
-87,
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/idl.kt':[
-592,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/idl.kt": [
+592
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/main.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/main.kt": [
 10,
 109,
-111,
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Lib/src/androidTest/kotlin/internalTest.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Lib/src/androidTest/kotlin/internalTest.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Lib/src/test/kotlin/internalTest.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Lib/src/test/kotlin/internalTest.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/buildCacheSimple/src/main/kotlin/foo.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/buildCacheSimple/src/main/kotlin/foo.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/useA.kt':[
-1,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/useA.kt": [
+1
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaLibraryProject/app/src/main/kotlin/App.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaLibraryProject/app/src/main/kotlin/App.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/src/main/java/com/example/databinding/MainActivity.kt':[
-18,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/src/main/java/com/example/databinding/MainActivity.kt": [
+18
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt19179/app/src/main/kotlin/Test.kt':[
-5,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt19179/app/src/main/kotlin/Test.kt": [
+5
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsDceProject/mainProject/src/main/kotlin/exampleapp/main.kt':[
-7,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsDceProject/mainProject/src/main/kotlin/exampleapp/main.kt": [
+7
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProject/mainProject/src/main/kotlin/example/main.kt':[
-7,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProject/mainProject/src/main/kotlin/example/main.kt": [
+7
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithSourceMapInline/app/src/main/kotlin/main.kt':[
-1,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithSourceMapInline/app/src/main/kotlin/main.kt": [
+1
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libJvm/src/main/kotlin/javaLibUse.kt':[
-5,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libJvm/src/main/kotlin/javaLibUse.kt": [
+5
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJvm/src/main/kotlin/javaLibUse.kt':[
-5,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJvm/src/main/kotlin/javaLibUse.kt": [
+5
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJvm/src/main/kotlin/javaLibUse.kt':[
-5,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJvm/src/main/kotlin/javaLibUse.kt": [
+5
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectWithDependency/projB/src/main/kotlin/helloWorld.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectWithDependency/projB/src/main/kotlin/helloWorld.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/samWithReceiverSimple/src/test.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/samWithReceiverSimple/src/test.kt": [
 23,
-24,
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressWarnings/src/helloWorld.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressWarnings/src/helloWorld.kt": [
+5
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt": [
+544
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-accessToInternal/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+19
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-extraArguments/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+3
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-helloworld/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+3
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-extraArguments/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+3
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
 5,
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt':[
-544,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kotlin-version-in-manifest/src/main/kotlin/test.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-accessToInternal/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-moduleName/src/main/kotlin/org/jetbrains/moduleName.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-extraArguments/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-moduleNameDefault/src/main/kotlin/org/jetbrains/moduleName.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-helloworld/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir-absolute/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-extraArguments/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-5,
-13,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kotlin-version-in-manifest/src/main/kotlin/test.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/js/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-moduleName/src/main/kotlin/org/jetbrains/moduleName.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/jvm/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-moduleNameDefault/src/main/kotlin/org/jetbrains/moduleName.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-plugins/use-test-extension/src/main/kotlin/main.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir-absolute/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-3,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-3,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-3,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/js/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-3,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/jvm/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-3,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-plugins/use-test-extension/src/main/kotlin/main.kt':[
-3,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-sam-with-receiver-simple/src/main/kotlin/test.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-sam-with-receiver-simple/src/main/kotlin/test.kt": [
 7,
-8,
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
 5,
-13,
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin/src/it/simple/src/main/kotlin/yo.kt':[
-1,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin/src/it/simple/src/main/kotlin/yo.kt": [
+1
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/Templates.kt':[
-212,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/Templates.kt": [
+212
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/test/org/jetbrains/kotlin/kotlinp/test/GenerateKotlinpTests.kt':[
-10,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/test/org/jetbrains/kotlin/kotlinp/test/GenerateKotlinpTests.kt": [
+10
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/KotlinKapt3IntegrationTests.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/KotlinKapt3IntegrationTests.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/lineMarking/KotlinSpringModelDependenciesLineMarkerProvider.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/lineMarking/KotlinSpringModelDependenciesLineMarkerProvider.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/tests/org/jetbrains/kotlin/tests/GenerateUltimateTests.kt':[
-30,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/tests/org/jetbrains/kotlin/tests/GenerateUltimateTests.kt": [
+30
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1186.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1186.json
@@ -1,194 +1,194 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ICReporter.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ICReporter.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/IncrementalJvmCache.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/IncrementalJvmCache.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/src/org/jetbrains/kotlin/android/tests/CodegenTestsOnAndroidRunner.kt':[
-175,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/src/org/jetbrains/kotlin/android/tests/CodegenTestsOnAndroidRunner.kt": [
+175
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/CallGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/CallGenerator.kt": [
 40,
-44,
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/Callable.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/Callable.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ObjectSuperCallArgumentGenerator.kt':[
-85,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ObjectSuperCallArgumentGenerator.kt": [
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ScriptCodegen.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ScriptCodegen.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/extensions/ExpressionCodegenExtension.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/extensions/ExpressionCodegenExtension.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt':[
-107,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt": [
+107
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodBodyVisitor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodBodyVisitor.kt": [
 51,
-53,
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt':[
-159,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt": [
+159
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/BoxingInterpreter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/BoxingInterpreter.kt": [
 136,
 137,
 138,
 139,
 140,
 141,
-142,
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/MethodAnalyzer.kt':[
-79,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/MethodAnalyzer.kt": [
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/AbstractForInProgressionLoopGenerator.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/AbstractForInProgressionLoopGenerator.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/AbstractForInProgressionOrRangeLoopGenerator.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/AbstractForInProgressionOrRangeLoopGenerator.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/AbstractForInRangeLoopGenerator.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/AbstractForInRangeLoopGenerator.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/ForInArrayLoopGenerator.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/ForInArrayLoopGenerator.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/ForInCharSequenceLoopGenerator.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/ForInCharSequenceLoopGenerator.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/ForInDefinitelySafeSimpleProgressionLoopGenerator.kt':[
-81,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/ForInDefinitelySafeSimpleProgressionLoopGenerator.kt": [
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/IteratorForLoopGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/IteratorForLoopGenerator.kt": [
 64,
-89,
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/IncompatibleClassTracker.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/IncompatibleClassTracker.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplEvaluator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplEvaluator.kt": [
 175,
-195,
+195
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/javac/JavacLogger.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/javac/JavacLogger.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/modules/CoreJrtFileSystem.kt':[
-79,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/modules/CoreJrtFileSystem.kt": [
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/modules/CoreJrtVirtualFile.kt':[
-79,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/modules/CoreJrtVirtualFile.kt": [
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplExceptionReporter.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplExceptionReporter.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/writer/ConsoleReplWriter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/writer/ConsoleReplWriter.kt": [
 26,
 27,
 28,
 29,
-30,
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/CompilerCallbackServicesFacadeServer.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/CompilerCallbackServicesFacadeServer.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/report/DaemonMessageReporter.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/report/DaemonMessageReporter.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/instructions/InstructionVisitor.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/instructions/InstructionVisitor.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/extensions/StorageComponentContainerContributor.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/extensions/StorageComponentContainerContributor.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegatedPropertyInferenceSession.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegatedPropertyInferenceSession.kt": [
 98,
 99,
-100,
+100
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/FiniteBoundRestrictionChecker.kt':[
-125,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/FiniteBoundRestrictionChecker.kt": [
+125
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/IdentifierChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/IdentifierChecker.kt": [
 28,
-29,
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeAliasExpansionReportStrategy.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeAliasExpansionReportStrategy.kt": [
 38,
 43,
 46,
 52,
-55,
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/DiagnosticReporterByTrackingStrategy.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/DiagnosticReporterByTrackingStrategy.kt": [
 39,
 71,
-75,
+75
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/AdditionalTypeChecker.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/AdditionalTypeChecker.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/KotlinVersionStringAnnotationValueChecker.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/KotlinVersionStringAnnotationValueChecker.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/extensions/SyntheticResolveExtension.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/extensions/SyntheticResolveExtension.kt": [
 89,
 97,
 106,
-115,
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyScriptClassMemberScope.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyScriptClassMemberScope.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt": [
 152,
 153,
 310,
-319,
+319
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunner.kt": [
 84,
-319,
+319
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/utils/TestICReporter.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/utils/TestICReporter.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/IrBuildUtils.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/IrBuildUtils.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrCallGenerator.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrCallGenerator.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/NewArray.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/NewArray.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/ClassLowerWithContext.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/ClassLowerWithContext.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/components/StubJavaResolverCache.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/components/StubJavaResolverCache.kt": [
 32,
 34,
 36,
-38,
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/builder/KotlinLightClassBuilderFactory.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/builder/KotlinLightClassBuilderFactory.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtCodeFragment.kt':[
-159,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtCodeFragment.kt": [
+159
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtFile.kt':[
-179,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtFile.kt": [
+179
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/stubs/elements/StubIndexService.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/stubs/elements/StubIndexService.kt": [
 29,
 32,
 35,
@@ -197,29 +197,29 @@
 44,
 47,
 50,
-53,
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/InferenceSession.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/InferenceSession.kt": [
 18,
 19,
-20,
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/InvokeProcessors.kt':[
-201,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/InvokeProcessors.kt": [
+201
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ScopeTowerProcessors.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ScopeTowerProcessors.kt": [
 31,
-144,
+144
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/TowerLevels.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/TowerLevels.kt": [
 216,
 309,
-338,
+338
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/scopes/LexicalScopeStorage.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/scopes/LexicalScopeStorage.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/SerializerExtension.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/SerializerExtension.kt": [
 30,
 33,
 36,
@@ -229,617 +229,617 @@
 48,
 51,
 54,
-57,
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/test/testFramework/MockProjects.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/test/testFramework/MockProjects.kt": [
 31,
-34,
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/cli/FriendPathsTest.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/cli/FriendPathsTest.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTemplateTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTemplateTest.kt": [
 613,
 614,
-615,
+615
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/util/ArgsToParamsMatchingTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/util/ArgsToParamsMatchingTest.kt": [
 101,
 103,
 105,
 107,
-109,
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/JavaClassesTracker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/JavaClassesTracker.kt": [
 28,
-29,
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaPackageScope.kt':[
-156,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaPackageScope.kt": [
+156
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaStaticClassScope.kt':[
-124,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaStaticClassScope.kt": [
+124
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/AbstractBinaryClassAnnotationAndConstantLoader.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/AbstractBinaryClassAnnotationAndConstantLoader.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/typeSignatureMapping.kt':[
-287,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/typeSignatureMapping.kt": [
+287
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/incremental/components/ExpectActualTracker.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/incremental/components/ExpectActualTracker.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/incremental/components/LookupTracker.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/incremental/components/LookupTracker.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRenderer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRenderer.kt": [
+71
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/AbstractTypeConstructor.kt": [
 71,
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/AbstractTypeConstructor.kt':[
-71,
-74,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedMemberScope.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedMemberScope.kt": [
 134,
-151,
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/util.runtime/src/org/jetbrains/kotlin/utils/functions.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/util.runtime/src/org/jetbrains/kotlin/utils/functions.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/FileAttributeService.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/FileAttributeService.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/compiler/configuration/BaseKotlinCompilerSettings.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/compiler/configuration/BaseKotlinCompilerSettings.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/common/AnnotationLoaderForStubBuilderImpl.kt':[
-85,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/common/AnnotationLoaderForStubBuilderImpl.kt": [
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/stubBuilder/CallableClsStubBuilder.kt':[
-209,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/stubBuilder/CallableClsStubBuilder.kt": [
+209
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/IdeModuleVisibilityManagerImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/IdeModuleVisibilityManagerImpl.kt": [
 25,
-26,
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionBenchmarkSink.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionBenchmarkSink.kt": [
 42,
 44,
-46,
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt':[
-399,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt": [
+399
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/KotlinFixtureCompletionBaseTestCase.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/KotlinFixtureCompletionBaseTestCase.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/handlers/AbstractCompletionHandlerTests.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/handlers/AbstractCompletionHandlerTests.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/dependencies/JavaClassesInScriptDependenciesShortNameCache.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/dependencies/JavaClassesInScriptDependenciesShortNameCache.kt": [
 35,
 49,
-59,
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GradleKotlinFrameworkSupportProvider.kt':[
-129,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GradleKotlinFrameworkSupportProvider.kt": [
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/KotlinWithLibraryConfigurator.kt':[
-329,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/KotlinWithLibraryConfigurator.kt": [
+329
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/debuggerUtil.kt':[
-139,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/debuggerUtil.kt": [
+139
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/framework/CustomLibraryDescriptorWithDeferredConfig.kt':[
-116,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/framework/CustomLibraryDescriptorWithDeferredConfig.kt": [
+116
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/inspections/api/IncompatibleAPIJavaVisitor.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/inspections/api/IncompatibleAPIJavaVisitor.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/internal/KotlinDecompilerServiceImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/internal/KotlinDecompilerServiceImpl.kt": [
 109,
 111,
 113,
 115,
 123,
 125,
-127,
+127
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/output/InlayScratchOutputHandler.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/output/InlayScratchOutputHandler.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/output/ScratchOutputHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/output/ScratchOutputHandler.kt": [
 39,
 40,
 41,
 42,
-43,
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/ui/ScratchFileHook.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/ui/ScratchFileHook.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/vcs/BunchCheckinHandler.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/vcs/BunchCheckinHandler.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/versions/UnsupportedAbiVersionNotificationPanelProvider.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/versions/UnsupportedAbiVersionNotificationPanelProvider.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/src/org/jetbrains/kotlin/idea/liveTemplates/KotlinShortenFQNamesProcessor.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/src/org/jetbrains/kotlin/idea/liveTemplates/KotlinShortenFQNamesProcessor.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/src/org/jetbrains/kotlin/idea/liveTemplates/macro/AnyVariableMacro.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/src/org/jetbrains/kotlin/idea/liveTemplates/macro/AnyVariableMacro.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/KotlinMavenImporter.kt':[
-81,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/KotlinMavenImporter.kt": [
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/configuration/KotlinMavenConfigurator.kt':[
-180,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/configuration/KotlinMavenConfigurator.kt": [
+180
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/jsr223/KotlinJsr223JvmScriptEngine4Idea.kt':[
-92,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/jsr223/KotlinJsr223JvmScriptEngine4Idea.kt": [
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinPluginUpdater.kt':[
-288,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinPluginUpdater.kt": [
+288
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/KotlinQualifiedNameProvider.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/KotlinQualifiedNameProvider.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateEqualsWizard.kt':[
-95,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateEqualsWizard.kt": [
+95
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinOptimizeImportsRefactoringHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinOptimizeImportsRefactoringHelper.kt": [
 47,
-69,
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/postfix/KtPostfixTemplateProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/postfix/KtPostfixTemplateProvider.kt": [
 66,
-71,
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/facet/KotlinFacetCompilerPluginsTab.kt':[
-180,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/facet/KotlinFacetCompilerPluginsTab.kt": [
+180
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/ImportSettingsPanel.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/ImportSettingsPanel.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/framework/KotlinSdkType.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/framework/KotlinSdkType.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/imports/KotlinImportOptimizer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/imports/KotlinImportOptimizer.kt": [
 83,
-86,
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/PlatformUnresolvedProvider.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/PlatformUnresolvedProvider.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt':[
-980,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt": [
+980
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinImplicitThisToParameterUsage.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinImplicitThisToParameterUsage.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinParameterUsage.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinParameterUsage.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinUsageInfo.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinUsageInfo.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/copy/CopyKotlinDeclarationsHandler.kt':[
-333,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/copy/CopyKotlinDeclarationsHandler.kt": [
+333
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/cutPaste/MoveDeclarationsPassFactory.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/cutPaste/MoveDeclarationsPassFactory.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementRenderingUtils.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementRenderingUtils.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/AbstractKotlinInplaceIntroducer.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/AbstractKotlinInplaceIntroducer.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinIntroduceParameterMethodUsageProcessor.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinIntroduceParameterMethodUsageProcessor.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinVariableInplaceIntroducer.kt':[
-155,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinVariableInplaceIntroducer.kt": [
+155
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/ui/AbstractParameterTablePanel.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/ui/AbstractParameterTablePanel.kt": [
 57,
 141,
 145,
-149,
+149
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt": [
 663,
 667,
-671,
+671
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveDeclarationsDelegate.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveDeclarationsDelegate.kt": [
 45,
 49,
-53,
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveFilesOrDirectories/KotlinMoveDirectoryWithClassesHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveFilesOrDirectories/KotlinMoveDirectoryWithClassesHelper.kt": [
 99,
-124,
+124
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveFilesOrDirectories/MoveKotlinClassHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveFilesOrDirectories/MoveKotlinClassHandler.kt": [
 40,
-43,
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveFilesOrDirectories/MoveKotlinFileHandler.kt':[
-149,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveFilesOrDirectories/MoveKotlinFileHandler.kt": [
+149
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/EmptyPullUpHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/EmptyPullUpHelper.kt": [
 28,
 32,
 36,
 40,
 44,
-48,
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/JavaToKotlinPostconversionPullUpHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/JavaToKotlinPostconversionPullUpHelper.kt": [
 34,
 36,
 38,
 40,
-43,
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt": [
 310,
-654,
+654
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinPropertyProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinPropertyProcessor.kt": [
 150,
-189,
+189
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/KotlinUsageContextDataFlowPanelBase.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/KotlinUsageContextDataFlowPanelBase.kt": [
 82,
-86,
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ImportInsertHelperImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ImportInsertHelperImpl.kt": [
 338,
-341,
+341
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/versions/KotlinUpdatePluginComponent.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/versions/KotlinUpdatePluginComponent.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/findUsages/AbstractFindUsagesTest.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/findUsages/AbstractFindUsagesTest.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/actions/AbstractNavigationTest.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/actions/AbstractNavigationTest.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractInspectionTest.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractInspectionTest.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/generate/AbstractCodeInsightActionTest.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/generate/AbstractCodeInsightActionTest.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/configuration/AbstractConfigureKotlinTest.kt':[
-151,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/configuration/AbstractConfigureKotlinTest.kt": [
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/evaluate/AbstractKotlinEvaluateExpressionTest.kt':[
-88,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/evaluate/AbstractKotlinEvaluateExpressionTest.kt": [
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/decompiler/textBuilder/AbstractDecompiledTextBaseTest.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/decompiler/textBuilder/AbstractDecompiledTextBaseTest.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixTest.kt':[
-73,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixTest.kt": [
+73
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/rename/AbstractRenameTest.kt':[
-175,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/rename/AbstractRenameTest.kt": [
+175
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/slicer/AbstractSlicerTest.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/slicer/AbstractSlicerTest.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/JavaToKotlinConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/JavaToKotlinConverter.kt": [
 301,
-304,
+304
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Element.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Element.kt": [
 95,
-100,
+100
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Expression.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Expression.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalJpsTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalJpsTest.kt": [
 374,
-425,
+425
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractLookupTrackerTest.kt':[
-268,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractLookupTrackerTest.kt": [
+268
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTest.kt": [
 983,
 984,
 985,
 986,
-987,
+987
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/incremental/compilerUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/incremental/compilerUtils.kt": [
 59,
 62,
-65,
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/model/Serializer.kt':[
-73,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/model/Serializer.kt": [
+73
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/platforms/KotlinModuleBuilderTarget.kt':[
-174,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/platforms/KotlinModuleBuilderTarget.kt": [
+174
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.ast/src/org/jetbrains/kotlin/js/backend/NoOpSourceLocationConsumer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.ast/src/org/jetbrains/kotlin/js/backend/NoOpSourceLocationConsumer.kt": [
 20,
 22,
-24,
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.ast/src/org/jetbrains/kotlin/js/backend/ast/JsVisitor.kt':[
-159,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.ast/src/org/jetbrains/kotlin/js/backend/ast/JsVisitor.kt": [
+159
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/ReachabilityTracker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/ReachabilityTracker.kt": [
 133,
-135,
+135
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsIdentifierChecker.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsIdentifierChecker.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/nativeAnnotationCheckers.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/nativeAnnotationCheckers.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutinePasses.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutinePasses.kt": [
 312,
-314,
+314
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/DoWhileGuardElimination.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/DoWhileGuardElimination.kt": [
 108,
-140,
+140
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryAssignmentElimination.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryAssignmentElimination.kt": [
 121,
-123,
+123
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt": [
 176,
-178,
+178
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/WhileConditionFolding.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/WhileConditionFolding.kt": [
 194,
-241,
+241
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/resolveTemporaryNames.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/resolveTemporaryNames.kt": [
 154,
-156,
+156
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/util/collectUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/util/collectUtils.kt": [
 30,
 32,
 57,
 59,
-109,
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/util/fixForwardNameReferences.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/util/fixForwardNameReferences.kt": [
 75,
-77,
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.parser/src/com/google/gwt/dev/js/ThrowExceptionReporter.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.parser/src/com/google/gwt/dev/js/ThrowExceptionReporter.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt':[
-246,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt": [
+246
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/EncodeSignatureTest.kt':[
-197,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/EncodeSignatureTest.kt": [
+197
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/ast/NameResolutionTest.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/ast/NameResolutionTest.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/optimizer/BasicOptimizerTest.kt':[
-138,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/optimizer/BasicOptimizerTest.kt": [
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/AbstractDeclarationVisitor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/AbstractDeclarationVisitor.kt": [
 38,
-114,
+114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/DeclarationBodyVisitor.kt':[
-104,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/DeclarationBodyVisitor.kt": [
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/MainTest.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/MainTest.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/OrgTest.kt':[
-6,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/OrgTest.kt": [
+6
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/other/name/NameTest.kt':[
-6,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/other/name/NameTest.kt": [
+6
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/some/SomeTest.kt':[
-6,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/some/SomeTest.kt": [
+6
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/some/name/NameTest.kt':[
-6,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/some/name/NameTest.kt": [
+6
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/test/kotlinx/metadata/test/MetadataSmokeTest.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/test/kotlinx/metadata/test/MetadataSmokeTest.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/jvmScriptCompilation.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/jvmScriptCompilation.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/ArrayList.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/ArrayList.kt": [
 34,
-37,
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/console.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/console.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/internal/contracts/ContractBuilder.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/internal/contracts/ContractBuilder.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/properties/ObservableProperty.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/properties/ObservableProperty.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/testUtils.kt':[
-12,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/testUtils.kt": [
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/default/functions.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/default/functions.kt": [
 4,
 6,
 11,
-13,
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/inline/inlineExposed.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/inline/inlineExposed.kt": [
 4,
-12,
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/internalPart.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/internalPart.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/private/privateMultifile2.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/private/privateMultifile2.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/public/publicPart.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/public/publicPart.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/hidden.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/hidden.kt": [
 15,
-25,
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/jvmNames.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/jvmNames.kt": [
 4,
-13,
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidJackProject/Android/root/kotlin/org/jetbrains/kotlin/gradle/test/androidalfa/MainActivity2.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidJackProject/Android/root/kotlin/org/jetbrains/kotlin/gradle/test/androidalfa/MainActivity2.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/root/kotlin/org/jetbrains/kotlin/gradle/test/androidalfa/MainActivity2.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/root/kotlin/org/jetbrains/kotlin/gradle/test/androidalfa/MainActivity2.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/allOpenSimple/src/test.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/allOpenSimple/src/test.kt": [
 7,
-12,
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/allOpenSpring/src/test.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/allOpenSpring/src/test.kt": [
 7,
+11
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/customJdk/src/main.kt": [
+2
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/A.kt": [
+2
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/utils.kt": [
+1
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/lib/src/main/kotlin/A.kt": [
+2
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/lib/src/main/kotlin/utils.kt": [
+1
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/AA.kt": [
+6
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/BB.kt": [
+6
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/A.kt": [
+4
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/B.kt": [
+4
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/src/main/java/com/example/databinding/EnumAdapter.kt": [
+97
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/locationMapping/src/main/java/test.kt": [
+7
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/src/main/java/foo/topLevelDummyFun.kt": [
+3
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/bar/B.kt": [
 11,
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/customJdk/src/main.kt':[
-2,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/A.kt':[
-2,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/utils.kt':[
-1,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/lib/src/main/kotlin/A.kt':[
-2,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/lib/src/main/kotlin/utils.kt':[
-1,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/AA.kt':[
-6,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/BB.kt':[
-6,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/A.kt':[
-4,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/B.kt':[
-4,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/src/main/java/com/example/databinding/EnumAdapter.kt':[
-97,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/locationMapping/src/main/java/test.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/baz/util.kt": [
 7,
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/src/main/java/foo/topLevelDummyFun.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/foo/A.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/bar/B.kt':[
-11,
-13,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinBuiltins/app/src/main/kotlin/f.kt": [
+4
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/baz/util.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinInJavaRoot/src/main/java/kotlinPackage/KotlinClass.kt": [
+7
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinInJavaRoot/src/main/java2/kotlinPackage2/KotlinClass2.kt": [
+7
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/main/kotlin/dummyUtil.kt": [
+3
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/manyClasses/src/main/kotlin/dummy.kt": [
+8
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/moveClassToOtherModule/app/src/main/java/foo/A.kt": [
+4
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/allopenPluginsDsl/src/main/kotlin/test.kt": [
 7,
-9,
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/foo/A.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressWarnings/src/helloWorld.kt": [
+5
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinBuiltins/app/src/main/kotlin/f.kt':[
-4,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/scripting/internal/ScriptingGradleSubplugin.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinInJavaRoot/src/main/java/kotlinPackage/KotlinClass.kt':[
-7,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinJsDce.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinInJavaRoot/src/main/java2/kotlinPackage2/KotlinClass2.kt':[
-7,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-customJdk/src/main/kotlin/main.kt": [
+2
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/main/kotlin/dummyUtil.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+5
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/manyClasses/src/main/kotlin/dummy.kt':[
-8,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/moveClassToOtherModule/app/src/main/java/foo/A.kt':[
-4,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/allopenPluginsDsl/src/main/kotlin/test.kt':[
-7,
-12,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressWarnings/src/helloWorld.kt':[
-5,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/scripting/internal/ScriptingGradleSubplugin.kt':[
-23,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinJsDce.kt':[
-60,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-customJdk/src/main/kotlin/main.kt':[
-2,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-5,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-reflection/src/main/kotlin/main/main.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-reflection/src/main/kotlin/main/main.kt": [
 22,
-32,
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-5,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+5
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin/src/it/simple/src/main/kotlin/yo.kt':[
-1,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin/src/it/simple/src/main/kotlin/yo.kt": [
+1
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/test/kotlin/org/jetbrains/kotlin/script/util/ScriptUtilIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/test/kotlin/org/jetbrains/kotlin/script/util/ScriptUtilIT.kt": [
 188,
 189,
-190,
+190
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/test/org/jetbrains/kotlin/kotlinp/test/KotlinpCompilerTestDataTest.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/test/org/jetbrains/kotlin/kotlinp/test/KotlinpCompilerTestDataTest.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/AndroidXmlHandler.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/AndroidXmlHandler.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3BuilderFactory.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3BuilderFactory.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ErrorTypeCorrector.kt':[
-179,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ErrorTypeCorrector.kt": [
+179
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/KaptStubLineInformation.kt':[
-114,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/KaptStubLineInformation.kt": [
+114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/AbstractKotlinKapt3Test.kt':[
-222,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/AbstractKotlinKapt3Test.kt": [
+222
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastApiTest.kt':[
-21,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastApiTest.kt": [
+21
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1192.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1192.json
@@ -1,101 +1,101 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/instrument.kt':[
-149,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/instrument.kt": [
+149
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/intellijDependencies.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/intellijDependencies.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/plugin.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/plugin.kt": [
 24,
 29,
 36,
-167,
+167
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/AndroidTestGenerator.kt':[
-142,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/AndroidTestGenerator.kt": [
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/PropertyReferenceCodegen.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/PropertyReferenceCodegen.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/RangeCodegenUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/RangeCodegenUtil.kt": [
 62,
 126,
-152,
+152
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineCodegen.kt':[
-91,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineCodegen.kt": [
+91
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegenForDefaultBody.kt':[
-81,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegenForDefaultBody.kt": [
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/Concat.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/Concat.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/TypeIntrinsics.kt':[
-117,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/TypeIntrinsics.kt": [
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/KotlinJsr223JvmScriptEngineBase.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/KotlinJsr223JvmScriptEngineBase.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/MockExternalAnnotationsManager.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/MockExternalAnnotationsManager.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/psi/DebugTextUtil.kt':[
-124,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/psi/DebugTextUtil.kt": [
+124
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/parsing/ClassesFqNamesTest.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/parsing/ClassesFqNamesTest.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsIrBackendContext.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsIrBackendContext.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Concat.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Concat.kt": [
 63,
-63,
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IrIntrinsicFunction.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IrIntrinsicFunction.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrBlockImpl.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrBlockImpl.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DumpIrTree.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DumpIrTree.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/SymbolTable.kt':[
-104,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/SymbolTable.kt": [
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt':[
-466,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt": [
+466
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/jvm/compiler/AbstractCompileJavaAgainstKotlinTest.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/jvm/compiler/AbstractCompileJavaAgainstKotlinTest.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-java8/tests/org/jetbrains/kotlin/generators/tests/GenerateJava8Tests.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-java8/tests/org/jetbrains/kotlin/generators/tests/GenerateJava8Tests.kt": [
 43,
-59,
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/cli/jvm/KotlinCliJavaFileManagerTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/cli/jvm/KotlinCliJavaFileManagerTest.kt": [
 67,
 70,
 71,
 72,
 73,
-74,
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/codegen/MethodOrderTest.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/codegen/MethodOrderTest.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerApiTest.kt':[
-107,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerApiTest.kt": [
+107
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt": [
 61,
 105,
 108,
@@ -105,73 +105,73 @@
 128,
 307,
 353,
-367,
+367
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/generators/tests/GenerateCompilerTests.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/generators/tests/GenerateCompilerTests.kt": [
 118,
 158,
 174,
 234,
-237,
+237
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/jvm/compiler/CompileKotlinAgainstCustomBinariesTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/jvm/compiler/CompileKotlinAgainstCustomBinariesTest.kt": [
 84,
 113,
 149,
 203,
 231,
 249,
-261,
+261
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTemplateTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTemplateTest.kt": [
 63,
-264,
+264
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTest.kt": [
 41,
-57,
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/serialization/VersionRequirementTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/serialization/VersionRequirementTest.kt": [
 130,
 131,
 132,
 133,
-134,
+134
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/src/kotlin/Progressions.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/src/kotlin/Progressions.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/specialBuiltinMembers.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/specialBuiltinMembers.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/constants/constantValues.kt':[
-197,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/constants/constantValues.kt": [
+197
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KDeclarationContainerImpl.kt':[
-145,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KDeclarationContainerImpl.kt": [
+145
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/util.runtime/src/org/jetbrains/kotlin/utils/addToStdlib.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/util.runtime/src/org/jetbrains/kotlin/utils/addToStdlib.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/jdi/jdiEval.kt':[
-296,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/jdi/jdiEval.kt": [
+296
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/test-generator/tests/org/jetbrains/kotlin/generators/tests/generator/TestGenerator.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/test-generator/tests/org/jetbrains/kotlin/generators/tests/generator/TestGenerator.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/protobuf/GenerateProtoBufCompare.kt':[
-342,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/protobuf/GenerateProtoBufCompare.kt": [
+342
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/tests/GeneratePrimitiveVsObjectEqualityTestData.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/tests/GeneratePrimitiveVsObjectEqualityTestData.kt": [
 40,
 44,
 59,
 195,
 195,
 196,
-196,
+196
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt": [
 168,
 168,
 215,
@@ -183,21 +183,21 @@
 907,
 923,
 926,
-929,
+929
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinPsiChecker.kt':[
-352,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinPsiChecker.kt": [
+352
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GradleKotlinFrameworkSupportProvider.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GradleKotlinFrameworkSupportProvider.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinDslGradleKotlinFrameworkSupportProvider.kt':[
-71,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinDslGradleKotlinFrameworkSupportProvider.kt": [
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/inspections/gradle/KotlinGradleInspectionVisitor.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/inspections/gradle/KotlinGradleInspectionVisitor.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/MultiplatformProjectImportingTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/MultiplatformProjectImportingTest.kt": [
 39,
 44,
 320,
@@ -205,9 +205,9 @@
 392,
 402,
 405,
-759,
+759
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleConfiguratorTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleConfiguratorTest.kt": [
 27,
 27,
 29,
@@ -218,9 +218,9 @@
 1017,
 1140,
 1197,
-1197,
+1197
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleFacetImportTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleFacetImportTest.kt": [
 88,
 130,
 142,
@@ -230,29 +230,29 @@
 156,
 157,
 158,
-1377,
+1377
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleInspectionTest.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleInspectionTest.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/PomFile.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/PomFile.kt": [
 235,
 235,
 248,
-252,
+252
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/test/org/jetbrains/kotlin/idea/maven/AbstractKotlinMavenInspectionTest.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/test/org/jetbrains/kotlin/idea/maven/AbstractKotlinMavenInspectionTest.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/test/org/jetbrains/kotlin/idea/maven/KotlinMavenArchetypesProviderTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/test/org/jetbrains/kotlin/idea/maven/KotlinMavenArchetypesProviderTest.kt": [
 33,
 34,
 44,
 44,
 44,
-45,
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/test/org/jetbrains/kotlin/idea/maven/KotlinMavenImporterTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/test/org/jetbrains/kotlin/idea/maven/KotlinMavenImporterTest.kt": [
 76,
 104,
 104,
@@ -264,53 +264,53 @@
 2177,
 2220,
 2263,
-2316,
+2316
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/test/org/jetbrains/kotlin/idea/maven/MavenUpdateConfigurationQuickFixTest.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/test/org/jetbrains/kotlin/idea/maven/MavenUpdateConfigurationQuickFixTest.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinScriptAction.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinScriptAction.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinExpressionTypeProvider.kt':[
-108,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinExpressionTypeProvider.kt": [
+108
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinLanguageCodeStyleSettingsProvider.kt':[
-302,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinLanguageCodeStyleSettingsProvider.kt": [
+302
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/NamingConventionInspections.kt':[
-132,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/NamingConventionInspections.kt": [
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/SimplifiableCallChainInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/SimplifiableCallChainInspection.kt": [
 57,
 66,
-75,
+75
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToConcatenatedStringIntention.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToConcatenatedStringIntention.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ToRawStringLiteralIntention.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ToRawStringLiteralIntention.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/BranchedUnfoldingUtils.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/BranchedUnfoldingUtils.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ConvertCollectionFix.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ConvertCollectionFix.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
-508,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
+508
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt':[
-488,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt": [
+488
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/versions/KotlinRuntimeLibraryUtil.kt':[
-252,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/versions/KotlinRuntimeLibraryUtil.kt": [
+252
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/asJava/KtFileLightClassTest.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/asJava/KtFileLightClassTest.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/asJava/KtLightAnnotationTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/asJava/KtLightAnnotationTest.kt": [
 51,
 103,
 107,
@@ -318,32 +318,32 @@
 356,
 392,
 403,
-413,
+413
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/findUsages/OptionsParser.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/findUsages/OptionsParser.kt": [
 35,
-44,
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/OutdatedKotlinRuntimeNotificationTest.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/OutdatedKotlinRuntimeNotificationTest.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/ResolveElementCacheTest.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/ResolveElementCacheTest.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/ImplicitPackagePrefixTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/ImplicitPackagePrefixTest.kt": [
 30,
 30,
 31,
 36,
-36,
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/IdeaModuleInfoTest.kt':[
-337,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/IdeaModuleInfoTest.kt": [
+337
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractMoveOnCutPasteTest.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractMoveOnCutPasteTest.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/smartEnter/SmartEnterTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/smartEnter/SmartEnterTest.kt": [
 20,
 69,
 263,
@@ -353,92 +353,92 @@
 716,
 1033,
 1131,
-1229,
+1229
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinInTempDirTest.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinInTempDirTest.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/evaluate/AbstractKotlinEvaluateExpressionTest.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/evaluate/AbstractKotlinEvaluateExpressionTest.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/decompiler/navigation/NavigateFromLibrarySourcesTest.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/decompiler/navigation/NavigateFromLibrarySourcesTest.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/decompiler/navigation/NavigationWithMultipleLibrariesTest.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/decompiler/navigation/NavigationWithMultipleLibrariesTest.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/editor/TypedHandlerTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/editor/TypedHandlerTest.kt": [
 38,
 128,
 226,
 283,
 289,
 331,
-393,
+393
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionDescriptionTest.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionDescriptionTest.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocFinderTest.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocFinderTest.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocSampleTest.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocSampleTest.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixMultiFileTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixMultiFileTest.kt": [
 170,
-232,
+232
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/CommonIntentionActionsTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/CommonIntentionActionsTest.kt": [
 71,
 204,
-340,
+340
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/UpdateConfigurationQuickFixTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/UpdateConfigurationQuickFixTest.kt": [
 46,
 46,
 92,
-115,
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureTest.kt": [
 423,
-606,
+606
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinMultiModuleChangeSignatureTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinMultiModuleChangeSignatureTest.kt": [
 65,
-69,
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/introduce/AbstractExtractionTest.kt':[
-230,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/introduce/AbstractExtractionTest.kt": [
+230
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/move/MoveKotlinDeclarationsHandlerTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/move/MoveKotlinDeclarationsHandlerTest.kt": [
 62,
-132,
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/run/RunConfigurationTest.kt':[
-147,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/run/RunConfigurationTest.kt": [
+147
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/run/StandaloneScriptRunConfigurationTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/run/StandaloneScriptRunConfigurationTest.kt": [
 42,
-80,
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/search/PsiBasedClassResolverTest.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/search/PsiBasedClassResolverTest.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/stubs/DebugTextByStubTest.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/stubs/DebugTextByStubTest.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/psi/KotlinInjectionTest.kt':[
-456,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/psi/KotlinInjectionTest.kt": [
+456
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/psi/StringTemplateExpressionManipulatorTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/psi/StringTemplateExpressionManipulatorTest.kt": [
 43,
-51,
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalJpsTest.kt':[
-286,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalJpsTest.kt": [
+286
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTest.kt": [
 223,
 421,
 424,
@@ -453,9 +453,9 @@
 660,
 817,
 896,
-938,
+938
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTestIncremental.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTestIncremental.kt": [
 57,
 64,
 86,
@@ -465,107 +465,107 @@
 89,
 89,
 90,
-90,
+90
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/GenerateJsTests.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/GenerateJsTests.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/EncodeSignatureTest.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/EncodeSignatureTest.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/test/JSTestGenerator.kt':[
-139,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/test/JSTestGenerator.kt": [
+139
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/kotlin-jsr223-local-example/src/test/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223ScriptEngineIT.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/kotlin-jsr223-local-example/src/test/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223ScriptEngineIT.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/KotlinClassMetadata.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/KotlinClassMetadata.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/test/kotlinx/metadata/test/MetadataSmokeTest.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/test/kotlinx/metadata/test/MetadataSmokeTest.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Arrays.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Arrays.kt": [
 809,
 899,
 2059,
 2159,
-11386,
+11386
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt": [
 172,
 184,
-194,
+194
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt": [
 104,
-116,
+116
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Strings.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Strings.kt": [
 66,
 76,
-1077,
+1077
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk7/test/TryWithResourcesAutoCloseableTest.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk7/test/TryWithResourcesAutoCloseableTest.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk7/test/TryWithResourcesCloseableTest.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk7/test/TryWithResourcesCloseableTest.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jre7/test/TryWithResourcesAutoCloseableTest.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jre7/test/TryWithResourcesAutoCloseableTest.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jre7/test/TryWithResourcesCloseableTest.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jre7/test/TryWithResourcesCloseableTest.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt':[
-186,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt": [
+186
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/util/MathJVM.kt':[
-588,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/util/MathJVM.kt": [
+588
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/FileTreeWalks.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/FileTreeWalks.kt": [
 17,
-17,
+17
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/Files.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/Files.kt": [
 84,
 89,
 98,
 104,
 123,
-203,
+203
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/collections/collections.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/collections/collections.kt": [
 51,
 68,
-355,
+355
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/collections/maps.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/collections/maps.kt": [
 15,
-134,
+134
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/comparisons/comparisons.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/comparisons/comparisons.kt": [
 72,
-84,
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/MapTest.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/MapTest.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/SequenceTest.kt':[
-152,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/SequenceTest.kt": [
+152
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/properties/delegation/lazy/LazyValuesTest.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/properties/delegation/lazy/LazyValuesTest.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/text/StringNumberConversionTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/text/StringNumberConversionTest.kt": [
 92,
-93,
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/text/StringTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/text/StringTest.kt": [
 326,
 329,
 330,
@@ -576,33 +576,33 @@
 481,
 543,
 567,
-739,
+739
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/config.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/config.kt": [
 19,
-26,
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/gen.kt':[
-253,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/gen.kt": [
+253
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildCacheIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildCacheIT.kt": [
 38,
-42,
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt": [
 39,
 92,
 241,
-241,
+241
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/JavaUpToDateIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/JavaUpToDateIT.kt": [
 18,
 18,
 18,
 18,
-21,
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt": [
 45,
 45,
 46,
@@ -612,131 +612,131 @@
 65,
 66,
 106,
-203,
+203
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalIT.kt": [
 37,
 38,
 42,
 85,
-161,
+161
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kotlin2JsGradlePluginIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kotlin2JsGradlePluginIT.kt": [
 67,
 231,
 234,
 237,
-246,
+246
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt": [
 40,
 40,
 105,
 409,
-581,
+581
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginMultiVersionIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginMultiVersionIT.kt": [
 31,
 32,
 33,
 34,
-83,
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MultiplatformGradleIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MultiplatformGradleIT.kt": [
 37,
 39,
 41,
-140,
+140
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/SimpleKotlinGradleIT.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/SimpleKotlinGradleIT.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/UpToDatenessIT.kt':[
-71,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/UpToDatenessIT.kt": [
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt':[
-238,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt": [
+238
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Comparables.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Comparables.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt": [
 45,
 46,
 84,
 131,
-558,
+558
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt": [
 33,
 628,
 673,
 991,
 994,
 1147,
-1151,
+1151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Mapping.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Mapping.kt": [
 58,
 70,
 114,
-176,
+176
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Ordering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Ordering.kt": [
 32,
 43,
 110,
-317,
+317
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Sets.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Sets.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/SourceFile.kt':[
-10,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/SourceFile.kt": [
+10
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializers.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializers.kt": [
 70,
 225,
 238,
 272,
 275,
-347,
+347
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/AbstractAndroidExtensionsExpressionCodegenExtension.kt':[
-221,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/AbstractAndroidExtensionsExpressionCodegenExtension.kt": [
+221
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/CacheMechanisms.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/CacheMechanisms.kt": [
 68,
 75,
 102,
-109,
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/ResourcePropertyStackValue.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/ResourcePropertyStackValue.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/parcel/AbstractParcelBoxTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/parcel/AbstractParcelBoxTest.kt": [
 61,
-124,
+124
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Plugin.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Plugin.kt": [
 117,
-145,
+145
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt':[
-335,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt": [
+335
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/KotlinKapt3IntegrationTests.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/KotlinKapt3IntegrationTests.kt": [
 46,
-65,
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptingCommandLineProcessor.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptingCommandLineProcessor.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastApiTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastApiTest.kt": [
 85,
-332,
-],
+332
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S122.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S122.json
@@ -1,99 +1,99 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/CodegenTestsOnAndroidGenerator.kt':[
-172,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/CodegenTestsOnAndroidGenerator.kt": [
+172
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrSourceCompilerForInline.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrSourceCompilerForInline.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/NewCommonSuperTypeCalculator.kt':[
-124,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/NewCommonSuperTypeCalculator.kt": [
+124
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/CallableReferenceResolver.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/CallableReferenceResolver.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/daemon/LogCheckUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/daemon/LogCheckUtil.kt": [
 35,
-36,
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt": [
 125,
-127,
+127
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt':[
-219,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt": [
+219
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/handlerUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/handlerUtils.kt": [
 94,
-97,
+97
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt": [
 337,
 436,
-460,
+460
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/j2k/IdeaDocCommentConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/j2k/IdeaDocCommentConverter.kt": [
 256,
-260,
+260
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/ReplColors.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/ReplColors.kt": [
 34,
-44,
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/benchmark/AbstractCompletionBenchmarkAction.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/benchmark/AbstractCompletionBenchmarkAction.kt": [
 105,
-110,
+110
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt':[
-201,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt": [
+201
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/ImportSettingsPanel.kt':[
-186,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/ImportSettingsPanel.kt": [
+186
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt':[
-184,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt": [
+184
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/decompiler/stubBuilder/AbstractClsStubBuilderTest.kt':[
-111,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/decompiler/stubBuilder/AbstractClsStubBuilderTest.kt": [
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/scratch/AbstractScratchRunActionTest.kt':[
-135,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/scratch/AbstractScratchRunActionTest.kt": [
+135
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryAssignmentElimination.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryAssignmentElimination.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt": [
 283,
-299,
+299
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.parser/src/org/jetbrains/kotlin/js/parser/sourcemaps/JSON.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.parser/src/org/jetbrains/kotlin/js/parser/sourcemaps/JSON.kt": [
 168,
 169,
 170,
 172,
-232,
+232
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/MainTest.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/MainTest.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/jvm/src/test/kotlin/TestJVMTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/jvm/src/test/kotlin/TestJVMTest.kt": [
 33,
 40,
 50,
-56,
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt':[
-1852,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt": [
+1852
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt':[
-1382,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt": [
+1382
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sets.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sets.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/ArrayIterator.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/ArrayIterator.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/ArrayIterators.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/ArrayIterators.kt": [
 13,
 19,
 25,
@@ -101,48 +101,48 @@
 37,
 43,
 49,
-55,
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/FileTreeWalks.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/FileTreeWalks.kt": [
 157,
-180,
+180
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/utils/AssertionsJVMTest.kt':[
-15,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/utils/AssertionsJVMTest.kt": [
+15
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/utils/LazyJVMTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/utils/LazyJVMTest.kt": [
 32,
 114,
-115,
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/ArraysTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/ArraysTest.kt": [
 389,
-395,
+395
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/CollectionTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/CollectionTest.kt": [
 708,
 711,
 717,
-720,
+720
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/properties/delegation/lazy/LazyValuesTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/properties/delegation/lazy/LazyValuesTest.kt": [
 38,
-61,
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/text/RegexTest.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/text/RegexTest.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/utils/PreconditionsTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/utils/PreconditionsTest.kt": [
 16,
-38,
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/typeMappings.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/typeMappings.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/UpToDatenessIT.kt':[
-150,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/UpToDatenessIT.kt": [
+150
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S125.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S125.json
@@ -1,208 +1,208 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/embeddable.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/embeddable.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/AssertCodegenUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/AssertCodegenUtil.kt": [
 68,
-77,
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SourceCompilerForInline.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SourceCompilerForInline.kt": [
 364,
-374,
+374
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/IteratorForLoopGenerator.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/IteratorForLoopGenerator.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/tests/org/jetbrains/kotlin/container/tests/ComponentContainerTest.kt':[
-190,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/tests/org/jetbrains/kotlin/container/tests/ComponentContainerTest.kt": [
+190
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/ControlFlowInstructionsGenerator.kt':[
-313,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/ControlFlowInstructionsGenerator.kt": [
+313
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt':[
-286,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt": [
+286
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/DiagnosticReporterImpl.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/DiagnosticReporterImpl.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewResolutionOldInference.kt':[
-282,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewResolutionOldInference.kt": [
+282
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt':[
-734,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt": [
+734
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/util/slicedMap/OpenAddressLinearProbingHashTable.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/util/slicedMap/OpenAddressLinearProbingHashTable.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/Ir.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/Ir.kt": [
 80,
 145,
 164,
 170,
-185,
+185
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/SecondaryCtorLowering.kt':[
-179,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/SecondaryCtorLowering.kt": [
+179
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/Namer.kt':[
-15,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/Namer.kt": [
+15
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt": [
 160,
-427,
+427
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt": [
 95,
-117,
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrSourceCompilerForInline.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrSourceCompilerForInline.kt": [
 141,
 145,
-150,
+150
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Concat.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Concat.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/RangeTo.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/RangeTo.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt':[
-213,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt": [
+213
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt':[
-194,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt": [
+194
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/AssignmentGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/AssignmentGenerator.kt": [
 59,
-62,
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/KotlinCall.kt':[
-17,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/KotlinCall.kt": [
+17
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/PackageMappingProvider.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/PackageMappingProvider.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/FunctionWithAllInvokes.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/FunctionWithAllInvokes.kt": [
 22,
-48,
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/script.runtime/src/kotlin/script/experimental/dependencies/AsyncDependenciesResolver.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/script.runtime/src/kotlin/script/experimental/dependencies/AsyncDependenciesResolver.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/values.kt':[
-102,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/values.kt": [
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/builtins/primitives.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/builtins/primitives.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt':[
-806,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt": [
+806
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt':[
-298,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt": [
+298
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSimpleGetterProvider.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSimpleGetterProvider.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/KotlinMavenImporter.kt':[
-302,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/KotlinMavenImporter.kt": [
+302
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/KotlinConsoleKeeper.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/KotlinConsoleKeeper.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/commonUtils.kt':[
-81,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/commonUtils.kt": [
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
-749,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
+749
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Expressions.kt':[
-224,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Expressions.kt": [
+224
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt": [
 95,
 100,
-127,
+127
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/utils/expandIsCalls.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/utils/expandIsCalls.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/JsImpl.kt':[
-15,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/JsImpl.kt": [
+15
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/KotlinModuleMetadata.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/KotlinModuleMetadata.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/HashSet.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/HashSet.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/LinkedHashMap.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/LinkedHashMap.kt": [
 49,
 57,
 68,
 72,
-197,
+197
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/LinkedHashSet.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/LinkedHashSet.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt": [
 274,
-283,
+283
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/regex/Regex.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/regex/Regex.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/FileTreeWalks.kt':[
-290,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/FileTreeWalks.kt": [
+290
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/Files.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/Files.kt": [
 225,
 230,
 234,
 239,
-285,
+285
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/ReadWrite.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/ReadWrite.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/text/RegexJVMTest.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/text/RegexJVMTest.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Grouping.kt':[
-268,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Grouping.kt": [
+268
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/ArraysTest.kt':[
-624,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/ArraysTest.kt": [
+624
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/CollectionTest.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/CollectionTest.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/GroupingTest.kt':[
-104,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/GroupingTest.kt": [
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/SequenceTest.kt':[
-301,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/SequenceTest.kt": [
+301
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/ranges/ProgressionLastElementTest.kt':[
-75,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/ranges/ProgressionLastElementTest.kt": [
+75
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/default/jvmOverloads.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/default/jvmOverloads.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/download.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/download.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/generators/GenerateStandardLib.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/generators/GenerateStandardLib.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt':[
-101,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt": [
+101
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S126.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S126.json
@@ -1,109 +1,109 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ChangesCollector.kt':[
-184,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ChangesCollector.kt": [
+184
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/buildUtil.kt':[
-142,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/buildUtil.kt": [
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend-common/src/org/jetbrains/kotlin/backend/common/CodegenUtil.kt':[
-96,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend-common/src/org/jetbrains/kotlin/backend/common/CodegenUtil.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/InterfaceImplBodyCodegen.kt':[
-78,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/InterfaceImplBodyCodegen.kt": [
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ScriptCodegen.kt':[
-229,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ScriptCodegen.kt": [
+229
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/fakeDescriptorsForReferences.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/fakeDescriptorsForReferences.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt": [
 192,
 512,
 526,
-545,
+545
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInlinerUtil.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInlinerUtil.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/ReifiedTypeInliner.kt':[
-236,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/ReifiedTypeInliner.kt": [
+236
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/ConstantConditionEliminationMethodTransformer.kt':[
-96,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/ConstantConditionEliminationMethodTransformer.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/RedundantNopsCleanupMethodTransformer.kt':[
-111,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/RedundantNopsCleanupMethodTransformer.kt": [
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/variableLiveness.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/variableLiveness.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/nullCheck/RedundantNullCheckMethodTransformer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/nullCheck/RedundantNullCheckMethodTransformer.kt": [
 123,
 162,
-185,
+185
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/BuilderFactoryForDuplicateSignatureDiagnostics.kt':[
-210,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/BuilderFactoryForDuplicateSignatureDiagnostics.kt": [
+210
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/JvmRuntimeVersionsConsistencyChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/JvmRuntimeVersionsConsistencyChecker.kt": [
 135,
-151,
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/ClasspathRootsResolver.kt':[
-215,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/ClasspathRootsResolver.kt": [
+215
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Registry.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Registry.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/classFiles/BinaryClassSignatureParser.kt':[
-123,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/classFiles/BinaryClassSignatureParser.kt": [
+123
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/ExternalFunChecker.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/ExternalFunChecker.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmDefaultChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmDefaultChecker.kt": [
 34,
-57,
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmSimpleNameBacktickChecker.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmSimpleNameBacktickChecker.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/annotationCheckers.kt':[
-104,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/annotationCheckers.kt": [
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/declarationCheckers.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/declarationCheckers.kt": [
 115,
-203,
+203
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/extensions/PartialAnalysisHandlerExtension.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/extensions/PartialAnalysisHandlerExtension.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ConstructorConsistencyChecker.kt':[
-160,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ConstructorConsistencyChecker.kt": [
+160
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt": [
 335,
 639,
-807,
+807
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt": [
 399,
-1515,
+1515
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/Renderers.kt':[
-524,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/Renderers.kt": [
+524
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationUseSiteTargetChecker.kt':[
-97,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationUseSiteTargetChecker.kt": [
+97
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/BindingContextUtils.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/BindingContextUtils.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt": [
 290,
 436,
 557,
@@ -111,471 +111,471 @@
 695,
 704,
 718,
-828,
+828
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegatingBindingTrace.kt':[
-107,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegatingBindingTrace.kt": [
+107
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LateinitModifierApplicabilityChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LateinitModifierApplicabilityChecker.kt": [
 50,
 66,
-93,
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LazyTopDownAnalyzer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LazyTopDownAnalyzer.kt": [
 135,
-138,
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverloadResolver.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverloadResolver.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverrideResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverrideResolver.kt": [
 225,
 233,
 255,
 321,
 637,
-796,
+796
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt": [
 198,
 629,
-651,
+651
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallExpressionResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallExpressionResolver.kt": [
 356,
-494,
+494
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt": [
 120,
 248,
 373,
 382,
-553,
+553
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/DeprecatedCallChecker.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/DeprecatedCallChecker.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/LateinitIntrinsicApplicabilityChecker.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/LateinitIntrinsicApplicabilityChecker.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/coroutineCallChecker.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/coroutineCallChecker.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/SmartCastManager.kt':[
-182,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/SmartCastManager.kt": [
+182
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/UnderscoreChecker.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/UnderscoreChecker.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyClassMemberScope.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyClassMemberScope.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/scopes/receivers/ExpressionReceiver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/scopes/receivers/ExpressionReceiver.kt": [
 62,
-71,
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt':[
-161,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt": [
+161
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/DefaultArgumentStubGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/DefaultArgumentStubGenerator.kt": [
 331,
-384,
+384
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LowerUtils.kt':[
-232,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LowerUtils.kt": [
+232
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt": [
 121,
-281,
+281
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt": [
 142,
-154,
+154
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt':[
-109,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt": [
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/ConstAndJvmFieldPropertiesLowering.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/ConstAndJvmFieldPropertiesLowering.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/EnumClassLowering.kt':[
-405,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/EnumClassLowering.kt": [
+405
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/InterfaceLowering.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/InterfaceLowering.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/wrappers/trees/TreeBasedClass.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/wrappers/trees/TreeBasedClass.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForSourceDeclaration.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForSourceDeclaration.kt": [
 207,
-216,
+216
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/kdoc/psi/impl/KDocTag.kt':[
-112,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/kdoc/psi/impl/KDocTag.kt": [
+112
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/DescriptorSerializer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/DescriptorSerializer.kt": [
 242,
 312,
-343,
+343
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractDiagnosticsTest.kt':[
-335,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractDiagnosticsTest.kt": [
+335
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/util/src/org/jetbrains/kotlin/utils/JsLibraryUtils.kt':[
-131,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/util/src/org/jetbrains/kotlin/utils/JsLibraryUtils.kt": [
+131
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/tests/org/jetbrains/kotlin/jvm/runtime/AbstractJvmRuntimeDescriptorLoaderTest.kt':[
-161,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/tests/org/jetbrains/kotlin/jvm/runtime/AbstractJvmRuntimeDescriptorLoaderTest.kt": [
+161
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/name/FqNamesUtil.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/name/FqNamesUtil.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/kClassCache.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/kClassCache.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/protobuf/GenerateProtoBufCompare.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/protobuf/GenerateProtoBufCompare.kt": [
 218,
-306,
+306
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/codeInsight/ReferenceVariantsHelper.kt':[
-379,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/codeInsight/ReferenceVariantsHelper.kt": [
+379
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/psi/patternMatching/KotlinPsiUnifier.kt':[
-924,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/psi/patternMatching/KotlinPsiUnifier.kt": [
+924
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/textBuilder/buildDecompiledText.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/textBuilder/buildDecompiledText.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/TypeKindHighlightingVisitor.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/TypeKindHighlightingVisitor.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/VariablesHighlightingVisitor.kt':[
-112,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/VariablesHighlightingVisitor.kt": [
+112
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/referenceUtil.kt':[
-145,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/referenceUtil.kt": [
+145
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/PsiBasedClassResolver.kt':[
-197,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/PsiBasedClassResolver.kt": [
+197
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinReferencesSearcher.kt':[
-228,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinReferencesSearcher.kt": [
+228
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/CommentSaver.kt':[
-320,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/CommentSaver.kt": [
+320
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/tests/org/jetbrains/kotlin/android/KotlinAndroidTestCase.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/tests/org/jetbrains/kotlin/android/KotlinAndroidTestCase.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/tests/org/jetbrains/kotlin/android/lint/AbstractKotlinLintTest.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/tests/org/jetbrains/kotlin/android/lint/AbstractKotlinLintTest.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt':[
-383,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt": [
+383
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt':[
-208,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt": [
+208
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionUtils.kt':[
-224,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionUtils.kt": [
+224
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/LookupElementFactory.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/LookupElementFactory.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinCallableInsertHandler.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinCallableInsertHandler.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/generateUtil.kt':[
-191,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/generateUtil.kt": [
+191
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleSourceSetDataService.kt':[
-127,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleSourceSetDataService.kt": [
+127
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/inspections/gradle/KotlinGradleInspectionVisitor.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/inspections/gradle/KotlinGradleInspectionVisitor.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/classLoading/ClassLoadingAdapter.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/classLoading/ClassLoadingAdapter.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/injection/InterpolatedStringInjectorProcessor.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/injection/InterpolatedStringInjectorProcessor.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/injection/KotlinLanguageInjector.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/injection/KotlinLanguageInjector.kt": [
+269
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/compile/KtCompilingExecutor.kt": [
+266
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/HistoryUpdater.kt": [
+75
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt": [
+117
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeToInlineBuilder.kt": [
+161
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinCopyPasteReferenceProcessor.kt": [
 269,
+320
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/compile/KtCompilingExecutor.kt':[
-266,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/HistoryUpdater.kt':[
-75,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt':[
-117,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeToInlineBuilder.kt':[
-161,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinCopyPasteReferenceProcessor.kt':[
-269,
-320,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/PlainTextPasteImportResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/PlainTextPasteImportResolver.kt": [
 97,
-103,
+103
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt": [
 208,
-246,
+246
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/fixers/KotlinCatchParameterFixer.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/fixers/KotlinCatchParameterFixer.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/fixers/KotlinPropertySetterParametersFixer.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/fixers/KotlinPropertySetterParametersFixer.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindClassUsagesHandler.kt':[
-150,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindClassUsagesHandler.kt": [
+150
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRainbowVisitor.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRainbowVisitor.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/markers/KotlinLineMarkerProvider.kt':[
-126,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/markers/KotlinLineMarkerProvider.kt": [
+126
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RecursivePropertyAccessorInspection.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RecursivePropertyAccessorInspection.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SimplifyWhenWithBooleanConstantConditionInspection.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SimplifyWhenWithBooleanConstantConditionInspection.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SortModifiersInspection.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SortModifiersInspection.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedReceiverParameterInspection.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedReceiverParameterInspection.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/UselessCallOnNotNullInspection.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/UselessCallOnNotNullInspection.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionTypeParameterToReceiverIntention.kt':[
-309,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionTypeParameterToReceiverIntention.kt": [
+309
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPrimaryConstructorToSecondaryIntention.kt':[
-169,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPrimaryConstructorToSecondaryIntention.kt": [
+169
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt": [
 116,
-133,
+133
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertSealedClassToEnumIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertSealedClassToEnumIntention.kt": [
 129,
-149,
+149
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTryFinallyToUseCallIntention.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTryFinallyToUseCallIntention.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MovePropertyToClassBodyIntention.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MovePropertyToClassBodyIntention.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/branchedTransformationUtils.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/branchedTransformationUtils.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/declarations/ConvertMemberToExtensionIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/declarations/ConvertMemberToExtensionIntention.kt": [
 200,
-212,
+212
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/FilterTransformation.kt':[
-166,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/FilterTransformation.kt": [
+166
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinTypeArgumentInfoHandler.kt':[
-189,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinTypeArgumentInfoHandler.kt": [
+189
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/TypeHints.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/TypeHints.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddTypeAnnotationToValueParameterFix.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddTypeAnnotationToValueParameterFix.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeVariableTypeFix.kt':[
-145,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeVariableTypeFix.kt": [
+145
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemovePartsFromPropertyFix.kt':[
-91,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemovePartsFromPropertyFix.kt": [
+91
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/WrongPrimitiveLiteralFix.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/WrongPrimitiveLiteralFix.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
-591,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
+591
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableFromUsageFix.kt':[
-138,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableFromUsageFix.kt": [
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/migration/MigrateExternalExtensionFix.kt':[
-173,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/migration/MigrateExternalExtensionFix.kt": [
+173
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt": [
 195,
 296,
-583,
+583
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinCallableDefinitionUsage.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinCallableDefinitionUsage.kt": [
 120,
 190,
-210,
+210
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt':[
-132,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt": [
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementSelectionUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementSelectionUtils.kt": [
 113,
-134,
+134
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractableAnalysisUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractableAnalysisUtil.kt": [
 273,
-324,
+324
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt':[
-199,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt": [
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinInplaceParameterIntroducer.kt':[
-153,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinInplaceParameterIntroducer.kt": [
+153
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt':[
-207,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt": [
+207
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt": [
 545,
-759,
+759
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt':[
-131,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt": [
+131
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/testIntegration/KotlinTestFinder.kt':[
-75,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/testIntegration/KotlinTestFinder.kt": [
+75
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/versions/KotlinJvmMetadataVersionIndex.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/versions/KotlinJvmMetadataVersionIndex.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/KotlinOutputChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/KotlinOutputChecker.kt": [
 65,
-93,
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/inspections/InspectionDescriptionTest.kt':[
-142,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/inspections/InspectionDescriptionTest.kt": [
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocSampleTest.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocSampleTest.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeBuilder.kt": [
 279,
 301,
 317,
-332,
+332
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt':[
-142,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt": [
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt':[
-764,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt": [
+764
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt':[
-323,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt": [
+323
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ForConverter.kt':[
-251,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ForConverter.kt": [
+251
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt": [
 292,
-337,
+337
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/propertyDetection.kt':[
-199,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/propertyDetection.kt": [
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalJpsTest.kt':[
-276,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalJpsTest.kt": [
+276
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt": [
 128,
-202,
+202
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/ReachabilityTracker.kt':[
-193,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/ReachabilityTracker.kt": [
+193
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/NameSuggestion.kt':[
-249,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/NameSuggestion.kt": [
+249
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsBuiltinNameClashChecker.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsBuiltinNameClashChecker.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsDynamicDeclarationChecker.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsDynamicDeclarationChecker.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsExternalChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsExternalChecker.kt": [
 62,
 134,
-169,
+169
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsInheritanceChecker.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsInheritanceChecker.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutineBodyTransformer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutineBodyTransformer.kt": [
 325,
-375,
+375
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutineTransformer.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutineTransformer.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/DeadCodeElimination.kt':[
-190,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/DeadCodeElimination.kt": [
+190
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/EmptyStatementElimination.kt':[
-94,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/EmptyStatementElimination.kt": [
+94
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/IfStatementReduction.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/IfStatementReduction.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt": [
 273,
-489,
+489
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/WhileConditionFolding.kt':[
-212,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/WhileConditionFolding.kt": [
+212
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/removeDuplicateImports.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/removeDuplicateImports.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/generateTestDataForReservedWords.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/generateTestDataForReservedWords.kt": [
 281,
-322,
+322
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt':[
-461,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt": [
+461
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/utils/LineOutputToStringVisitor.kt':[
-90,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/utils/LineOutputToStringVisitor.kt": [
+90
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/context/UsageTracker.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/context/UsageTracker.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/general/Merger.kt':[
-108,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/general/Merger.kt": [
+108
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/src/kotlinx/metadata/impl/writers.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/src/kotlinx/metadata/impl/writers.kt": [
 62,
-92,
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Arrays.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Arrays.kt": [
 2846,
 2864,
 2882,
@@ -584,57 +584,57 @@
 2936,
 2954,
 2972,
-2990,
+2990
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt':[
-619,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt": [
+619
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/mdn.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/mdn.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/fileUtil.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/fileUtil.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/utils.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/utils.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/impl/pathUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/impl/pathUtil.kt": [
 38,
-65,
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Comparables.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Comparables.kt": [
 204,
-318,
+318
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-js-merger/src/FileMerger.kt':[
-134,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-js-merger/src/FileMerger.kt": [
+134
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt':[
-352,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt": [
+352
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableDeclarationChecker.kt':[
-166,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableDeclarationChecker.kt": [
+166
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableResolveExtension.kt':[
-102,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableResolveExtension.kt": [
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/AndroidLayoutXmlFileManager.kt':[
-122,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/AndroidLayoutXmlFileManager.kt": [
+122
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/parcel/quickfixes/ParcelMigrateToParcelizeQuickFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/parcel/quickfixes/ParcelMigrateToParcelizeQuickFix.kt": [
 235,
-260,
+260
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/res/IDEAndroidLayoutXmlFileManager.kt':[
-102,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/res/IDEAndroidLayoutXmlFileManager.kt": [
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt':[
-232,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt": [
+232
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/nodejs/cli/KotlinNodeJsRunConfigurationProducer.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/nodejs/cli/KotlinNodeJsRunConfigurationProducer.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/nodejs/mocha/KotlinMochaRunConfigurationProducer.kt':[
-88,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/nodejs/mocha/KotlinMochaRunConfigurationProducer.kt": [
+88
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S134.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S134.json
@@ -1,87 +1,87 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/jdksFinder.kt':[
-169,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/jdksFinder.kt": [
+169
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/kotlinPluginArtifact.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/kotlinPluginArtifact.kt": [
 122,
 146,
 155,
-174,
+174
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/parser.kt':[
-363,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/parser.kt": [
+363
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend-common/src/org/jetbrains/kotlin/backend/common/CodegenUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend-common/src/org/jetbrains/kotlin/backend/common/CodegenUtil.kt": [
 99,
-192,
+192
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/CollectionStubMethodGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/CollectionStubMethodGenerator.kt": [
 110,
 122,
-150,
+150
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt':[
-570,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt": [
+570
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt": [
 299,
 505,
 572,
 811,
-1052,
+1052
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingMethodTransformer.kt':[
-113,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingMethodTransformer.kt": [
+113
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/MethodAnalyzer.kt':[
-122,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/MethodAnalyzer.kt": [
+122
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/nullCheck/RedundantNullCheckMethodTransformer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/nullCheck/RedundantNullCheckMethodTransformer.kt": [
 164,
-187,
+187
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/BuilderFactoryForDuplicateSignatureDiagnostics.kt':[
-178,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/BuilderFactoryForDuplicateSignatureDiagnostics.kt": [
+178
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.kt": [
 81,
 178,
-193,
+193
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CliTrace.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CliTrace.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/index/JvmDependenciesIndexImpl.kt':[
-134,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/index/JvmDependenciesIndexImpl.kt": [
+134
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/modules/JavaModuleGraph.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/modules/JavaModuleGraph.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt": [
 147,
 152,
-161,
+161
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JavaNullabilityChecker.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JavaNullabilityChecker.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/synthetic/SamAdapterFunctionsScope.kt':[
-109,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/synthetic/SamAdapterFunctionsScope.kt": [
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/reflectionUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/reflectionUtil.kt": [
 33,
 90,
 99,
-122,
+122
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ConstructorConsistencyChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ConstructorConsistencyChecker.kt": [
 150,
-156,
+156
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt": [
 347,
 450,
 456,
@@ -89,104 +89,104 @@
 782,
 810,
 824,
-831,
+831
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt':[
-1579,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt": [
+1579
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/WhenChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/WhenChecker.kt": [
 83,
 114,
 115,
 201,
 337,
-348,
+348
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/ControlFlowInstructionsGenerator.kt':[
-208,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/ControlFlowInstructionsGenerator.kt": [
+208
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationChecker.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationChecker.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationUseSiteTargetChecker.kt':[
-95,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationUseSiteTargetChecker.kt": [
+95
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationResolver.kt':[
-91,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationResolver.kt": [
+91
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt':[
-705,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt": [
+705
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/FunctionDescriptorResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/FunctionDescriptorResolver.kt": [
 398,
-407,
+407
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LazyTopDownAnalyzer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LazyTopDownAnalyzer.kt": [
 131,
-136,
+136
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/NonExpansiveInheritanceRestrictionChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/NonExpansiveInheritanceRestrictionChecker.kt": [
 106,
-133,
+133
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverrideResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverrideResolver.kt": [
 634,
 639,
-874,
+874
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt':[
-838,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt": [
+838
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt": [
 374,
-387,
+387
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/DeprecatedCallChecker.kt':[
-79,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/DeprecatedCallChecker.kt": [
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/DelegatingDataFlowInfo.kt':[
-129,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/DelegatingDataFlowInfo.kt": [
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/SmartCastManager.kt':[
-184,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/SmartCastManager.kt": [
+184
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/PSICallResolver.kt':[
-649,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/PSICallResolver.kt": [
+649
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/InlineParameterChecker.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/InlineParameterChecker.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt':[
-173,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt": [
+173
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/diagnostics/KotlinSuppressCache.kt':[
-157,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/diagnostics/KotlinSuppressCache.kt": [
+157
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/inline/InlineAnalyzerExtension.kt':[
-103,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/inline/InlineAnalyzerExtension.kt": [
+103
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/FunctionsTypingVisitor.kt':[
-283,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/FunctionsTypingVisitor.kt": [
+283
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/unqualifiedSuper/unqualifiedSuper.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/unqualifiedSuper/unqualifiedSuper.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunner.kt':[
-223,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunner.kt": [
+223
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/SecondaryCtorLowering.kt':[
-207,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/SecondaryCtorLowering.kt": [
+207
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt':[
-462,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt": [
+462
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt':[
-106,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt": [
+106
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/LoopExpressionGenerator.kt':[
-129,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/LoopExpressionGenerator.kt": [
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt": [
 96,
 104,
 114,
@@ -196,459 +196,459 @@
 150,
 158,
 168,
-176,
+176
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/LightClassUtil.kt':[
-92,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/LightClassUtil.kt": [
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForSourceDeclaration.kt':[
-403,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForSourceDeclaration.kt": [
+403
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/lightClassUtils.kt':[
-169,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/lightClassUtils.kt": [
+169
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/createByPattern.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/createByPattern.kt": [
 157,
 163,
-253,
+253
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ArgumentsToParametersMapper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ArgumentsToParametersMapper.kt": [
 166,
-238,
+238
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/KotlinConstraintSystemCompleter.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/KotlinConstraintSystemCompleter.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/FlatSignature.kt':[
-145,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/FlatSignature.kt": [
+145
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/types/TypeApproximator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/types/TypeApproximator.kt": [
 402,
 422,
-433,
+433
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractDiagnosticsTest.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractDiagnosticsTest.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/jvm/compiler/AbstractWriteSignatureTest.kt':[
-219,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/jvm/compiler/AbstractWriteSignatureTest.kt": [
+219
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/resolve/typeApproximation/CapturedTypeApproximationTest.kt':[
-119,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/resolve/typeApproximation/CapturedTypeApproximationTest.kt": [
+119
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/util/src/org/jetbrains/kotlin/utils/JsLibraryUtils.kt':[
-124,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/util/src/org/jetbrains/kotlin/utils/JsLibraryUtils.kt": [
+124
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/components/ReflectKotlinClass.kt':[
-132,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/components/ReflectKotlinClass.kt": [
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/tests/org/jetbrains/kotlin/jvm/runtime/AbstractJvmRuntimeDescriptorLoaderTest.kt':[
-166,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/tests/org/jetbrains/kotlin/jvm/runtime/AbstractJvmRuntimeDescriptorLoaderTest.kt": [
+166
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererImpl.kt": [
 317,
 634,
-638,
+638
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/utils.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/utils.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/util/scopeUtils.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/util/scopeUtils.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/deserialization/ModuleMapping.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/deserialization/ModuleMapping.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt": [
 104,
 151,
-220,
+220
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/jdi/test/jdiTest.kt':[
-71,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/jdi/test/jdiTest.kt": [
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/test/suiteBuilder.kt':[
-73,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/test/suiteBuilder.kt": [
+73
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/kdoc/findKDoc.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/kdoc/findKDoc.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/OptimizedImportsBuilder.kt':[
-199,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/OptimizedImportsBuilder.kt": [
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/psi/patternMatching/KotlinPsiUnifier.kt':[
-922,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/psi/patternMatching/KotlinPsiUnifier.kt": [
+922
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt": [
 226,
-232,
+232
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/PerModulePackageCacheService.kt':[
-249,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/PerModulePackageCacheService.kt": [
+249
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/IDELightClassContexts.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/IDELightClassContexts.kt": [
 257,
-264,
+264
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/LibraryDependenciesCache.kt':[
-111,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/LibraryDependenciesCache.kt": [
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/ModuleIndexCache.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/ModuleIndexCache.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/navigation/findDecompiledDeclaration.kt':[
-174,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/navigation/findDecompiledDeclaration.kt": [
+174
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinPsiChecker.kt':[
-298,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinPsiChecker.kt": [
+298
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/KotlinIndexers.kt':[
-95,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/KotlinIndexers.kt": [
+95
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinReferencesSearcher.kt':[
-259,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinReferencesSearcher.kt": [
+259
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt": [
 296,
 558,
 867,
 868,
-869,
+869
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/OperatorReferenceSearcher.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/OperatorReferenceSearcher.kt": [
 272,
-311,
+311
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/utils.kt':[
-196,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/utils.kt": [
+196
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/CommentSaver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/CommentSaver.kt": [
 255,
 310,
 315,
 328,
-370,
+370
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/idea-android-output-parser/src/org/jetbrains/kotlin/android/KotlinOutputParserHelper.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/idea-android-output-parser/src/org/jetbrains/kotlin/android/KotlinOutputParserHelper.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/configure/KotlinAndroidGradleLibraryDataService.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/configure/KotlinAndroidGradleLibraryDataService.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/folding/ResourceFoldingBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/folding/ResourceFoldingBuilder.kt": [
 196,
 227,
-231,
+231
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt':[
-213,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt": [
+213
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionUtils.kt": [
 200,
 206,
-209,
+209
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/ExtensionFunctionTypeValueCompletion.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/ExtensionFunctionTypeValueCompletion.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/FromUnresolvedNamesCompletion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/FromUnresolvedNamesCompletion.kt": [
 50,
-56,
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/InsertHandlerProvider.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/InsertHandlerProvider.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt": [
 210,
 245,
-273,
+273
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordValues.kt':[
-111,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordValues.kt": [
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KotlinCompletionContributor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KotlinCompletionContributor.kt": [
 115,
 121,
-128,
+128
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/LambdaSignatureTemplates.kt':[
-71,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/LambdaSignatureTemplates.kt": [
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/VariableOrParameterNameWithTypeCompletion.kt':[
-159,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/VariableOrParameterNameWithTypeCompletion.kt": [
+159
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinClassifierInsertHandler.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinClassifierInsertHandler.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinFunctionInsertHandler.kt':[
-109,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinFunctionInsertHandler.kt": [
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/MultipleArgumentsItemProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/MultipleArgumentsItemProvider.kt": [
 64,
-69,
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt": [
 121,
 152,
-232,
+232
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/handlers/CompletionHandlerTestBase.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/handlers/CompletionHandlerTestBase.kt": [
 81,
-89,
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ExpectedInfos.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ExpectedInfos.kt": [
 424,
-429,
+429
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt": [
 123,
-411,
+411
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ShortenReferences.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ShortenReferences.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/Utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/Utils.kt": [
 70,
-79,
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/generateUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/generateUtil.kt": [
 65,
-184,
+184
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/overrideImplement/OverrideMembersHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/overrideImplement/OverrideMembersHandler.kt": [
 43,
 61,
-68,
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GroovyBuildScriptManipulator.kt':[
-92,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GroovyBuildScriptManipulator.kt": [
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleProjectResolverExtension.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleProjectResolverExtension.kt": [
 149,
-159,
+159
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/core/script/GradleScriptTemplateProvider.kt':[
-305,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/core/script/GradleScriptTemplateProvider.kt": [
+305
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/inspections/gradle/GradleHeuristicHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/inspections/gradle/GradleHeuristicHelper.kt": [
 67,
-74,
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/inspections/gradle/KotlinGradleInspectionVisitor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/inspections/gradle/KotlinGradleInspectionVisitor.kt": [
 77,
-83,
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/run/MultiplatformGradleProjectTaskRunner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/run/MultiplatformGradleProjectTaskRunner.kt": [
 134,
-137,
+137
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/KotlinExtraSteppingFilter.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/KotlinExtraSteppingFilter.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/KotlinJavaModuleConfigurator.kt':[
-113,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/KotlinJavaModuleConfigurator.kt": [
+113
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt": [
 167,
-285,
+285
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinPositionManager.kt':[
-125,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinPositionManager.kt": [
+125
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/KotlinFieldBreakpoint.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/KotlinFieldBreakpoint.kt": [
 137,
 149,
 156,
 170,
-177,
+177
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/FrameVisitor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/FrameVisitor.kt": [
 62,
-72,
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinCodeFragmentFactory.kt':[
-244,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinCodeFragmentFactory.kt": [
+244
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/extractFunctionForDebuggerUtil.kt':[
-296,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/extractFunctionForDebuggerUtil.kt": [
+296
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSmartStepIntoHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSmartStepIntoHandler.kt": [
 156,
 187,
-196,
+196
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinStepOverInlinedLinesHint.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinStepOverInlinedLinesHint.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/filters/KotlinExceptionFilter.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/filters/KotlinExceptionFilter.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/framework/CustomLibraryDescriptorWithDeferredConfig.kt':[
-102,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/framework/CustomLibraryDescriptorWithDeferredConfig.kt": [
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/compile/KtCompilingExecutor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/compile/KtCompilingExecutor.kt": [
 182,
-245,
+245
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/MavenModulesRelationship.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/MavenModulesRelationship.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/inspections/KotlinMavenPluginPhaseInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/inspections/KotlinMavenPluginPhaseInspection.kt": [
 109,
 137,
-149,
+149
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-test-framework/test/org/jetbrains/kotlin/idea/test/ConfigLibraryUtil.kt':[
-144,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-test-framework/test/org/jetbrains/kotlin/idea/test/ConfigLibraryUtil.kt": [
+144
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinQuickDocumentationProvider.kt':[
-297,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinQuickDocumentationProvider.kt": [
+297
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/CheckComponentsUsageSearchAction.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/CheckComponentsUsageSearchAction.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/SearchNotPropertyCandidatesAction.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/SearchNotPropertyCandidatesAction.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt": [
 267,
-269,
+269
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeToInlineBuilder.kt':[
-174,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeToInlineBuilder.kt": [
+174
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/UsageReplacementStrategy.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/UsageReplacementStrategy.kt": [
 134,
-170,
+170
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt": [
 88,
-148,
+148
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/DataForConversion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/DataForConversion.kt": [
 78,
 93,
-252,
+252
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt": [
 210,
 248,
-251,
+251
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesHandlerFactory.kt':[
-71,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesHandlerFactory.kt": [
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRecursiveCallLineMarkerProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRecursiveCallLineMarkerProvider.kt": [
 74,
-164,
+164
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/DeprecatedCallableAddReplaceWithInspection.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/DeprecatedCallableAddReplaceWithInspection.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MoveSuspiciousCallableReferenceIntoParenthesesInspection.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MoveSuspiciousCallableReferenceIntoParenthesesInspection.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantExplicitTypeInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantExplicitTypeInspection.kt": [
 34,
 37,
 42,
-45,
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt':[
-251,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt": [
+251
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionToPropertyIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionToPropertyIntention.kt": [
 123,
-150,
+150
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionTypeParameterToReceiverIntention.kt':[
-205,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionTypeParameterToReceiverIntention.kt": [
+205
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt':[
-249,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt": [
+249
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt": [
 127,
-152,
+152
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertSecondaryConstructorToPrimaryIntention.kt':[
-132,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertSecondaryConstructorToPrimaryIntention.kt": [
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToStringTemplateIntention.kt':[
-113,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToStringTemplateIntention.kt": [
+113
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTwoComparisonsToRangeCheckIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTwoComparisonsToRangeCheckIntention.kt": [
 149,
-151,
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/CreateKotlinSubClassIntention.kt':[
-125,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/CreateKotlinSubClassIntention.kt": [
+125
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/DestructureIntention.kt':[
-297,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/DestructureIntention.kt": [
+297
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/InvertIfConditionIntention.kt':[
-129,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/InvertIfConditionIntention.kt": [
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/Utils.kt':[
-156,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/Utils.kt": [
+156
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/branchedTransformationUtils.kt':[
-117,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/branchedTransformationUtils.kt": [
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/declarations/ConvertMemberToExtensionIntention.kt':[
-207,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/declarations/ConvertMemberToExtensionIntention.kt": [
+207
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt": [
 90,
-192,
+192
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/AddToCollectionTransformation.kt':[
-152,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/AddToCollectionTransformation.kt": [
+152
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt':[
-302,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt": [
+302
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/ForEachTransformation.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/ForEachTransformation.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessor.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessor.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinTypeArgumentInfoHandler.kt':[
-205,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinTypeArgumentInfoHandler.kt": [
+205
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeMemberFunctionSignatureFix.kt':[
-168,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeMemberFunctionSignatureFix.kt": [
+168
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeVariableTypeFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeVariableTypeFix.kt": [
 142,
-148,
+148
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ExclExclCallFixes.kt':[
-144,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ExclExclCallFixes.kt": [
+144
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt": [
 241,
-248,
+248
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/SpecifyOverrideExplicitlyFix.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/SpecifyOverrideExplicitlyFix.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/SuperClassNotInitialized.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/SuperClassNotInitialized.kt": [
 95,
-101,
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
-1102,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
+1102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageFixBase.kt':[
-166,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageFixBase.kt": [
+166
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt": [
 141,
 254,
 285,
@@ -657,220 +657,220 @@
 854,
 855,
 858,
-862,
+862
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementSelectionUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementSelectionUtils.kt": [
 117,
-140,
+140
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/duplicateUtil.kt':[
-109,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/duplicateUtil.kt": [
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractorUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractorUtil.kt": [
 182,
-183,
+183
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt": [
 240,
 261,
-276,
+276
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceTypeAlias/introduceTypeAliasImpl.kt':[
-210,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceTypeAlias/introduceTypeAliasImpl.kt": [
+210
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt": [
 195,
 203,
 209,
 267,
-287,
+287
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt':[
-768,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt": [
+768
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveDeclarationsDelegate.kt':[
-163,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveDeclarationsDelegate.kt": [
+163
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsProcessor.kt": [
 309,
-313,
+313
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveUtils.kt": [
 153,
-156,
+156
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt": [
 121,
 126,
 507,
-518,
+518
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/KotlinPushDownProcessor.kt':[
-181,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/KotlinPushDownProcessor.kt": [
+181
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameConflictUtils.kt':[
-303,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameConflictUtils.kt": [
+303
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/findUsages/AbstractFindUsagesTest.kt':[
-316,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/findUsages/AbstractFindUsagesTest.kt": [
+316
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/intentions/AbstractIntentionTest.kt':[
-183,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/intentions/AbstractIntentionTest.kt": [
+183
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionDescriptionTest.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionDescriptionTest.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixMultiFileTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixMultiFileTest.kt": [
 171,
 242,
-246,
+246
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixTest.kt": [
 222,
-246,
+246
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/AnnotationConverter.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/AnnotationConverter.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ClassBodyConverter.kt':[
-103,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ClassBodyConverter.kt": [
+103
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt": [
 124,
 127,
 130,
-138,
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ConstructorConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ConstructorConverter.kt": [
 57,
-269,
+269
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt": [
 394,
 639,
-685,
+685
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt": [
 313,
 318,
 373,
 386,
 401,
 422,
-489,
+489
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ForConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ForConverter.kt": [
 166,
 172,
-244,
+244
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/OverloadReducer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/OverloadReducer.kt": [
 81,
-160,
+160
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt':[
-351,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt": [
+351
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/importConversion.kt':[
-136,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/importConversion.kt": [
+136
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/propertyDetection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/propertyDetection.kt": [
 194,
 200,
-355,
+355
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/tests/org/jetbrains/kotlin/j2k/AbstractJavaToKotlinConverterForWebDemoTest.kt':[
-119,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/tests/org/jetbrains/kotlin/j2k/AbstractJavaToKotlinConverterForWebDemoTest.kt": [
+119
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt": [
 242,
-261,
+261
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Context.kt':[
-95,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Context.kt": [
+95
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/NameSuggestion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/NameSuggestion.kt": [
 123,
-130,
+130
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsNameClashChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsNameClashChecker.kt": [
 73,
-182,
+182
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/IfStatementReduction.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/IfStatementReduction.kt": [
 46,
-63,
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryAssignmentElimination.kt':[
-194,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryAssignmentElimination.kt": [
+194
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/removeDuplicateImports.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/removeDuplicateImports.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/generateTestDataForReservedWords.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/generateTestDataForReservedWords.kt": [
 297,
-318,
+318
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/reference/CallArgumentTranslator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/reference/CallArgumentTranslator.kt": [
 98,
-113,
+113
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/runners/BasicJvmScriptEvaluator.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/runners/BasicJvmScriptEvaluator.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt": [
 562,
-565,
+565
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/InternalHashCodeMap.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/InternalHashCodeMap.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/stringsCode.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/stringsCode.kt": [
 102,
-106,
+106
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/CollectionToArray.kt':[
-73,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/CollectionToArray.kt": [
+73
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt": [
 273,
 279,
-297,
+297
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/FileTreeWalks.kt':[
-320,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/FileTreeWalks.kt": [
+320
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/Files.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/Files.kt": [
 472,
-539,
+539
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/ranges/ProgressionLastElementTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/ranges/ProgressionLastElementTest.kt": [
 72,
 73,
-78,
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/TypeParameterParsers.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/TypeParameterParsers.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/descriptors/AndroidSyntheticPackageFragmentDescriptor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/descriptors/AndroidSyntheticPackageFragmentDescriptor.kt": [
 70,
-76,
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/AndroidLayoutXmlFileManager.kt':[
-119,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/AndroidLayoutXmlFileManager.kt": [
+119
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Extension.kt':[
-354,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Extension.kt": [
+354
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt": [
 63,
 91,
-165,
+165
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/KotlinUSimpleReferenceExpression.kt':[
-84,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/KotlinUSimpleReferenceExpression.kt": [
+84
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S138.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S138.json
@@ -1,209 +1,209 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/render.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/render.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/plugins/PublishedKotlinModule.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/plugins/PublishedKotlinModule.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt": [
 135,
 206,
-456,
+456
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/pseudocodeUtils.kt':[
-75,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/pseudocodeUtils.kt": [
+75
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LazyTopDownAnalyzer.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LazyTopDownAnalyzer.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt':[
-186,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt": [
+186
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyDeclarationResolver.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyDeclarationResolver.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/DefaultArgumentStubGenerator.kt':[
-226,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/DefaultArgumentStubGenerator.kt": [
+226
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/generators/tests/GenerateCompilerTests.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/generators/tests/GenerateCompilerTests.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/jdi/test/jdiTest.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/jdi/test/jdiTest.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/builtins/unsignedTypes.kt':[
-313,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/builtins/unsignedTypes.kt": [
+313
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt':[
-165,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt": [
+165
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt':[
-466,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt": [
+466
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/textBuilder/buildDecompiledText.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/textBuilder/buildDecompiledText.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/findUsages/UsageTypeUtils.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/findUsages/UsageTypeUtils.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt':[
-286,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt": [
+286
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt": [
 197,
 348,
-524,
+524
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/TypeInstantiationItems.kt':[
-142,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/TypeInstantiationItems.kt": [
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleProjectResolverExtension.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleProjectResolverExtension.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleFacetImportTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleFacetImportTest.kt": [
 1259,
 1671,
-1781,
+1781
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleMultiplatformRunTest.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleMultiplatformRunTest.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSmartStepIntoHandler.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSmartStepIntoHandler.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/inspections/KotlinMavenPluginPhaseInspection.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/inspections/KotlinMavenPluginPhaseInspection.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/test/org/jetbrains/kotlin/idea/maven/KotlinMavenImporterTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/test/org/jetbrains/kotlin/idea/maven/KotlinMavenImporterTest.kt": [
 170,
 297,
 1892,
 2141,
-2455,
+2455
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinLanguageCodeStyleSettingsProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinLanguageCodeStyleSettingsProvider.kt": [
 21,
-172,
+172
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/declarations/ConvertMemberToExtensionIntention.kt':[
-104,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/declarations/ConvertMemberToExtensionIntention.kt": [
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocRenderer.kt':[
-192,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocRenderer.kt": [
+192
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
-438,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
+438
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt':[
-349,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt": [
+349
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/ui/KotlinChangeSignatureDialog.kt':[
-162,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/ui/KotlinChangeSignatureDialog.kt": [
+162
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt':[
-319,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt": [
+319
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/copy/CopyKotlinDeclarationsHandler.kt':[
-176,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/copy/CopyKotlinDeclarationsHandler.kt": [
+176
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementRenderingUtils.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementRenderingUtils.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/inline/KotlinInlineTypeAliasHandler.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/inline/KotlinInlineTypeAliasHandler.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractableAnalysisUtil.kt':[
-225,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractableAnalysisUtil.kt": [
+225
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractorUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractorUtil.kt": [
 232,
-414,
+414
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt':[
-151,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt": [
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinIntroduceParameterHandler.kt':[
-216,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinIntroduceParameterHandler.kt": [
+216
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt": [
 148,
-468,
+468
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameConflictUtils.kt':[
-215,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameConflictUtils.kt": [
+215
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/KotlinSafeDeleteProcessor.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/KotlinSafeDeleteProcessor.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt':[
-311,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt": [
+311
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt':[
-351,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt": [
+351
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt':[
-232,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt": [
+232
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/WhileConditionFolding.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/WhileConditionFolding.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstDeserializer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstDeserializer.kt": [
 125,
-280,
+280
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstSerializer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstSerializer.kt": [
 119,
-278,
+278
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/generateTestDataForReservedWords.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/generateTestDataForReservedWords.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/expression/LoopTranslator.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/expression/LoopTranslator.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm-host/src/kotlin/script/experimental/jvmhost/impl/KJVMCompilerImpl.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm-host/src/kotlin/script/experimental/jvmhost/impl/KJVMCompilerImpl.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/render.kt':[
-150,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/render.kt": [
+150
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/MemberBuilder.kt':[
-158,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/MemberBuilder.kt": [
+158
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt':[
-74,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt": [
+74
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1451.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1451.json
@@ -1,1301 +1,1301 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/AndroidSdkDependencies.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/AndroidSdkDependencies.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/Bootstrap.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/Bootstrap.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/CommonUtil.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/CommonUtil.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/SmartJavaExec.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/SmartJavaExec.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/artifacts.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/artifacts.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/dependencies.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/dependencies.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/embeddable.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/embeddable.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/instrument.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/instrument.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/jdksFinder.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/jdksFinder.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/context.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/context.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/extension.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/extension.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/kotlinPluginArtifact.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/kotlinPluginArtifact.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/parser.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/parser.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/pathContext.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/pathContext.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/plugin.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/plugin.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/render.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/render.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/xml.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/xml.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/plugins/PublishedKotlinModule.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/plugins/PublishedKotlinModule.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/sourceSets.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/sourceSets.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/stripMetadata.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/stripMetadata.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/preprocessCommandLineArguments.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/preprocessCommandLineArguments.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/snapshots/FileSnapshotMapTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/snapshots/FileSnapshotMapTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/snapshots/FileSnapshotTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/snapshots/FileSnapshotTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/CommonBackendContext.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/CommonBackendContext.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/DumpIrTreeWithDescriptorsVisitor.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/DumpIrTreeWithDescriptorsVisitor.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/Ir.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/Ir.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/StatementGenerator.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/StatementGenerator.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/arguments/GenerateKotlinGradleOptionsTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/arguments/GenerateKotlinGradleOptionsTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinMethodSmartStepIntoTarget.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinMethodSmartStepIntoTarget.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/projectView/KotlinProblemFileHighlightFilter.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/projectView/KotlinProblemFileHighlightFilter.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/TooLongCharLiteralToStringFix.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/TooLongCharLiteralToStringFix.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/SafeDeleteSuperTypeUsageInfo.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/SafeDeleteSuperTypeUsageInfo.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/test/CompatibilityVerifierVersionComparisonTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/test/CompatibilityVerifierVersionComparisonTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.ast/src/org/jetbrains/kotlin/js/backend/ast/JsEmpty.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.ast/src/org/jetbrains/kotlin/js/backend/ast/JsEmpty.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.ast/src/org/jetbrains/kotlin/js/backend/ast/JsVisitor.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.ast/src/org/jetbrains/kotlin/js/backend/ast/JsVisitor.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/FunctionInlineMutator.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/FunctionInlineMutator.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.parser/src/com/google/gwt/dev/js/parserExceptions/parserExceptions.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.parser/src/com/google/gwt/dev/js/parserExceptions/parserExceptions.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/annotation-processor-example/src/main/kotlin/example/ExampleAnnotationProcessor.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/annotation-processor-example/src/main/kotlin/example/ExampleAnnotationProcessor.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/annotation-processor-example/src/main/kotlin/example/annotations.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/annotation-processor-example/src/main/kotlin/example/annotations.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/browser-example-with-library/src/main/kotlin/sample/Hello.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/browser-example-with-library/src/main/kotlin/sample/Hello.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/browser-example-with-library/src/test/kotlin/sample/SampleTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/browser-example-with-library/src/test/kotlin/sample/SampleTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/browser-example/src/main/kotlin/sample/Hello.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/browser-example/src/main/kotlin/sample/Hello.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/browser-example/src/test/kotlin/sample/SampleTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/browser-example/src/test/kotlin/sample/SampleTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/js-example/src/main/kotlin/sample/Hello.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/js-example/src/main/kotlin/sample/Hello.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/js-example/src/test/kotlin/sample/SampleTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/js-example/src/test/kotlin/sample/SampleTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/kotlin-js-library-example/src/main/kotlin/sample/Main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/kotlin-js-library-example/src/main/kotlin/sample/Main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/main/kotlin/Main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/main/kotlin/Main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/MainTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/MainTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/OrgTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/OrgTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/other/name/NameTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/other/name/NameTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/some/SomeTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/some/SomeTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/some/name/NameTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/js/it/src/test/kotlin/org/some/name/NameTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/jquery/common.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/jquery/common.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/jquery/ui.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/jquery/ui.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/collections/maps.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/collections/maps.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/collections/sequences.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/collections/sequences.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/misc/preconditions.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/misc/preconditions.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/misc/tuples.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/misc/tuples.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/text/regex.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/text/regex.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/text/strings.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/text/strings.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/companions/companions.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/companions/companions.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/default/constructors.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/default/constructors.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/default/functions.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/default/functions.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/inline/inlineExposed.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/inline/inlineExposed.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/inline/inlineOnly.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/inline/inlineOnly.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/internalClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/internalClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/internalMultifile1.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/internalMultifile1.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/internalMultifile2.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/internalMultifile2.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/internalPart.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/internalPart.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/publicClassInternalMember.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/internal/publicClassInternalMember.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/localClasses/fromStdlib.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/localClasses/fromStdlib.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/localClasses/lambdas.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/localClasses/lambdas.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/localClasses/localClasses.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/localClasses/localClasses.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/internalClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/internalClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/internalInterface.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/internalInterface.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/internalObject.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/internalObject.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/privateClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/privateClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/privateInterface.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/privateInterface.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/privateObject.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/privateObject.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/publicAbstractClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/publicAbstractClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/publicClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/publicClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/publicInterface.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/publicInterface.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/publicObject.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/publicObject.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/publicOpenClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/nestedClasses/publicOpenClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/private/privateClassMembers.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/private/privateClassMembers.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/private/privateMultifile1.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/private/privateMultifile1.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/private/privateMultifile2.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/private/privateMultifile2.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/private/privatePart.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/private/privatePart.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/protected/protectedInAbstract.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/protected/protectedInAbstract.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/protected/protectedInFinal.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/protected/protectedInFinal.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/protected/protectedInOpen.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/protected/protectedInOpen.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/public/publicMultifile1.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/public/publicMultifile1.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/public/publicMultifile2.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/public/publicMultifile2.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/public/publicPart.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/public/publicPart.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/hidden.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/hidden.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/internalLateinitMember.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/internalLateinitMember.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/jvmField.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/jvmField.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/jvmNames.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/jvmNames.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/whenMappings/enumWhen.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/whenMappings/enumWhen.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/whenMappings/sealedClassWhen.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/whenMappings/sealedClassWhen.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/mdn.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/mdn.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/types.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/types.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/utils.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/utils.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-api/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/AbstractCompileWithDependenciesTracking.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-api/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/AbstractCompileWithDependenciesTracking.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/AbstractKotlinAndroidGradleTests.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/AbstractKotlinAndroidGradleTests.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseMultiGradleVersionIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseMultiGradleVersionIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ClassFileIsRemovedIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ClassFileIsRemovedIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ExecutionStrategyIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ExecutionStrategyIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KOTLIN_VERSION.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KOTLIN_VERSION.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3AndroidIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3AndroidIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kotlin2JsGradlePluginIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kotlin2JsGradlePluginIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginMultiVersionIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginMultiVersionIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/PluginsDslIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/PluginsDslIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/SimpleKotlinGradleIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/SimpleKotlinGradleIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/TestRootAffectedIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/TestRootAffectedIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/UpToDatenessIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/UpToDatenessIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/fileUtil.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/fileUtil.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/gradleRunningUtils.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/gradleRunningUtils.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/stringUtil.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/stringUtil.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/versionsUtils.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/versionsUtils.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/jps/BaseIncrementalGradleIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/jps/BaseIncrementalGradleIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/jps/KotlinGradlePluginJpsParametrizedIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/jps/KotlinGradlePluginJpsParametrizedIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/AndroidModule.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/AndroidModule.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/ApplicationComponent.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/ApplicationComponent.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/BaseApplication.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/BaseApplication.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/DemoActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/DemoActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/DemoApplication.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/DemoApplication.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/ForApplication.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/ForApplication.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/UseRJavaActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/UseRJavaActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/ui/HomeActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/ui/HomeActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/useBuildConfigJava.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/useBuildConfigJava.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/debug/java/debug.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/debug/java/debug.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/demo/java/demo.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/demo/java/demo.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/demoDebug/java/demoDebug.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/demoDebug/java/demoDebug.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/full/java/full.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/full/java/full.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/fullRelease/java/fullRelease.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/fullRelease/java/fullRelease.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/main/java/MainActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/main/java/MainActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/release/java/release.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsManyVariants/app/src/release/java/release.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsProject/app/src/main/java/com/example/androidextensions/noLayoutUsages.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsProject/app/src/main/java/com/example/androidextensions/noLayoutUsages.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/github/frankiesardo/icepick/CustomView.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/github/frankiesardo/icepick/CustomView.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/github/frankiesardo/icepick/Example.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/github/frankiesardo/icepick/Example.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/github/frankiesardo/icepick/ExampleBundler.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/github/frankiesardo/icepick/ExampleBundler.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/github/frankiesardo/icepick/MainActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/github/frankiesardo/icepick/MainActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/github/frankiesardo/icepick/MyBundler.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/github/frankiesardo/icepick/MyBundler.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/sample/icepick/lib/BaseActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/sample/icepick/lib/BaseActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/sample/icepick/lib/BaseCustomView.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/src/main/java/com/sample/icepick/lib/BaseCustomView.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/root/kotlin/org/jetbrains/kotlin/gradle/test/androidalfa/MainActivity2.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/root/kotlin/org/jetbrains/kotlin/gradle/test/androidalfa/MainActivity2.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/src/main/java/foo/FooKotlinClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/src/main/java/foo/FooKotlinClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/src/main/java/org/jetbrains/kotlin/gradle/InternalDummy.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/src/main/java/org/jetbrains/kotlin/gradle/InternalDummy.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/src/main/java2/bar/BarKotlinClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/src/main/java2/bar/BarKotlinClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/src/test/kotlin/org/jetbrains/kotlin/gradle/InternalDummyTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/src/test/kotlin/org/jetbrains/kotlin/gradle/InternalDummyTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Lib/src/androidTest/kotlin/internalTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Lib/src/androidTest/kotlin/internalTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Lib/src/main/kotlin/lib/libUtil.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Lib/src/main/kotlin/lib/libUtil.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Lib/src/test/kotlin/internalTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Lib/src/test/kotlin/internalTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Test/src/main/kotlin/Test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Test/src/main/kotlin/Test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/additionalJavaSrc/src/main/kotlin/helloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/additionalJavaSrc/src/main/kotlin/helloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/allOpenSimple/src/annotations.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/allOpenSimple/src/annotations.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/allOpenSimple/src/test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/allOpenSimple/src/test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/allOpenSpring/src/test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/allOpenSpring/src/test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/buildCacheSimple/src/main/kotlin/foo.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/buildCacheSimple/src/main/kotlin/foo.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/buildCacheSimple/src/main/kotlin/fooUsage.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/buildCacheSimple/src/main/kotlin/fooUsage.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/classpathTest/src/main/kotlin/helloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/classpathTest/src/main/kotlin/helloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/classpathTest/src/test/kotlin/tests.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/classpathTest/src/test/kotlin/tests.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/convertBetweenJavaAndKotlin/src/main/java/foo/Bar.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/convertBetweenJavaAndKotlin/src/main/java/foo/Bar.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/convertBetweenJavaAndKotlin/src/main/java/foo/KotlinBarUser.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/convertBetweenJavaAndKotlin/src/main/java/foo/KotlinBarUser.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/coroutinesProjectDSL/src/main/kotlin/main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/coroutinesProjectDSL/src/main/kotlin/main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/customCompilerFile/src/main/kotlin/Dummy.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/customCompilerFile/src/main/kotlin/Dummy.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/customJdk/src/main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/customJdk/src/main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/customSrcDir/src/helloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/customSrcDir/src/helloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/destinationDirReferencedDuringEvaluation/src/main/kotlin/foo/Greeter.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/destinationDirReferencedDuringEvaluation/src/main/kotlin/foo/Greeter.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/destinationDirReferencedDuringEvaluation/src/test/kotlin/foo/GreeterTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/destinationDirReferencedDuringEvaluation/src/test/kotlin/foo/GreeterTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/A.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/A.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/useA.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/useA.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/useBuzz.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/useBuzz.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/utils.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/src/main/kotlin/utils.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/lib/src/main/kotlin/A.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/lib/src/main/kotlin/A.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/lib/src/main/kotlin/utils.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/lib/src/main/kotlin/utils.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/AA.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/AA.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/BB.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/BB.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/FooDummy.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/FooDummy.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/JavaClassChild.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/JavaClassChild.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/fooCallUseAB.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/fooCallUseAB.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/fooUseA.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/fooUseA.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/fooUseAA.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/fooUseAA.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/fooUseB.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/fooUseB.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/fooUseBB.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/fooUseBB.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/useJavaClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/app/src/main/java/foo/useJavaClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/A.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/A.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/B.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/B.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/BarDummy.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/BarDummy.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/barUseA.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/barUseA.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/barUseAB.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/barUseAB.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/barUseB.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/barUseB.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/useTrackedJavaClassSameModule.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/incrementalMultiproject/lib/src/main/java/bar/useTrackedJavaClassSameModule.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaLibraryProject/app/src/main/kotlin/App.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaLibraryProject/app/src/main/kotlin/App.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaLibraryProject/libA/src/main/kotlin/HelloA.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaLibraryProject/libA/src/main/kotlin/HelloA.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaLibraryProject/libB/src/main/kotlin/HelloB.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaLibraryProject/libB/src/main/kotlin/HelloB.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaPackagePrefix/src/main/java/app/App.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaPackagePrefix/src/main/java/app/App.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaPackagePrefix/src/main/java/util/Appender.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaPackagePrefix/src/main/java/util/Appender.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/jvmTarget/src/helloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/jvmTarget/src/helloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-butterknife/app/src/main/java/org/example/kotlin/butterknife/SimpleActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-butterknife/app/src/main/java/org/example/kotlin/butterknife/SimpleActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-butterknife/app/src/main/java/org/example/kotlin/butterknife/SimpleAdapter.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-butterknife/app/src/main/java/org/example/kotlin/butterknife/SimpleAdapter.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-butterknife/app/src/main/java/org/example/kotlin/butterknife/SimpleApp.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-butterknife/app/src/main/java/org/example/kotlin/butterknife/SimpleApp.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/AndroidModule.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/AndroidModule.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/ApplicationComponent.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/ApplicationComponent.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/BaseApplication.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/BaseApplication.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/DemoActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/DemoActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/DemoApplication.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/DemoApplication.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/ForApplication.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/ForApplication.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/ui/HomeActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dagger/app/src/main/java/com/example/dagger/kotlin/ui/HomeActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/src/main/java/com/example/databinding/EnumAdapter.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/src/main/java/com/example/databinding/EnumAdapter.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/src/main/java/com/example/databinding/MainActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/src/main/java/com/example/databinding/MainActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/src/main/java/com/example/databinding/UserProfile.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/src/main/java/com/example/databinding/UserProfile.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/DatabaseApplication.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/DatabaseApplication.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/core/AppDatabase.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/core/AppDatabase.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/core/CalendarConverter.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/core/CalendarConverter.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/core/Item.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/core/Item.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/core/ItemRepository.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/core/ItemRepository.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/ui/BaseActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/ui/BaseActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/ui/MainActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/ui/MainActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/ui/MainAdapter.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/src/main/java/mobi/porquenao/poc/kotlin/ui/MainAdapter.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-realm/src/main/java/io/realm/examples/kotlin/KotlinExampleActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-realm/src/main/java/io/realm/examples/kotlin/KotlinExampleActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-realm/src/main/java/io/realm/examples/kotlin/model/Cat.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-realm/src/main/java/io/realm/examples/kotlin/model/Cat.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-realm/src/main/java/io/realm/examples/kotlin/model/Dog.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-realm/src/main/java/io/realm/examples/kotlin/model/Dog.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-realm/src/main/java/io/realm/examples/kotlin/model/Person.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-realm/src/main/java/io/realm/examples/kotlin/model/Person.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/arguments/src/main/java/test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/arguments/src/main/java/test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/autoService/processor/src/main/kotlin/processor/MyProcessor.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/autoService/processor/src/main/kotlin/processor/MyProcessor.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/autoService/src/main/kotlin/annotation/ProcessThis.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/autoService/src/main/kotlin/annotation/ProcessThis.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/autoService/src/main/kotlin/model/Model.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/autoService/src/main/kotlin/model/Model.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kaptOutputKotlinCode/src/main/java/test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kaptOutputKotlinCode/src/main/java/test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt15001/app/src/main/java/MainActivity.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt15001/app/src/main/java/MainActivity.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt15001/app/src/main/java/MyComponent.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt15001/app/src/main/java/MyComponent.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt15001/app/src/main/java/MyModule.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt15001/app/src/main/java/MyModule.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt18799/app/src/main/java/com.Constants.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt18799/app/src/main/java/com.Constants.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt18799/app/src/main/java/com.b.A.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt18799/app/src/main/java/com.b.A.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt18799/app/src/main/java/lib.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt18799/app/src/main/java/lib.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt19179/api/src/main/kotlin/Api.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt19179/api/src/main/kotlin/Api.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt19179/app/src/main/kotlin/Test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt19179/app/src/main/kotlin/Test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt19179/processor/src/main/kotlin/Processor.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt19179/processor/src/main/kotlin/Processor.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/localAnnotationProcessor/annotation-processor/src/main/java/TestAnnotationProcessor.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/localAnnotationProcessor/annotation-processor/src/main/java/TestAnnotationProcessor.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/localAnnotationProcessor/example/src/main/java/Example.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/localAnnotationProcessor/example/src/main/java/Example.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/localAnnotationProcessor/example/src/test/java/test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/localAnnotationProcessor/example/src/test/java/test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/locationMapping/src/main/java/test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/locationMapping/src/main/java/test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/src/main/java/foo/InternalDummy.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/src/main/java/foo/InternalDummy.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/src/main/java/foo/InternalDummyUser.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/src/main/java/foo/InternalDummyUser.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/src/main/java/foo/topLevelDummyFun.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/src/main/java/foo/topLevelDummyFun.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/src/main/java/test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/src/main/java/test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/src/test/java/foo/InternalDummyTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/src/test/java/foo/InternalDummyTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/bar/B.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/bar/B.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/bar/useB.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/bar/useB.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/baz/util.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/baz/util.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/foo/A.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/foo/A.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsDceProject/libraryProject/src/main/kotlin/examplelib/lib.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsDceProject/libraryProject/src/main/kotlin/examplelib/lib.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsDceProject/mainProject/src/main/kotlin/exampleapp/main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsDceProject/mainProject/src/main/kotlin/exampleapp/main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/app/src/main/kotlin/DummyInAppMain.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/app/src/main/kotlin/DummyInAppMain.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/app/src/main/kotlin/useAInAppMain.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/app/src/main/kotlin/useAInAppMain.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/app/src/test/kotlin/DummyInAppTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/app/src/test/kotlin/DummyInAppTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/app/src/test/kotlin/useAInAppTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/app/src/test/kotlin/useAInAppTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/lib/src/main/kotlin/A.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/lib/src/main/kotlin/A.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/lib/src/main/kotlin/DummyInLibMain.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/lib/src/main/kotlin/DummyInLibMain.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/lib/src/main/kotlin/useAInLibMain.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/lib/src/main/kotlin/useAInLibMain.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/lib/src/test/kotlin/DummyInLibTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/lib/src/test/kotlin/DummyInLibTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/lib/src/test/kotlin/useAInLibTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsICProject/lib/src/test/kotlin/useAInLibTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsNoOutputFileProject/src/main/kotlin/example/Dummy.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsNoOutputFileProject/src/main/kotlin/example/Dummy.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsNoOutputFileProject/src/test/kotlin/example/DummyTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsNoOutputFileProject/src/test/kotlin/example/DummyTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProject/libraryProject/src/main/kotlin/example/library/Adder.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProject/libraryProject/src/main/kotlin/example/library/Adder.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProject/libraryProject/src/main/kotlin/example/library/Counter.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProject/libraryProject/src/main/kotlin/example/library/Counter.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProject/mainProject/src/main/kotlin/example/main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProject/mainProject/src/main/kotlin/example/main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithCustomSourceset/src/integrationTest/kotlin/MainIT.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithCustomSourceset/src/integrationTest/kotlin/MainIT.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithCustomSourceset/src/main/kotlin/Main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithCustomSourceset/src/main/kotlin/Main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithSourceMapInline/app/src/main/kotlin/main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithSourceMapInline/app/src/main/kotlin/main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithSourceMapInline/lib/src/main/kotlin/foo.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithSourceMapInline/lib/src/main/kotlin/foo.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithTests/src/main/kotlin/Main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithTests/src/main/kotlin/Main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithTests/src/test/kotlin/MainTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithTests/src/test/kotlin/MainTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinBuiltins/app/src/main/kotlin/f.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinBuiltins/app/src/main/kotlin/f.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinBuiltins/app/src/main/kotlin/main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinBuiltins/app/src/main/kotlin/main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinGradleSubplugin/src/main/kotlin/helloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinGradleSubplugin/src/main/kotlin/helloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinInJavaRoot/src/main/java/kotlinPackage/Dummy.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinInJavaRoot/src/main/java/kotlinPackage/Dummy.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinInJavaRoot/src/main/java/kotlinPackage/KotlinClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinInJavaRoot/src/main/java/kotlinPackage/KotlinClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinInJavaRoot/src/main/java2/kotlinPackage2/KotlinClass2.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinInJavaRoot/src/main/java2/kotlinPackage2/KotlinClass2.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/src/deploy/kotlin/kotlinSrc.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/src/deploy/kotlin/kotlinSrc.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/src/main/kotlin/helloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/src/main/kotlin/helloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/src/test/kotlin/tests.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/src/test/kotlin/tests.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/main/kotlin/Dummy.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/main/kotlin/Dummy.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/main/kotlin/Greeter.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/main/kotlin/Greeter.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/main/kotlin/KotlinGreetingJoiner.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/main/kotlin/KotlinGreetingJoiner.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/main/kotlin/dummyUtil.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/main/kotlin/dummyUtil.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/test/kotlin/TestGreeter.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/test/kotlin/TestGreeter.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/test/kotlin/TestKotlinGreetingJoiner.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/src/test/kotlin/TestKotlinGreetingJoiner.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProjectWithBuildSrc/src/main/kotlin/Hello.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProjectWithBuildSrc/src/main/kotlin/Hello.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/languageVersion/src/main/kotlin/helloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/languageVersion/src/main/kotlin/helloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/moveClassToOtherModule/app/src/main/java/foo/A.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/moveClassToOtherModule/app/src/main/java/foo/A.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/moveClassToOtherModule/app/src/main/java/foo/useA.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/moveClassToOtherModule/app/src/main/java/foo/useA.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/moveClassToOtherModule/lib/src/main/java/bar/Dummy.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/moveClassToOtherModule/lib/src/main/java/bar/Dummy.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/lib/src/main/kotlin/PlatformClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/lib/src/main/kotlin/PlatformClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/lib/src/test/kotlin/PlatformTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/lib/src/test/kotlin/PlatformTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libAndroid/src/main/kotlin/PlatformClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libAndroid/src/main/kotlin/PlatformClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libAndroid/src/test/kotlin/PlatformTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libAndroid/src/test/kotlin/PlatformTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libJvm/src/main/kotlin/PlatformClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libJvm/src/main/kotlin/PlatformClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libJvm/src/main/kotlin/javaLibUse.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libJvm/src/main/kotlin/javaLibUse.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libJvm/src/test/kotlin/PlatformTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libJvm/src/test/kotlin/PlatformTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libA/src/main/kotlin/PlatformClassA.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libA/src/main/kotlin/PlatformClassA.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libA/src/test/kotlin/PlatformTestA.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libA/src/test/kotlin/PlatformTestA.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libB/src/main/kotlin/PlatformClassB.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libB/src/main/kotlin/PlatformClassB.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libB/src/test/kotlin/PlatformTestB.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libB/src/test/kotlin/PlatformTestB.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJs/src/main/kotlin/PlatformClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJs/src/main/kotlin/PlatformClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJs/src/test/kotlin/PlatformTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJs/src/test/kotlin/PlatformTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJvm/src/main/kotlin/PlatformClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJvm/src/main/kotlin/PlatformClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJvm/src/main/kotlin/javaLibUse.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJvm/src/main/kotlin/javaLibUse.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJvm/src/test/kotlin/PlatformTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJvm/src/test/kotlin/PlatformTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/lib/src/main/kotlin/PlatformClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/lib/src/main/kotlin/PlatformClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/lib/src/test/kotlin/PlatformTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/lib/src/test/kotlin/PlatformTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJs/src/main/kotlin/PlatformClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJs/src/main/kotlin/PlatformClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJs/src/test/kotlin/PlatformTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJs/src/test/kotlin/PlatformTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJvm/src/main/kotlin/PlatformClass.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJvm/src/main/kotlin/PlatformClass.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJvm/src/main/kotlin/javaLibUse.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJvm/src/main/kotlin/javaLibUse.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJvm/src/test/kotlin/PlatformTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJvm/src/test/kotlin/PlatformTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectClassPathTest/subproject/src/main/kotlin/helloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectClassPathTest/subproject/src/main/kotlin/helloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectClassPathTest/subproject/src/test/kotlin/tests.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectClassPathTest/subproject/src/test/kotlin/tests.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectWithDependency/projA/src/main/kotlin/a.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectWithDependency/projA/src/main/kotlin/a.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectWithDependency/projB/src/main/kotlin/helloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectWithDependency/projB/src/main/kotlin/helloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/noArgJpa/src/test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/noArgJpa/src/test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/noArgKt18668/src/test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/noArgKt18668/src/test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/allopenPluginsDsl/src/main/kotlin/annotations.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/allopenPluginsDsl/src/main/kotlin/annotations.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/allopenPluginsDsl/src/main/kotlin/test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/allopenPluginsDsl/src/main/kotlin/test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/allopenPluginsDsl/src/test/kotlin/HelloTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/allopenPluginsDsl/src/test/kotlin/HelloTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/applyToSubprojects/subproject/src/main/kotlin/helloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/applyToSubprojects/subproject/src/main/kotlin/helloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/applyToSubprojects/subproject/src/test/kotlin/tests.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/applyToSubprojects/subproject/src/test/kotlin/tests.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/src/deploy/kotlin/kotlinSrc.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/src/deploy/kotlin/kotlinSrc.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/src/main/kotlin/helloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/src/main/kotlin/helloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/src/test/kotlin/tests.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/src/test/kotlin/tests.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressWarnings/src/helloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressWarnings/src/helloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/typeAlias/src/main/kotlin/Curry.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/typeAlias/src/main/kotlin/Curry.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/typeAlias/src/main/kotlin/Dummy.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/typeAlias/src/main/kotlin/Dummy.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/typeAlias/src/main/kotlin/UseCurry.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/typeAlias/src/main/kotlin/UseCurry.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/agp25/kotlin/org/jetbrains/kotlin/gradle/plugin/android/Android25ProjectHandler.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/agp25/kotlin/org/jetbrains/kotlin/gradle/plugin/android/Android25ProjectHandler.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleCompilationResults.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleCompilationResults.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinCommonOptions.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinCommonOptions.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinCommonToolOptions.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinCommonToolOptions.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJsDceOptions.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJsDceOptions.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJsDceOptionsBase.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJsDceOptionsBase.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJsOptions.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJsOptions.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJsOptionsBase.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJsOptionsBase.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJvmOptions.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJvmOptions.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJvmOptionsBase.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJvmOptionsBase.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinMultiplatformCommonOptions.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinMultiplatformCommonOptions.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinMultiplatformCommonOptionsBase.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinMultiplatformCommonOptionsBase.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/KaptTask.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/KaptTask.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/CopyClassesToJavaOutputStatus.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/CopyClassesToJavaOutputStatus.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/SourceRoots.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/SourceRoots.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/tasksUtils.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/tasksUtils.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/incremental/jvmUtils.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/incremental/jvmUtils.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJvmOptionsImplTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJvmOptionsImplTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/util/bytecodeUtils.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/util/bytecodeUtils.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-allopen-spring/src/main/kotlin/Component.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-allopen-spring/src/main/kotlin/Component.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-apiVersion/src/main/kotlin/main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-apiVersion/src/main/kotlin/main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-classpath/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-classpath/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-customJdk/src/main/kotlin/main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-customJdk/src/main/kotlin/main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/CoffeeApp.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/CoffeeApp.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/CoffeeMaker.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/CoffeeMaker.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/DripCoffeeModule.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/DripCoffeeModule.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/ElectricHeater.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/ElectricHeater.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/Heater.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/Heater.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/Pump.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/Pump.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/PumpModule.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/PumpModule.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/Thermosiphon.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/Thermosiphon.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/test/kotlin/hello/tests/ExampleTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/test/kotlin/hello/tests/ExampleTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-extraArguments/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-extraArguments/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-helloworld/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-helloworld/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-extraArguments/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-extraArguments/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-sourceMapEmbedSources/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-sourceMapEmbedSources/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-jvmTarget/src/main/kotlin/main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-jvmTarget/src/main/kotlin/main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/AllOpenTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/AllOpenTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/CoffeeApp.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/CoffeeApp.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/CoffeeMaker.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/CoffeeMaker.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/DripCoffeeModule.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/DripCoffeeModule.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/ElectricHeater.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/ElectricHeater.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/Heater.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/Heater.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/Pump.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/Pump.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/PumpModule.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/PumpModule.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/Thermosiphon.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/Thermosiphon.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/test/kotlin/hello/tests/ExampleTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/test/kotlin/hello/tests/ExampleTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-generateKotlinCode/app/src/main/kotlin/test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-generateKotlinCode/app/src/main/kotlin/test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-languageVersion/src/main/kotlin/main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-languageVersion/src/main/kotlin/main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-moduleNameDefault/src/main/kotlin/org/jetbrains/moduleName.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-moduleNameDefault/src/main/kotlin/org/jetbrains/moduleName.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir-absolute/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir-absolute/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/js/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/js/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/js/src/test/kotlin/org/jetbrains/JSSpecificTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/js/src/test/kotlin/org/jetbrains/JSSpecificTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/jvm/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/jvm/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/jvm/src/test/kotlin/org/jetbrains/JVMSpecificTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/jvm/src/test/kotlin/org/jetbrains/JVMSpecificTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/shared/src/main/kotlin/org/jetbrains/api.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/shared/src/main/kotlin/org/jetbrains/api.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/shared/src/test/kotlin/org/jetbrains/SharedTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-multiplatform/shared/src/test/kotlin/org/jetbrains/SharedTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-plugins/test-extension/src/main/kotlin/org/jetbrains/kotlin/test/MavenPluginComponent.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-plugins/test-extension/src/main/kotlin/org/jetbrains/kotlin/test/MavenPluginComponent.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-plugins/test-extension/src/main/kotlin/org/jetbrains/kotlin/test/TestKotlinPluginRegistrar.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-plugins/test-extension/src/main/kotlin/org/jetbrains/kotlin/test/TestKotlinPluginRegistrar.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-plugins/use-test-extension/src/main/kotlin/main.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-plugins/use-test-extension/src/main/kotlin/main.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-sam-with-receiver-simple/src/main/kotlin/test.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-sam-with-receiver-simple/src/main/kotlin/test.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/test/resources/kotlinSimple/src/main/kotlin/A.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/test/resources/kotlinSimple/src/main/kotlin/A.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/test/resources/kotlinSimple/src/main/kotlin/Dummy.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/test/resources/kotlinSimple/src/main/kotlin/Dummy.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/test/resources/kotlinSimple/src/main/kotlin/useA.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/test/resources/kotlinSimple/src/main/kotlin/useA.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin/src/it/simple/src/main/kotlin/yo.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin/src/it/simple/src/main/kotlin/yo.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinStandardJsr223ScriptTemplate.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinStandardJsr223ScriptTemplate.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/context.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/context.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableCodegenExtension.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableCodegenExtension.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/declarations/KotlinUAnnotation.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/declarations/KotlinUAnnotation.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/evaluation/KotlinEvaluatorExtension.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/evaluation/KotlinEvaluatorExtension.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/ElvisExpression.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/ElvisExpression.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/KotlinUTypeReferenceExpression.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/KotlinUTypeReferenceExpression.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/LocalFunction.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/LocalFunction.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/internal/CliKotlinUastBindingContextProviderService.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/internal/CliKotlinUastBindingContextProviderService.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/psi/UastKotlinPsiParameter.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/psi/UastKotlinPsiParameter.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/psi/UastKotlinPsiVariable.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/psi/UastKotlinPsiVariable.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/AbstractKotlinIdentifiersTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/AbstractKotlinIdentifiersTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/AbstractKotlinRenderLogTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/AbstractKotlinRenderLogTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/AbstractKotlinTypesTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/AbstractKotlinTypesTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/AbstractKotlinUastTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/AbstractKotlinUastTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/AbstractKotlinValuesTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/AbstractKotlinValuesTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastApiTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastApiTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastResolveTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastResolveTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastTypesTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastTypesTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastValuesTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastValuesTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/SimpleKotlinRenderLogTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/SimpleKotlinRenderLogTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/inspections/KotlinSpringComponentScanInspection.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/inspections/KotlinSpringComponentScanInspection.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/tests/org/jetbrains/kotlin/idea/spring/tests/inspections/AbstractSpringInspectionTest.kt':[
-0,
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/tests/org/jetbrains/kotlin/idea/spring/tests/inspections/AbstractSpringInspectionTest.kt": [
+0
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/tests/org/jetbrains/kotlin/idea/spring/tests/quickfixes/AbstractSpringQuickFixTest.kt':[
-0,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/tests/org/jetbrains/kotlin/idea/spring/tests/quickfixes/AbstractSpringQuickFixTest.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1479.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1479.json
@@ -1,21 +1,21 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreter.kt": [
 116,
-218,
+218
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinUsageTypeProvider.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinUsageTypeProvider.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Expressions.kt':[
-187,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ast/Expressions.kt": [
+187
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstDeserializer.kt':[
-463,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstDeserializer.kt": [
+463
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstSerializer.kt':[
-495,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstSerializer.kt": [
+495
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt':[
-408,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt": [
+408
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1656.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1656.json
@@ -1,8 +1,8 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KotlinCompletionContributor.kt':[
-71,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KotlinCompletionContributor.kt": [
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt':[
-171,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt": [
+171
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1763.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1763.json
@@ -1,8 +1,8 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt':[
-172,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt": [
+172
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/tests/org/jetbrains/kotlin/android/AbstractAndroidFindUsagesTest.kt':[
-23,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/tests/org/jetbrains/kotlin/android/AbstractAndroidFindUsagesTest.kt": [
+23
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1764.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1764.json
@@ -1,12 +1,12 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/numbers.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/numbers.kt": [
 12,
-18,
+18
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/ranges/RangeTest.kt':[
-291,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/ranges/RangeTest.kt": [
+291
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/utils/GradleVersionTest.kt':[
-37,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/utils/GradleVersionTest.kt": [
+37
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1821.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1821.json
@@ -1,69 +1,69 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ChangesCollector.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ChangesCollector.kt": [
 93,
-108,
+108
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/PropertyReferenceCodegen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/PropertyReferenceCodegen.kt": [
 226,
 230,
-234,
+234
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SourceCompilerForInline.kt':[
-443,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SourceCompilerForInline.kt": [
+443
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/ApiVersionCallsPreprocessingMethodTransformer.kt':[
-83,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/ApiVersionCallsPreprocessingMethodTransformer.kt": [
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/BoxingInterpreter.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/BoxingInterpreter.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingMethodTransformer.kt':[
-293,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingMethodTransformer.kt": [
+293
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt": [
 45,
-69,
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/nullCheck/RedundantNullCheckMethodTransformer.kt':[
-225,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/nullCheck/RedundantNullCheckMethodTransformer.kt": [
+225
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplCompilingEvaluator.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplCompilingEvaluator.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/js/dce/K2JSDce.kt':[
-166,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/js/dce/K2JSDce.kt": [
+166
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/JvmRuntimeVersionsConsistencyChecker.kt':[
-346,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/JvmRuntimeVersionsConsistencyChecker.kt": [
+346
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/BasicCompilerServicesWithResultsFacadeServer.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/BasicCompilerServicesWithResultsFacadeServer.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt':[
-145,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt": [
+145
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/report/CompileServicesFacadeMessageCollector.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/report/CompileServicesFacadeMessageCollector.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/config/JvmTarget.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/config/JvmTarget.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/fileClasses/JvmFileClassUtil.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/fileClasses/JvmFileClassUtil.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/classFiles/BinaryJavaClass.kt':[
-183,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/structure/impl/classFiles/BinaryJavaClass.kt": [
+183
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/JvmOverridesBackwardCompatibilityHelper.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/JvmOverridesBackwardCompatibilityHelper.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JavaNullabilityChecker.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JavaNullabilityChecker.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt':[
-344,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt": [
+344
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/pseudocodeUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/pseudocodeUtils.kt": [
 147,
 169,
 187,
@@ -71,506 +71,506 @@
 207,
 248,
 249,
-254,
+254
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/LanguageFeatureMessageRenderer.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/LanguageFeatureMessageRenderer.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationChecker.kt": [
 214,
 222,
-230,
+230
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/VariableTypeAndInitializerResolver.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/VariableTypeAndInitializerResolver.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/coroutineCallChecker.kt':[
-85,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/coroutineCallChecker.kt": [
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/ExperimentalUsageChecker.kt':[
-200,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/ExperimentalUsageChecker.kt": [
+200
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/deprecationUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/deprecationUtil.kt": [
 156,
 167,
-175,
+175
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyDeclarationResolver.kt':[
-136,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyDeclarationResolver.kt": [
+136
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/LabelResolver.kt':[
-143,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/LabelResolver.kt": [
+143
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/VarargLowering.kt':[
-179,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/VarargLowering.kt": [
+179
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/SimpleNameGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/SimpleNameGenerator.kt": [
 36,
-58,
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/KtLightMemberImpl.kt':[
-97,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/KtLightMemberImpl.kt": [
+97
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/TypeCheckerContextForConstraintSystem.kt':[
-141,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/TypeCheckerContextForConstraintSystem.kt": [
+141
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/OverloadingConflictResolver.kt':[
-314,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/OverloadingConflictResolver.kt": [
+314
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ErrorCandidateFactory.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ErrorCandidateFactory.kt": [
 107,
-112,
+112
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/ContractSerializer.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/ContractSerializer.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/LazyOperationsLog.kt':[
-155,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/LazyOperationsLog.kt": [
+155
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTemplateTest.kt':[
-413,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTemplateTest.kt": [
+413
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/serialization/VersionRequirementTest.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/serialization/VersionRequirementTest.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/AnnotationTypeQualifierResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/AnnotationTypeQualifierResolver.kt": [
+167
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/typeEnhancement/typeEnhancement.kt": [
+76
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/AbstractBinaryClassAnnotationAndConstantLoader.kt": [
 167,
+344
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/typeEnhancement/typeEnhancement.kt':[
-76,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/AbstractBinaryClassAnnotationAndConstantLoader.kt':[
-167,
-344,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/ReflectionTypes.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/ReflectionTypes.kt": [
 79,
 83,
-87,
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/EffectiveVisibility.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/EffectiveVisibility.kt": [
 102,
 113,
 118,
 159,
-170,
+170
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRenderer.kt':[
-151,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRenderer.kt": [
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewKotlinTypeChecker.kt':[
-238,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewKotlinTypeChecker.kt": [
+238
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/AnnotationConstructorCaller.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/AnnotationConstructorCaller.kt": [
 77,
-172,
+172
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KDeclarationContainerImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KDeclarationContainerImpl.kt": [
 84,
-89,
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KFunctionImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KFunctionImpl.kt": [
 81,
-118,
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt": [
 230,
-244,
+244
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/RuntimeTypeMapper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/RuntimeTypeMapper.kt": [
 200,
-226,
+226
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreter.kt": [
 86,
 94,
 158,
 184,
 263,
 275,
-289,
+289
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt": [
 151,
-180,
+180
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/jdi/jdiValues.kt':[
-103,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/jdi/jdiValues.kt": [
+103
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt':[
-507,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt": [
+507
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/CallType.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/CallType.kt": [
 168,
 191,
-243,
+243
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/Utils.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/Utils.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/extensionsUtils.kt':[
-83,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/extensionsUtils.kt": [
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/psi/patternMatching/KotlinPsiUnifier.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/psi/patternMatching/KotlinPsiUnifier.kt": [
 311,
-404,
+404
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt": [
 275,
-290,
+290
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/KotlinIconProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/KotlinIconProvider.kt": [
 110,
-119,
+119
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/MapPsiToAsmDesc.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/MapPsiToAsmDesc.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/platformWrappers.kt':[
-195,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/platformWrappers.kt": [
+195
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/packageOracles.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/packageOracles.kt": [
 38,
-43,
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/findUsages/UsageTypeUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/findUsages/UsageTypeUtils.kt": [
 104,
 158,
-203,
+203
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/BeforeResolveHighlightingVisitor.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/BeforeResolveHighlightingVisitor.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinPsiChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinPsiChecker.kt": [
 217,
 253,
-258,
+258
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/searchUtil.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/searchUtil.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt": [
 217,
 274,
 485,
 511,
 552,
-900,
+900
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/InvokeOperatorReferenceSearcher.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/InvokeOperatorReferenceSearcher.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/OperatorReferenceSearcher.kt':[
-340,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/OperatorReferenceSearcher.kt": [
+340
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt':[
-315,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt": [
+315
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/InsertHandlerProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/InsertHandlerProvider.kt": [
 43,
-47,
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt": [
 217,
 271,
 349,
 374,
-378,
+378
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/LookupElementFactory.kt':[
-407,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/LookupElementFactory.kt": [
+407
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/Weighers.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/Weighers.kt": [
 133,
-257,
+257
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinNameSuggester.kt':[
-190,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinNameSuggester.kt": [
+190
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt':[
-128,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt": [
+128
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinEditorTextProvider.kt':[
-79,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinEditorTextProvider.kt": [
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/debuggerUtil.kt':[
-221,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/debuggerUtil.kt": [
+221
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinEvaluationBuilder.kt':[
-372,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinEvaluationBuilder.kt": [
+372
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSmartStepIntoHandler.kt':[
-196,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSmartStepIntoHandler.kt": [
+196
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/PomFile.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/PomFile.kt": [
 564,
-568,
+568
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/ClassUsageReplacementStrategy.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/ClassUsageReplacementStrategy.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/spellchecker/KotlinSpellcheckingStrategy.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/spellchecker/KotlinSpellcheckingStrategy.kt": [
 38,
-44,
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/DataForConversion.kt':[
-152,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/DataForConversion.kt": [
+152
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinSmartEnterHandler.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinSmartEnterHandler.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinElementDescriptionProvider.kt':[
-159,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinElementDescriptionProvider.kt": [
+159
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRecursiveCallLineMarkerProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRecursiveCallLineMarkerProvider.kt": [
 72,
-158,
+158
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CascadeIfInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CascadeIfInspection.kt": [
 43,
-46,
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/KotlinRedundantOverrideInspection.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/KotlinRedundantOverrideInspection.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MayBeConstantInspection.kt':[
-88,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MayBeConstantInspection.kt": [
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantExplicitTypeInspection.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantExplicitTypeInspection.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/conventionNameCalls/ReplaceCallWithBinaryOperatorInspection.kt':[
-134,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/conventionNameCalls/ReplaceCallWithBinaryOperatorInspection.kt": [
+134
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/AddAnnotationUseSiteTargetIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/AddAnnotationUseSiteTargetIntention.kt": [
 85,
-96,
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt": [
 226,
 235,
-242,
+242
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTwoComparisonsToRangeCheckIntention.kt':[
-116,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTwoComparisonsToRangeCheckIntention.kt": [
+116
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/DestructureIntention.kt':[
-155,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/DestructureIntention.kt": [
+155
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/InvertIfConditionIntention.kt':[
-231,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/InvertIfConditionIntention.kt": [
+231
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveExplicitTypeArgumentsIntention.kt':[
-136,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveExplicitTypeArgumentsIntention.kt": [
+136
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSingleLineLetIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSingleLineLetIntention.kt": [
 48,
-56,
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSizeCheckWithIsNotEmptyIntention.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSizeCheckWithIsNotEmptyIntention.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSizeZeroCheckWithIsEmptyIntention.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSizeZeroCheckWithIsEmptyIntention.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SimplifyBooleanWithConstantsIntention.kt':[
-113,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SimplifyBooleanWithConstantsIntention.kt": [
+113
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/Utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/Utils.kt": [
 50,
-185,
+185
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/BranchedFoldingUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/BranchedFoldingUtils.kt": [
 128,
-136,
+136
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/IfThenUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/IfThenUtils.kt": [
 207,
 237,
-249,
+249
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/branchedTransformationUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/branchedTransformationUtils.kt": [
 84,
-151,
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/AddToCollectionTransformation.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/AddToCollectionTransformation.kt": [
 144,
-173,
+173
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/SumTransformation.kt':[
-78,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/SumTransformation.kt": [
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/utils.kt": [
 215,
-224,
+224
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocRenderer.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocRenderer.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddAnnotationTargetFix.kt':[
-102,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddAnnotationTargetFix.kt": [
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ExclExclCallFixes.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ExclExclCallFixes.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ReplaceInfixOrOperatorCallFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ReplaceInfixOrOperatorCallFix.kt": [
 103,
-111,
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
 252,
 507,
 533,
 538,
-548,
+548
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/typeUtils.kt':[
-241,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/typeUtils.kt": [
+241
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createClass/CreateClassFromTypeReferenceActionFactory.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createClass/CreateClassFromTypeReferenceActionFactory.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createVariable/CreateParameterByRefActionFactory.kt':[
-97,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createVariable/CreateParameterByRefActionFactory.kt": [
+97
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/expectactual/CreateActualFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/expectactual/CreateActualFix.kt": [
 172,
-290,
+290
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageFixBase.kt':[
-159,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageFixBase.kt": [
+159
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt':[
-502,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt": [
+502
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt':[
-247,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt": [
+247
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt':[
-386,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt": [
+386
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractorUtil.kt':[
-358,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractorUtil.kt": [
+358
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt':[
-175,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt": [
+175
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt':[
-206,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt": [
+206
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/moveConflictUtils.kt':[
-112,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/moveConflictUtils.kt": [
+112
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveUtils.kt": [
 551,
 563,
-568,
+568
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinClassifierProcessor.kt':[
-110,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinClassifierProcessor.kt": [
+110
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameConflictUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameConflictUtils.kt": [
 151,
-169,
+169
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/KotlinSafeDeleteProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/KotlinSafeDeleteProcessor.kt": [
 165,
-176,
+176
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/roots/KotlinNonJvmSourceRootConverterProvider.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/roots/KotlinNonJvmSourceRootConverterProvider.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/Slicer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/Slicer.kt": [
 269,
 354,
-520,
+520
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/multiplatform/multiPlatformSetup.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/multiplatform/multiPlatformSetup.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt": [
 168,
 172,
 177,
 183,
 188,
-386,
+386
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Utils.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Utils.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/importConversion.kt':[
-92,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/importConversion.kt": [
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/usageProcessing/FieldToPropertyProcessing.kt':[
-109,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/usageProcessing/FieldToPropertyProcessing.kt": [
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt':[
-94,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt": [
+94
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/NameSuggestion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/NameSuggestion.kt": [
 283,
-290,
+290
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsDynamicCallChecker.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsDynamicCallChecker.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt": [
 83,
 98,
 113,
-181,
+181
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt':[
-627,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt": [
+627
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/WhileConditionFolding.kt':[
-141,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/WhileConditionFolding.kt": [
+141
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/callTranslator/CallTranslator.kt':[
-181,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/callTranslator/CallTranslator.kt": [
+181
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/expression/LoopTranslator.kt':[
-427,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/expression/LoopTranslator.kt": [
+427
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/intrinsic/operation/EqualsBOIF.kt':[
-107,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/intrinsic/operation/EqualsBOIF.kt": [
+107
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/utils/inlineUtils.kt':[
-104,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/utils/inlineUtils.kt": [
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/reflect/reflection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/reflect/reflection.kt": [
 22,
-35,
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/StringsJVM.kt':[
-442,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/StringsJVM.kt": [
+442
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Iterables.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Iterables.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/Indent.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/Indent.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/gen.kt':[
-252,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/gen.kt": [
+252
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/typeMappings.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/typeMappings.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/types.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/types.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt':[
-747,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt": [
+747
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/MemberBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/MemberBuilder.kt": [
 187,
 192,
 198,
@@ -578,32 +578,32 @@
 211,
 217,
 225,
-231,
+231
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt": [
 240,
-246,
+246
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/SignatureParserVisitor.kt':[
-220,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/SignatureParserVisitor.kt": [
+220
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt": [
 164,
 339,
 412,
 498,
-508,
+508
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/declarations/KotlinUMethod.kt':[
-96,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/declarations/KotlinUMethod.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/declarations/KotlinUVariable.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/declarations/KotlinUVariable.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/evaluation/KotlinEvaluatorExtension.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/evaluation/KotlinEvaluatorExtension.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/internal/kotlinInternalUastUtils.kt':[
-158,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/internal/kotlinInternalUastUtils.kt": [
+158
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1871.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1871.json
@@ -1,39 +1,39 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/protoDifferenceUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/protoDifferenceUtils.kt": [
 235,
-246,
+246
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt':[
-202,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt": [
+202
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/PrimitiveNumberRangeIntrinsicRangeValue.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/PrimitiveNumberRangeIntrinsicRangeValue.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/AbstractLazyMemberScope.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/AbstractLazyMemberScope.kt": [
 205,
-217,
+217
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/KCallablesJvm.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/KCallablesJvm.kt": [
 52,
-76,
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/KotlinFieldBreakpoint.kt':[
-290,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/KotlinFieldBreakpoint.kt": [
+290
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantNotNullExtensionReceiverOfInlineInspection.kt':[
-99,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantNotNullExtensionReceiverOfInlineInspection.kt": [
+99
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/typeUtils.kt':[
-197,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/typeUtils.kt": [
+197
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/ranges/RangeIterationTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/ranges/RangeIterationTest.kt": [
 29,
-34,
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt':[
-430,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt": [
+430
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt':[
-202,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt": [
+202
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1940.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S1940.json
@@ -1,11 +1,11 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ReferenceSearcher.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ReferenceSearcher.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/ranges/RangesJVM.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/ranges/RangesJVM.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/ranges/Ranges.kt':[
-68,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/ranges/Ranges.kt": [
+68
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S3776.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S3776.json
@@ -1,5 +1,5 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ProtoCompareGenerated.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/src/org/jetbrains/kotlin/incremental/ProtoCompareGenerated.kt": [
 41,
 96,
 142,
@@ -19,1670 +19,1670 @@
 1498,
 1594,
 1674,
-1860,
+1860
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/test/org/jetbrains/kotlin/incremental/testingUtils/incrementalModificationUtils.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/test/org/jetbrains/kotlin/incremental/testingUtils/incrementalModificationUtils.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/kotlinPluginArtifact.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/kotlinPluginArtifact.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/parser.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/parser.kt": [
 225,
-321,
+321
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/plugin.kt':[
-181,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/plugin.kt": [
+181
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/render.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/render.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/plugins/PublishedKotlinModule.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/plugins/PublishedKotlinModule.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/stripMetadata.kt':[
-14,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/stripMetadata.kt": [
+14
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/tasks.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/tasks.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/CodegenTestsOnAndroidGenerator.kt':[
-184,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/CodegenTestsOnAndroidGenerator.kt": [
+184
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/BoxedVsPrimitiveBranchedValues.kt':[
-316,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/BoxedVsPrimitiveBranchedValues.kt": [
+316
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/CollectionStubMethodGenerator.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/CollectionStubMethodGenerator.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/DefaultParameterValueSubstitutor.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/DefaultParameterValueSubstitutor.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/InterfaceImplBodyCodegen.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/InterfaceImplBodyCodegen.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ScriptCodegen.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ScriptCodegen.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/builtinSpecialBridges.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/builtinSpecialBridges.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt':[
-763,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt": [
+763
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/refinedIntTypesAnalysis.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/refinedIntTypesAnalysis.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt": [
 49,
 318,
-484,
+484
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt": [
 168,
-351,
+351
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt": [
 135,
 206,
 361,
 456,
-765,
+765
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/defaultMethodUtil.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/defaultMethodUtil.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/CapturedVarsOptimizationMethodTransformer.kt':[
-178,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/CapturedVarsOptimizationMethodTransformer.kt": [
+178
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/MethodAnalyzer.kt':[
-96,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/MethodAnalyzer.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/nullCheck/RedundantNullCheckMethodTransformer.kt':[
-155,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/nullCheck/RedundantNullCheckMethodTransformer.kt": [
+155
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/ForInDefinitelySafeSimpleProgressionLoopGenerator.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/ForInDefinitelySafeSimpleProgressionLoopGenerator.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InContinuousRangeOfComparableExpressionGenerator.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InContinuousRangeOfComparableExpressionGenerator.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InIntegralContinuousRangeExpressionGenerator.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InIntegralContinuousRangeExpressionGenerator.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/BuilderFactoryForDuplicateSignatureDiagnostics.kt':[
-159,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/BuilderFactoryForDuplicateSignatureDiagnostics.kt": [
+159
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt':[
-188,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt": [
+188
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/Jsr305Parser.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/Jsr305Parser.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/parseCommandLineArguments.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/parseCommandLineArguments.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplEvaluator.kt':[
-34,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplEvaluator.kt": [
+34
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-runner/src/org/jetbrains/kotlin/runner/Main.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-runner/src/org/jetbrains/kotlin/runner/Main.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/JvmRuntimeVersionsConsistencyChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/JvmRuntimeVersionsConsistencyChecker.kt": [
 99,
-275,
+275
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/ClasspathRootsResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/ClasspathRootsResolver.kt": [
 82,
-199,
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinToJVMBytecodeCompiler.kt':[
-178,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinToJVMBytecodeCompiler.kt": [
+178
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/index/JvmDependenciesIndexImpl.kt':[
-114,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/index/JvmDependenciesIndexImpl.kt": [
+114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/index/SingleJavaFileRootsIndex.kt':[
-78,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/index/SingleJavaFileRootsIndex.kt": [
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/modules/JavaModuleGraph.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/modules/JavaModuleGraph.kt": [
 27,
-63,
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/plugins/PluginCliParser.kt':[
-78,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/plugins/PluginCliParser.kt": [
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt':[
-312,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt": [
+312
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt':[
-129,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt": [
+129
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/RemoteCompilationCanceledStatusClient.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/RemoteCompilationCanceledStatusClient.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/InterfaceDefaultMethodCallChecker.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/InterfaceDefaultMethodCallChecker.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JavaNullabilityChecker.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JavaNullabilityChecker.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmDefaultChecker.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmDefaultChecker.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/annotationCheckers.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/annotationCheckers.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/declarationCheckers.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/declarationCheckers.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/extensions/PartialAnalysisHandlerExtension.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/extensions/PartialAnalysisHandlerExtension.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/reflectionUtil.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/reflectionUtil.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ConstructorConsistencyChecker.kt':[
-110,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ConstructorConsistencyChecker.kt": [
+110
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt": [
 264,
 320,
 406,
 562,
 651,
 773,
-859,
+859
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt": [
 633,
 918,
 1228,
-1564,
+1564
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/PseudocodeTraverser.kt':[
-79,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/PseudocodeTraverser.kt": [
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/PseudocodeVariablesData.kt':[
-245,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/PseudocodeVariablesData.kt": [
+245
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/WhenChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/WhenChecker.kt": [
 101,
 177,
-322,
+322
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/PseudocodeImpl.kt':[
-369,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/PseudocodeImpl.kt": [
+369
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/pseudocodeUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/pseudocodeUtils.kt": [
 75,
-142,
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt": [
 662,
 737,
 816,
-856,
+856
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/FunctionDescriptorResolver.kt':[
-380,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/FunctionDescriptorResolver.kt": [
+380
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LateinitModifierApplicabilityChecker.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LateinitModifierApplicabilityChecker.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LazyTopDownAnalyzer.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LazyTopDownAnalyzer.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LocalVariableResolver.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/LocalVariableResolver.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/NonExpansiveInheritanceRestrictionChecker.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/NonExpansiveInheritanceRestrictionChecker.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverloadResolver.kt':[
-240,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverloadResolver.kt": [
+240
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverrideResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverrideResolver.kt": [
 251,
-615,
+615
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/QualifiedExpressionResolver.kt':[
-396,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/QualifiedExpressionResolver.kt": [
+396
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/ShadowedExtensionChecker.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/ShadowedExtensionChecker.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt": [
 186,
 698,
-816,
+816
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallCompleter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallCompleter.kt": [
 68,
-154,
+154
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallExpressionResolver.kt':[
-205,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallExpressionResolver.kt": [
+205
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt": [
 281,
 350,
-497,
+497
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/DeprecatedCallChecker.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/DeprecatedCallChecker.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/OperatorCallChecker.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/OperatorCallChecker.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/ConstraintSystemBuilderImpl.kt':[
-199,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/ConstraintSystemBuilderImpl.kt": [
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/TypeBoundsImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/inference/TypeBoundsImpl.kt": [
 81,
-161,
+161
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/DelegatingDataFlowInfo.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/DelegatingDataFlowInfo.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/SmartCastManager.kt':[
-166,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/smartcasts/SmartCastManager.kt": [
+166
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/KotlinResolutionCallbacksImpl.kt':[
-83,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/KotlinResolutionCallbacksImpl.kt": [
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/PSICallResolver.kt':[
-603,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/PSICallResolver.kt": [
+603
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/ClassifierUsageChecker.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/ClassifierUsageChecker.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/DataClassDeclarationChecker.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/DataClassDeclarationChecker.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/ExpectedActualDeclarationChecker.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/ExpectedActualDeclarationChecker.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/InlineClassDeclarationChecker.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/InlineClassDeclarationChecker.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/InlineParameterChecker.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/InlineParameterChecker.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt": [
 138,
 359,
-526,
+526
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/deprecationUtil.kt':[
-284,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/deprecationUtil.kt": [
+284
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/inline/InlineAnalyzerExtension.kt':[
-91,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/inline/InlineAnalyzerExtension.kt": [
+91
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/FileScopeFactory.kt':[
-216,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/FileScopeFactory.kt": [
+216
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/AbstractLazyMemberScope.kt':[
-178,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/AbstractLazyMemberScope.kt": [
+178
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyClassMemberScope.kt':[
-212,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyClassMemberScope.kt": [
+212
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt": [
 131,
-691,
+691
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/FunctionsTypingVisitor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/FunctionsTypingVisitor.kt": [
 51,
-259,
+259
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/PatternMatchingTypingVisitor.kt':[
-328,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/PatternMatchingTypingVisitor.kt": [
+328
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt':[
-181,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt": [
+181
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunner.kt':[
-204,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunner.kt": [
+204
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/testLogsParsingUtil.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/testLogsParsingUtil.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/TailRecursionCallsCollector.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/TailRecursionCallsCollector.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/DefaultArgumentStubGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/DefaultArgumentStubGenerator.kt": [
 72,
-226,
+226
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/VarargLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/VarargLowering.kt": [
 67,
-99,
+99
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/IrElementToJsExpressionTransformer.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/IrElementToJsExpressionTransformer.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/SimpleNameGenerator.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/SimpleNameGenerator.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt':[
-414,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt": [
+414
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt": [
 82,
-126,
+126
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt':[
-70,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt": [
+70
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForSourceDeclaration.kt':[
-383,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForSourceDeclaration.kt": [
+383
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/duplicateJvmSignatureUtil.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/duplicateJvmSignatureUtil.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/lightAnnotations.kt':[
-235,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/lightAnnotations.kt": [
+235
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/kdoc/parser/KDocLinkParser.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/kdoc/parser/KDocLinkParser.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/kdoc/psi/impl/KDocTag.kt':[
-78,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/kdoc/psi/impl/KDocTag.kt": [
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinWhitespaceAndCommentsBinders.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinWhitespaceAndCommentsBinders.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/addRemoveModifier.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/addRemoveModifier.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/createByPattern.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/createByPattern.kt": [
 115,
-224,
+224
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/NewCommonSuperTypeCalculator.kt':[
-178,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/NewCommonSuperTypeCalculator.kt": [
+178
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ArgumentsToParametersMapper.kt':[
-232,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ArgumentsToParametersMapper.kt": [
+232
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/SimpleArgumentsChecks.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/SimpleArgumentsChecks.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/KotlinConstraintSystemCompleter.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/KotlinConstraintSystemCompleter.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/NewTypeSubstitutor.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/NewTypeSubstitutor.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/FlatSignature.kt':[
-124,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/FlatSignature.kt": [
+124
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ErrorCandidateFactory.kt':[
-97,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ErrorCandidateFactory.kt": [
+97
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt": [
 226,
-431,
+431
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/types/TypeApproximator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/types/TypeApproximator.kt": [
 122,
-341,
+341
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/DescriptorSerializer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/DescriptorSerializer.kt": [
 60,
-158,
+158
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractDiagnosticsTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractDiagnosticsTest.kt": [
 64,
-393,
+393
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/InlineTestUtil.kt':[
-106,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/InlineTestUtil.kt": [
+106
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/jvm/compiler/AbstractWriteSignatureTest.kt':[
-191,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/jvm/compiler/AbstractWriteSignatureTest.kt": [
+191
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/renderer/AbstractDescriptorRendererTest.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/renderer/AbstractDescriptorRendererTest.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/code/CodeConformanceTest.kt':[
-88,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/code/CodeConformanceTest.kt": [
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt':[
-541,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt": [
+541
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/resolve/typeApproximation/CapturedTypeApproximationTest.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/resolve/typeApproximation/CapturedTypeApproximationTest.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaScope.kt':[
-325,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaScope.kt": [
+325
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/AbstractBinaryClassAnnotationAndConstantLoader.kt':[
-220,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/AbstractBinaryClassAnnotationAndConstantLoader.kt": [
+220
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/typeSignatureMapping.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/typeSignatureMapping.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/tests/org/jetbrains/kotlin/jvm/runtime/AbstractJvmRuntimeDescriptorLoaderTest.kt':[
-138,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/tests/org/jetbrains/kotlin/jvm/runtime/AbstractJvmRuntimeDescriptorLoaderTest.kt": [
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererImpl.kt": [
 297,
 539,
 612,
-864,
+864
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewKotlinTypeChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewKotlinTypeChecker.kt": [
+180
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/utils.kt": [
+28
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/MemberDeserializer.kt": [
+35
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/deserialization/ModuleMapping.kt": [
+33
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata/src/org/jetbrains/kotlin/metadata/deserialization/VersionRequirement.kt": [
+84
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/AnnotationConstructorCaller.kt": [
+104
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt": [
 180,
+197
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/utils.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/MemberDeserializer.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/jdi/test/jdiTest.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/deserialization/ModuleMapping.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/test/suiteBuilder.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata/src/org/jetbrains/kotlin/metadata/deserialization/VersionRequirement.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/builtins/primitives.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/AnnotationConstructorCaller.kt':[
-104,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/evaluate/GenerateOperationsMap.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt':[
-180,
-197,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt':[
-74,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/jdi/test/jdiTest.kt':[
-39,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/test/suiteBuilder.kt':[
-58,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/builtins/primitives.kt':[
-56,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/evaluate/GenerateOperationsMap.kt':[
-37,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt": [
 204,
 253,
-466,
+466
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/NodeIndentStrategy.kt':[
-107,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/NodeIndentStrategy.kt": [
+107
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/codeInsight/ReferenceVariantsHelper.kt':[
-385,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/codeInsight/ReferenceVariantsHelper.kt": [
+385
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/kdoc/findKDoc.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/kdoc/findKDoc.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/CallType.kt':[
-138,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/CallType.kt": [
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/OptimizedImportsBuilder.kt':[
-117,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/OptimizedImportsBuilder.kt": [
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/implicitReceiversUtils.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/implicitReceiversUtils.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/psi/patternMatching/KotlinPsiUnifier.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/psi/patternMatching/KotlinPsiUnifier.kt": [
 172,
 330,
 510,
 587,
 771,
-896,
+896
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/resolve/lazy/PartialBodyResolveFilter.kt": [
 76,
 140,
 196,
-334,
+334
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/KotlinIconProvider.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/KotlinIconProvider.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/PerModulePackageCacheService.kt':[
-238,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/PerModulePackageCacheService.kt": [
+238
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/IDELightClassContexts.kt':[
-238,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/IDELightClassContexts.kt": [
+238
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/LightMemberOriginForCompiledElement.kt':[
-132,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/LightMemberOriginForCompiledElement.kt": [
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/ModuleIndexCache.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/ModuleIndexCache.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/navigation/SourceNavigationHelper.kt':[
-109,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/navigation/SourceNavigationHelper.kt": [
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/navigation/findDecompiledDeclaration.kt':[
-135,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/navigation/findDecompiledDeclaration.kt": [
+135
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/textBuilder/buildDecompiledText.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/textBuilder/buildDecompiledText.kt": [
 45,
-67,
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/findUsages/UsageTypeUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/findUsages/UsageTypeUtils.kt": [
 35,
-57,
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinPsiChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinPsiChecker.kt": [
 202,
-271,
+271
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinSuppressableWarningProblemGroup.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinSuppressableWarningProblemGroup.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/TypeKindHighlightingVisitor.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/TypeKindHighlightingVisitor.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/VariablesHighlightingVisitor.kt':[
-132,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/VariablesHighlightingVisitor.kt": [
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/renderersUtil.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/renderersUtil.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/IntentionBasedInspection.kt':[
-91,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/IntentionBasedInspection.kt": [
+91
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/intentions/OperatorToFunctionIntention.kt':[
-126,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/intentions/OperatorToFunctionIntention.kt": [
+126
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt':[
-134,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt": [
+134
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/KtSimpleNameReference.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/KtSimpleNameReference.kt": [
 52,
-105,
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/referenceUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/referenceUtil.kt": [
 78,
-228,
+228
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/KotlinIndexers.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/KotlinIndexers.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/PsiBasedClassResolver.kt':[
-102,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/PsiBasedClassResolver.kt": [
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinReferencesSearcher.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinReferencesSearcher.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt": [
 268,
 479,
 547,
 632,
 680,
 776,
-856,
+856
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/OperatorReferenceSearcher.kt':[
-265,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/OperatorReferenceSearcher.kt": [
+265
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/utils.kt':[
-182,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/utils.kt": [
+182
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/CommentSaver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/CommentSaver.kt": [
 241,
 294,
-346,
+346
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/ProjectRootsUtil.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/util/ProjectRootsUtil.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/idea-android-output-parser/src/org/jetbrains/kotlin/android/KotlinOutputParserHelper.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/idea-android-output-parser/src/org/jetbrains/kotlin/android/KotlinOutputParserHelper.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/folding/ResourceFoldingBuilder.kt':[
-170,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/folding/ResourceFoldingBuilder.kt": [
+170
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/inspection/IllegalIdentifierInspection.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/src/org/jetbrains/kotlin/android/inspection/IllegalIdentifierInspection.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/tests/org/jetbrains/kotlin/android/intention/AbstractAndroidResourceIntentionTest.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/tests/org/jetbrains/kotlin/android/intention/AbstractAndroidResourceIntentionTest.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt": [
 197,
 348,
-524,
+524
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionUtils.kt':[
-192,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionUtils.kt": [
+192
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/FromUnresolvedNamesCompletion.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/FromUnresolvedNamesCompletion.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/InsertHandlerProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/InsertHandlerProvider.kt": [
 40,
-87,
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt": [
 91,
 200,
 327,
-329,
+329
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordValues.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordValues.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KotlinCompletionCharFilter.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KotlinCompletionCharFilter.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KotlinCompletionContributor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KotlinCompletionContributor.kt": [
 66,
 199,
-262,
+262
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/LookupElementsCollector.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/LookupElementsCollector.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/OverridesCompletion.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/OverridesCompletion.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinCallableInsertHandler.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinCallableInsertHandler.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinClassifierInsertHandler.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinClassifierInsertHandler.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinFunctionInsertHandler.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/KotlinFunctionInsertHandler.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/WithTailInsertHandler.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/WithTailInsertHandler.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/MultipleArgumentsItemProvider.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/MultipleArgumentsItemProvider.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt':[
-183,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt": [
+183
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletionSession.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletionSession.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/TypeInstantiationItems.kt':[
-142,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/TypeInstantiationItems.kt": [
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/Utils.kt':[
-167,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/Utils.kt": [
+167
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/ExpectedCompletionUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/ExpectedCompletionUtils.kt": [
 235,
-338,
+338
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/handlers/CompletionHandlerTestBase.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/handlers/CompletionHandlerTestBase.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ExpectedInfos.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ExpectedInfos.kt": [
 270,
-413,
+413
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt": [
 112,
 113,
 394,
 400,
-427,
+427
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinNameSuggester.kt':[
-230,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinNameSuggester.kt": [
+230
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinNameSuggestionProvider.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinNameSuggestionProvider.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ShortenReferences.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ShortenReferences.kt": [
 77,
 135,
-438,
+438
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/SmartCastCalculator.kt':[
-82,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/SmartCastCalculator.kt": [
+82
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/Utils.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/Utils.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/generateUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/generateUtil.kt": [
 47,
-155,
+155
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/overrideImplement/OverrideMemberChooserObject.kt':[
-207,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/overrideImplement/OverrideMemberChooserObject.kt": [
+207
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/overrideImplement/OverrideMembersHandler.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/overrideImplement/OverrideMembersHandler.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GroovyBuildScriptManipulator.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GroovyBuildScriptManipulator.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleProjectResolverExtension.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleProjectResolverExtension.kt": [
 76,
-125,
+125
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/inspections/gradle/GradleHeuristicHelper.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/inspections/gradle/GradleHeuristicHelper.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/KotlinExtraSteppingFilter.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/KotlinExtraSteppingFilter.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerClassNameProvider.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerUtils.kt':[
-143,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/DebuggerUtils.kt": [
+143
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/InlineCallableUsagesSearcher.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/InlineCallableUsagesSearcher.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinEditorTextProvider.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinEditorTextProvider.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinPositionManager.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinPositionManager.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/KotlinFieldBreakpoint.kt':[
-119,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/KotlinFieldBreakpoint.kt": [
+119
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/breakpointTypeUtils.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/breakpoints/breakpointTypeUtils.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/FrameVisitor.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/FrameVisitor.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinCodeFragmentFactory.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinCodeFragmentFactory.kt": [
 63,
-219,
+219
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/extractFunctionForDebuggerUtil.kt':[
-269,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/extractFunctionForDebuggerUtil.kt": [
+269
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSmartStepIntoHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSmartStepIntoHandler.kt": [
 52,
 148,
-174,
+174
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSteppingCommandProvider.kt':[
-315,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSteppingCommandProvider.kt": [
+315
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/filters/KotlinExceptionFilter.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/filters/KotlinExceptionFilter.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/framework/CustomLibraryDescriptorWithDeferredConfig.kt':[
-146,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/framework/CustomLibraryDescriptorWithDeferredConfig.kt": [
+146
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/i18n/inspections/KotlinInvalidBundleOrPropertyInspection.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/i18n/inspections/KotlinInvalidBundleOrPropertyInspection.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/injection/KotlinLanguageInjector.kt':[
-85,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/injection/KotlinLanguageInjector.kt": [
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/internal/KotlinBytecodeToolWindow.kt':[
-320,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/internal/KotlinBytecodeToolWindow.kt": [
+320
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/actions/RunScratchAction.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/actions/RunScratchAction.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/compile/KtCompilingExecutor.kt':[
-157,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/compile/KtCompilingExecutor.kt": [
+157
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/inspections/KotlinMavenPluginPhaseInspection.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/inspections/KotlinMavenPluginPhaseInspection.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/HistoryKeyListener.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/HistoryKeyListener.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-test-framework/test/org/jetbrains/kotlin/idea/test/ConfigLibraryUtil.kt':[
-131,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-test-framework/test/org/jetbrains/kotlin/idea/test/ConfigLibraryUtil.kt": [
+131
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinQuickDocumentationProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinQuickDocumentationProvider.kt": [
 175,
-257,
+257
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateEqualsAndHashcodeAction.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateEqualsAndHashcodeAction.kt": [
 162,
-222,
+222
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/SearchNotPropertyCandidatesAction.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/SearchNotPropertyCandidatesAction.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt": [
 62,
 216,
 262,
 313,
 348,
-469,
+469
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeToInlineBuilder.kt':[
-146,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeToInlineBuilder.kt": [
+146
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/ReplacementPerformer.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/ReplacementPerformer.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/introduceValue.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/introduceValue.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/ConvertJavaCopyPasteProcessor.kt':[
-78,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/ConvertJavaCopyPasteProcessor.kt": [
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/DataForConversion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/DataForConversion.kt": [
 61,
-235,
+235
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/PlainTextPasteImportResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/PlainTextPasteImportResolver.kt": [
 73,
-114,
+114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt": [
 73,
-232,
+232
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinMultilineStringEnterHandler.kt':[
-111,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinMultilineStringEnterHandler.kt": [
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/facet/KotlinFacetEditorGeneralTab.kt':[
-151,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/facet/KotlinFacetEditorGeneralTab.kt": [
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinElementDescriptionProvider.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinElementDescriptionProvider.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesHandlerFactory.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesHandlerFactory.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinPreFormatProcessor.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinPreFormatProcessor.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/hierarchy/overrides/KotlinOverrideHierarchyNodeDescriptor.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/hierarchy/overrides/KotlinOverrideHierarchyNodeDescriptor.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRecursiveCallLineMarkerProvider.kt':[
-154,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRecursiveCallLineMarkerProvider.kt": [
+154
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/imports/KotlinImportOptimizer.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/imports/KotlinImportOptimizer.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/AddVarianceModifierInspection.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/AddVarianceModifierInspection.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ArrayInDataClassInspection.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ArrayInDataClassInspection.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeParameterInspection.kt':[
-73,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeParameterInspection.kt": [
+73
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBePrimaryConstructorPropertyInspection.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBePrimaryConstructorPropertyInspection.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeValInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeValInspection.kt": [
 44,
-114,
+114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CascadeIfInspection.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CascadeIfInspection.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/DeprecatedCallableAddReplaceWithInspection.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/DeprecatedCallableAddReplaceWithInspection.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/DestructuringWrongNameInspection.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/DestructuringWrongNameInspection.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/EqualsOrHashCodeInspection.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/EqualsOrHashCodeInspection.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/FakeJvmFieldConstantInspection.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/FakeJvmFieldConstantInspection.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ImplicitThisInspection.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ImplicitThisInspection.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/KotlinRedundantOverrideInspection.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/KotlinRedundantOverrideInspection.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/KotlinUnusedImportInspection.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/KotlinUnusedImportInspection.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/LeakingThisInspection.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/LeakingThisInspection.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/LiftReturnOrAssignmentInspection.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/LiftReturnOrAssignmentInspection.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MayBeConstantInspection.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MayBeConstantInspection.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MemberVisibilityCanBePrivateInspection.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MemberVisibilityCanBePrivateInspection.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MoveSuspiciousCallableReferenceIntoParenthesesInspection.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MoveSuspiciousCallableReferenceIntoParenthesesInspection.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantExplicitTypeInspection.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantExplicitTypeInspection.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantNotNullExtensionReceiverOfInlineInspection.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantNotNullExtensionReceiverOfInlineInspection.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSemicolonInspection.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSemicolonInspection.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantUnitExpressionInspection.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantUnitExpressionInspection.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceArrayOfWithLiteralInspection.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceArrayOfWithLiteralInspection.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ScopeFunctionConversionInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ScopeFunctionConversionInspection.kt": [
 178,
-298,
+298
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SelfAssignmentInspection.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SelfAssignmentInspection.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnnecessaryVariableInspection.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnnecessaryVariableInspection.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedReceiverParameterInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedReceiverParameterInspection.kt": [
 57,
-59,
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt": [
 133,
 192,
 228,
-234,
+234
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UseExpressionBodyInspection.kt':[
-106,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UseExpressionBodyInspection.kt": [
+106
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/conventionNameCalls/ReplaceCallWithBinaryOperatorInspection.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/conventionNameCalls/ReplaceCallWithBinaryOperatorInspection.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/AddAnnotationUseSiteTargetIntention.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/AddAnnotationUseSiteTargetIntention.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/AddJvmStaticIntention.kt':[
-69,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/AddJvmStaticIntention.kt": [
+69
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ChangeVisibilityModifierIntention.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ChangeVisibilityModifierIntention.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertEnumToSealedClassIntention.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertEnumToSealedClassIntention.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionToPropertyIntention.kt':[
-105,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionToPropertyIntention.kt": [
+105
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionTypeParameterToReceiverIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionTypeParameterToReceiverIntention.kt": [
 107,
-179,
+179
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionTypeReceiverToParameterIntention.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionTypeReceiverToParameterIntention.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt": [
 61,
-219,
+219
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPrimaryConstructorToSecondaryIntention.kt':[
-65,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPrimaryConstructorToSecondaryIntention.kt": [
+65
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertReferenceToLambdaIntention.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertReferenceToLambdaIntention.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertSecondaryConstructorToPrimaryIntention.kt':[
-117,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertSecondaryConstructorToPrimaryIntention.kt": [
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToBlockBodyIntention.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToBlockBodyIntention.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToStringTemplateIntention.kt':[
-80,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToStringTemplateIntention.kt": [
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTwoComparisonsToRangeCheckIntention.kt':[
-106,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTwoComparisonsToRangeCheckIntention.kt": [
+106
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/CreateKotlinSubClassIntention.kt':[
-113,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/CreateKotlinSubClassIntention.kt": [
+113
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/DestructureIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/DestructureIntention.kt": [
 169,
-283,
+283
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/InvertIfConditionIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/InvertIfConditionIntention.kt": [
 110,
-205,
+205
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/JoinDeclarationAndAssignmentIntention.kt':[
-104,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/JoinDeclarationAndAssignmentIntention.kt": [
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MoveMemberOutOfCompanionObjectIntention.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MoveMemberOutOfCompanionObjectIntention.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MoveMemberToCompanionObjectIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MoveMemberToCompanionObjectIntention.kt": [
 145,
-250,
+250
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ObjectLiteralToLambdaIntention.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ObjectLiteralToLambdaIntention.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveExplicitTypeArgumentsIntention.kt':[
-100,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveExplicitTypeArgumentsIntention.kt": [
+100
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveExplicitTypeIntention.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveExplicitTypeIntention.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SimplifyBooleanWithConstantsIntention.kt':[
-79,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SimplifyBooleanWithConstantsIntention.kt": [
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SpecifyTypeExplicitlyIntention.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SpecifyTypeExplicitlyIntention.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/UsePropertyAccessSyntaxIntention.kt':[
-128,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/UsePropertyAccessSyntaxIntention.kt": [
+128
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/Utils.kt':[
-147,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/Utils.kt": [
+147
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/BranchedFoldingUtils.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/BranchedFoldingUtils.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/IfToWhenIntention.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/IfToWhenIntention.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/WhenToIfIntention.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/WhenToIfIntention.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/declarations/ConvertMemberToExtensionIntention.kt':[
-104,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/declarations/ConvertMemberToExtensionIntention.kt": [
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/AddToCollectionTransformation.kt':[
-134,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/AddToCollectionTransformation.kt": [
+134
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt':[
-223,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt": [
+223
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/ForEachTransformation.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/ForEachTransformation.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/SumTransformation.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/SumTransformation.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/Condition.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/Condition.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/FilterTransformation.kt':[
-181,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/FilterTransformation.kt": [
+181
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/utils.kt':[
-317,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/utils.kt": [
+317
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessor.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessor.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/joinLines/JoinBlockIntoSingleStatementHandler.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/joinLines/JoinBlockIntoSingleStatementHandler.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocRenderer.kt':[
-192,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocRenderer.kt": [
+192
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/ArgumentNameHints.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/ArgumentNameHints.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinFunctionParameterInfoHandler.kt':[
-157,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinFunctionParameterInfoHandler.kt": [
+157
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinTypeArgumentInfoHandler.kt':[
-154,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinTypeArgumentInfoHandler.kt": [
+154
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/TypeHints.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/TypeHints.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionParametersFix.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionParametersFix.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt':[
-108,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt": [
+108
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeFunctionLiteralReturnTypeFix.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeFunctionLiteralReturnTypeFix.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeVariableTypeFix.kt':[
-126,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeVariableTypeFix.kt": [
+126
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ExclExclCallFixes.kt':[
-108,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ExclExclCallFixes.kt": [
+108
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt':[
-58,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt": [
+58
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/SuperClassNotInitialized.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/SuperClassNotInitialized.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
 438,
 811,
 908,
-1032,
+1032
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/typeUtils.kt':[
-140,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/typeUtils.kt": [
+140
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableFromUsageFix.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableFromUsageFix.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createClass/CreateClassFromReferenceExpressionActionFactory.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createClass/CreateClassFromReferenceExpressionActionFactory.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createClass/CreateClassFromUsageFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createClass/CreateClassFromUsageFix.kt": [
 95,
-177,
+177
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createTypeParameter/CreateTypeParameterFromUsageFix.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createTypeParameter/CreateTypeParameterFromUsageFix.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createVariable/CreateParameterByRefActionFactory.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createVariable/CreateParameterByRefActionFactory.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/expectactual/CreateActualFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/expectactual/CreateActualFix.kt": [
 96,
-216,
+216
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/migration/MigrateExternalExtensionFix.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/migration/MigrateExternalExtensionFix.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageFixBase.kt':[
-127,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageFixBase.kt": [
+127
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt": [
 237,
-349,
+349
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureUsageProcessor.kt": [
 223,
 346,
 510,
-837,
+837
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/ui/KotlinChangeSignatureDialog.kt':[
-162,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/ui/KotlinChangeSignatureDialog.kt": [
+162
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinCallableDefinitionUsage.kt':[
-165,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinCallableDefinitionUsage.kt": [
+165
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt": [
 176,
-319,
+319
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/copy/CopyKotlinDeclarationsHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/copy/CopyKotlinDeclarationsHandler.kt": [
 176,
-244,
+244
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementSelectionUtils.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementSelectionUtils.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/inline/KotlinInlineTypeAliasHandler.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/inline/KotlinInlineTypeAliasHandler.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractClass/ExtractSuperRefactoring.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractClass/ExtractSuperRefactoring.kt": [
 91,
 126,
-229,
+229
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractClass/ui/KotlinExtractInterfaceDialog.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractClass/ui/KotlinExtractInterfaceDialog.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/ExtractionData.kt':[
-199,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/ExtractionData.kt": [
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/duplicateUtil.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/duplicateUtil.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractableAnalysisUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractableAnalysisUtil.kt": [
 225,
-773,
+773
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractorUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractorUtil.kt": [
 56,
 159,
 160,
 232,
 414,
-459,
+459
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt": [
 72,
-151,
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinIntroduceParameterHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinIntroduceParameterHandler.kt": [
 133,
 135,
-216,
+216
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceTypeAlias/introduceTypeAliasImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceTypeAlias/introduceTypeAliasImpl.kt": [
 57,
 157,
-241,
+241
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceUtil.kt':[
-75,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceUtil.kt": [
+75
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt": [
 148,
 468,
-659,
+659
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/kotlinRefactoringUtil.kt": [
 361,
 572,
-734,
+734
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveDeclarationsDelegate.kt':[
-131,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveDeclarationsDelegate.kt": [
+131
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsHandler.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsHandler.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsProcessor.kt':[
-163,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsProcessor.kt": [
+163
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/moveConflictUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/moveConflictUtils.kt": [
 273,
 355,
 392,
-496,
+496
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveFilesUtil.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveFilesUtil.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveUtils.kt": [
 102,
 121,
 366,
-538,
+538
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/JavaToKotlinPreconversionPullUpHelper.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/JavaToKotlinPreconversionPullUpHelper.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt": [
 67,
 100,
 437,
 463,
-560,
+560
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/JavaToKotlinPushDownDelegate.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/JavaToKotlinPushDownDelegate.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/KotlinPushDownProcessor.kt':[
-171,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/KotlinPushDownProcessor.kt": [
+171
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinPropertyProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinPropertyProcessor.kt": [
 295,
 345,
-422,
+422
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameConflictUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameConflictUtils.kt": [
 90,
 115,
-215,
+215
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/KotlinSafeDeleteProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/KotlinSafeDeleteProcessor.kt": [
 80,
-140,
+140
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/roots/KotlinNonJvmSourceRootConverterProvider.kt':[
-134,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/roots/KotlinNonJvmSourceRootConverterProvider.kt": [
+134
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinAnnotatedElementsSearcher.kt':[
-75,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinAnnotatedElementsSearcher.kt": [
+75
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinOverridingMethodReferenceSearcher.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinOverridingMethodReferenceSearcher.kt": [
 77,
-81,
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/Slicer.kt':[
-312,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/slicer/Slicer.kt": [
+312
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/testIntegration/KotlinCreateTestIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/testIntegration/KotlinCreateTestIntention.kt": [
 54,
 87,
-113,
+113
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractInspectionTest.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractInspectionTest.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/KotlinDebuggerTestBase.kt':[
-290,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/KotlinDebuggerTestBase.kt": [
+290
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/KotlinOutputChecker.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/KotlinOutputChecker.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/evaluate/AbstractKotlinEvaluateExpressionTest.kt':[
-301,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/evaluate/AbstractKotlinEvaluateExpressionTest.kt": [
+301
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/intentions/AbstractIntentionTest.kt':[
-151,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/intentions/AbstractIntentionTest.kt": [
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionDescriptionTest.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionDescriptionTest.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixMultiFileTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixMultiFileTest.kt": [
 122,
-196,
+196
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixTest.kt": [
 84,
 200,
-234,
+234
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/run/RunConfigurationTest.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/run/RunConfigurationTest.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/slicer/AbstractSlicerTest.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/slicer/AbstractSlicerTest.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/AnnotationConverter.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/AnnotationConverter.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ClassBodyConverter.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ClassBodyConverter.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeBuilder.kt':[
-126,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeBuilder.kt": [
+126
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt": [
 97,
-161,
+161
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ConstructorConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ConstructorConverter.kt": [
 48,
 116,
-226,
+226
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt": [
 159,
 225,
 311,
-536,
+536
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt": [
 113,
 277,
 351,
 500,
 561,
-757,
+757
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ForConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ForConverter.kt": [
 39,
 150,
-216,
+216
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/OverloadReducer.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/OverloadReducer.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt": [
 144,
 279,
-343,
+343
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/propertyDetection.kt':[
-153,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/propertyDetection.kt": [
+153
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/KotlinBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/src/org/jetbrains/kotlin/jps/build/KotlinBuilder.kt": [
 206,
-305,
+305
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt':[
-193,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Analyzer.kt": [
+193
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Context.kt':[
-88,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Context.kt": [
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/NameSuggestion.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/NameSuggestion.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/encodeSignature.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/naming/encodeSignature.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsExternalChecker.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsExternalChecker.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsModuleCheckUtil.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsModuleCheckUtil.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsNameClashChecker.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsNameClashChecker.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutineBodyTransformer.kt':[
-243,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutineBodyTransformer.kt": [
+243
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutineFunctionTransformer.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutineFunctionTransformer.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutinePasses.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutinePasses.kt": [
 27,
 269,
-342,
+342
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/CoroutineStateElimination.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/CoroutineStateElimination.kt": [
 25,
-39,
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/DoWhileGuardElimination.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/DoWhileGuardElimination.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/EmptyStatementElimination.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/EmptyStatementElimination.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/IfStatementReduction.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/IfStatementReduction.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt": [
 36,
 38,
-80,
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryAssignmentElimination.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryAssignmentElimination.kt": [
 49,
-170,
+170
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt": [
 115,
 232,
-509,
+509
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/WhileConditionFolding.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/WhileConditionFolding.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/util/collectUtils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/util/collectUtils.kt": [
 240,
-370,
+370
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/util/fixForwardNameReferences.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/util/fixForwardNameReferences.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.parser/src/org/jetbrains/kotlin/js/parser/sourcemaps/SourceMapLocationRemapper.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.parser/src/org/jetbrains/kotlin/js/parser/sourcemaps/SourceMapLocationRemapper.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.parser/src/org/jetbrains/kotlin/js/parser/sourcemaps/SourceMapParser.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.parser/src/org/jetbrains/kotlin/js/parser/sourcemaps/SourceMapParser.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstDeserializer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstDeserializer.kt": [
 125,
-280,
+280
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstSerializer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/ast/JsAstSerializer.kt": [
 119,
-278,
+278
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/generateTestDataForReservedWords.kt':[
-260,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/generateTestDataForReservedWords.kt": [
+260
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/callTranslator/CallInfo.kt':[
-112,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/callTranslator/CallInfo.kt": [
+112
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/ClassTranslator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/ClassTranslator.kt": [
 229,
-358,
+358
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/expression/LoopTranslator.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/expression/LoopTranslator.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/reference/CallArgumentTranslator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/reference/CallArgumentTranslator.kt": [
+70
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/impl/JvmMetadataExtensions.kt": [
+112
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/src/kotlinx/metadata/impl/writers.kt": [
+282
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/host/scriptHostUtil.kt": [
+19
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/jvmScriptEnvironment.kt": [
+20
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt": [
+549
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/InternalHashCodeMap.kt": [
+126
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/CollectionToArray.kt": [
+51
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/Console.kt": [
+156
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt": [
+260
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt": [
+25
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/StringNumberConversions.kt": [
 70,
+133
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/impl/JvmMetadataExtensions.kt':[
-112,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/src/kotlinx/metadata/impl/writers.kt':[
-282,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/host/scriptHostUtil.kt':[
-19,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/jvmScriptEnvironment.kt':[
-20,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt':[
-549,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/InternalHashCodeMap.kt':[
-126,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/CollectionToArray.kt':[
-51,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/Console.kt':[
-156,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/Utils.kt':[
-260,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt':[
-25,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/StringNumberConversions.kt':[
-70,
-133,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/Strings.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/Strings.kt": [
 860,
-1045,
+1045
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/ranges/ProgressionLastElementTest.kt':[
-66,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/ranges/ProgressionLastElementTest.kt": [
+66
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/render.kt':[
-150,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/render.kt": [
+150
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt':[
-783,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt": [
+783
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/MemberBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/MemberBuilder.kt": [
 158,
-176,
+176
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/Main.kt':[
-12,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/Main.kt": [
+12
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt": [
 85,
 266,
-326,
+326
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableDeclarationChecker.kt':[
-104,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableDeclarationChecker.kt": [
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/AndroidLayoutXmlFileManager.kt':[
-103,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/res/AndroidLayoutXmlFileManager.kt": [
+103
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/parcel/quickfixes/ParcelMigrateToParcelizeQuickFix.kt':[
-182,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/parcel/quickfixes/ParcelMigrateToParcelizeQuickFix.kt": [
+182
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/AndroidIndicesHelperExtension.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/AndroidIndicesHelperExtension.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/AndroidPsiTreeChangePreprocessor.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/AndroidPsiTreeChangePreprocessor.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/javac/KaptJavaLog.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/javac/KaptJavaLog.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt": [
 266,
 487,
 600,
 789,
-881,
+881
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ErrorTypeCorrector.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ErrorTypeCorrector.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/KaptStubLineInformation.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/KaptStubLineInformation.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt": [
 47,
-137,
+137
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/src/org/jetbrains/kotlin/sourceSections/FilteredSectionsVirtualFile.kt':[
-108,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/src/org/jetbrains/kotlin/sourceSections/FilteredSectionsVirtualFile.kt": [
+108
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinAbstractUElement.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinAbstractUElement.kt": [
 42,
-130,
+130
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt": [
 149,
-303,
+303
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/KotlinUSimpleReferenceExpression.kt':[
-60,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/KotlinUSimpleReferenceExpression.kt": [
+60
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S3923.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S3923.json
@@ -1,5 +1,5 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/full/KClassifiers.kt':[
-56,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/full/KClassifiers.kt": [
+56
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S4144.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S4144.json
@@ -1,30 +1,30 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingInterpreter.kt':[
-94,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingInterpreter.kt": [
+94
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/ControlFlowGraph.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/ControlFlowGraph.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/jvm/compiler/Java9ModulesIntegrationTest.kt':[
-92,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/jvm/compiler/Java9ModulesIntegrationTest.kt": [
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/tests/org/jetbrains/kotlin/idea/liveTemplates/LiveTemplatesTest.kt':[
-136,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-live-templates/tests/org/jetbrains/kotlin/idea/liveTemplates/LiveTemplatesTest.kt": [
+136
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/Java9MultiModuleHighlightingTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/Java9MultiModuleHighlightingTest.kt": [
 48,
 53,
 58,
 71,
-76,
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinInTempDirTest.kt':[
-85,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinInTempDirTest.kt": [
+85
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocFinderTest.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocFinderTest.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/KotlinJpsBuildTest.kt": [
 356,
 363,
 384,
@@ -33,9 +33,9 @@
 408,
 643,
 650,
-908,
+908
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/MapTest.kt':[
-137,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/collections/MapTest.kt": [
+137
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S5612.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S5612.json
@@ -1,247 +1,247 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/SmartJavaExec.kt':[
-11,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/SmartJavaExec.kt": [
+11
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/intellijDependencies.kt':[
-118,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/intellijDependencies.kt": [
+118
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/parser.kt':[
-324,
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/parser.kt": [
+324
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/plugin.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/plugin.kt": [
 217,
-219,
+219
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/render.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/render.kt": [
 51,
 69,
 70,
 71,
-106,
+106
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/plugins/PublishedKotlinModule.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/plugins/PublishedKotlinModule.kt": [
 29,
 50,
 51,
-103,
+103
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/tasks.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/tasks.kt": [
 31,
-32,
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/BoxedVsPrimitiveBranchedValues.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/BoxedVsPrimitiveBranchedValues.kt": [
 320,
-321,
+321
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/MultifileClassCodegen.kt':[
-114,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/MultifileClassCodegen.kt": [
+114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/MultifileClassPartCodegen.kt':[
-96,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/MultifileClassPartCodegen.kt": [
+96
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt": [
 113,
 218,
-481,
+481
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt':[
-500,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt": [
+500
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/LambdaInfo.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/LambdaInfo.kt": [
 244,
-245,
+245
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt':[
-473,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt": [
+473
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/defaultMethodUtil.kt':[
-145,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/defaultMethodUtil.kt": [
+145
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/KClassJavaObjectTypeProperty.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/KClassJavaObjectTypeProperty.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingMethodTransformer.kt':[
-430,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingMethodTransformer.kt": [
+430
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/fixStack/AnalyzeTryCatchBlocks.kt':[
-76,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/fixStack/AnalyzeTryCatchBlocks.kt": [
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InContinuousRangeOfComparableExpressionGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InContinuousRangeOfComparableExpressionGenerator.kt": [
 52,
-99,
+99
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InIntegralContinuousRangeExpressionGenerator.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InIntegralContinuousRangeExpressionGenerator.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt':[
-189,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt": [
+189
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/Jsr305Parser.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/Jsr305Parser.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplCompilingEvaluator.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplCompilingEvaluator.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplEvaluator.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplEvaluator.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCliJavaFileManagerImpl.kt':[
-152,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCliJavaFileManagerImpl.kt": [
+152
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/GenericReplCompiler.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/GenericReplCompiler.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt':[
-97,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt": [
+97
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/ClientUtils.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/ClientUtils.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/frontend/java/di/injection.kt':[
-91,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/frontend/java/di/injection.kt": [
+91
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/extensions/PartialAnalysisHandlerExtension.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/extensions/PartialAnalysisHandlerExtension.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/analyzer/AnalyzerFacade.kt':[
-165,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/analyzer/AnalyzerFacade.kt": [
+165
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ConstructorConsistencyChecker.kt':[
-117,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ConstructorConsistencyChecker.kt": [
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt": [
 275,
 567,
-775,
+775
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/PseudocodeVariablesData.kt':[
-306,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/PseudocodeVariablesData.kt": [
+306
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/pseudocodeUtils.kt':[
-143,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/pseudocodeUtils.kt": [
+143
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/descriptors/annotations/AnnotationSplitter.kt':[
-81,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/descriptors/annotations/AnnotationSplitter.kt": [
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/ExposedVisibilityChecker.kt':[
-151,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/ExposedVisibilityChecker.kt": [
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/NonExpansiveInheritanceRestrictionChecker.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/NonExpansiveInheritanceRestrictionChecker.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeAliasExpander.kt':[
-104,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeAliasExpander.kt": [
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt':[
-821,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt": [
+821
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CandidateResolver.kt": [
 70,
 116,
-281,
+281
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/GenericCandidateResolver.kt':[
-359,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/GenericCandidateResolver.kt": [
+359
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewResolutionOldInference.kt':[
-272,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewResolutionOldInference.kt": [
+272
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyImportScope.kt':[
-107,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyImportScope.kt": [
+107
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt':[
-707,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt": [
+707
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/DefaultArgumentStubGenerator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/DefaultArgumentStubGenerator.kt": [
 89,
-353,
+353
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt':[
-614,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt": [
+614
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/TailrecLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/TailrecLowering.kt": [
 55,
-114,
+114
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/VarargLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/VarargLowering.kt": [
 107,
 134,
-137,
+137
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsDescriptorsFactory.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsDescriptorsFactory.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/BlockDecomposerLowering.kt':[
-680,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/BlockDecomposerLowering.kt": [
+680
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/CallableReferenceLowering.kt':[
-201,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/CallableReferenceLowering.kt": [
+201
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/IntrinsicifyCallsLowering.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/IntrinsicifyCallsLowering.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/SecondaryCtorLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/SecondaryCtorLowering.kt": [
 114,
-149,
+149
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/IrElementToJsExpressionTransformer.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/IrElementToJsExpressionTransformer.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/JsIntrinsicTransformers.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/JsIntrinsicTransformers.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/SimpleNameGenerator.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/SimpleNameGenerator.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt':[
-234,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt": [
+234
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt':[
-212,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt": [
+212
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt':[
-315,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt": [
+315
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ArgumentsGenerationUtils.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ArgumentsGenerationUtils.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/CallGenerator.kt':[
-139,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/CallGenerator.kt": [
+139
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ClassGenerator.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ClassGenerator.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/DataClassMembersGenerator.kt':[
-226,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/DataClassMembersGenerator.kt": [
+226
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/JavacWrapper.kt':[
-312,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/JavacWrapper.kt": [
+312
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/createByPattern.kt':[
-235,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/createByPattern.kt": [
+235
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/AnnotationSerializer.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/AnnotationSerializer.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common-jvm6/tests/org/jetbrains/kotlin/test/clientserver/TestProxy.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common-jvm6/tests/org/jetbrains/kotlin/test/clientserver/TestProxy.kt": [
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/InlineTestUtil.kt':[
-109,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/InlineTestUtil.kt": [
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/resolve/calls/AbstractResolvedCallsTest.kt':[
-133,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/resolve/calls/AbstractResolvedCallsTest.kt": [
+133
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-java8/tests/org/jetbrains/kotlin/generators/tests/GenerateJava8Tests.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-java8/tests/org/jetbrains/kotlin/generators/tests/GenerateJava8Tests.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/cli/jvm/repl/GenericReplTest.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/cli/jvm/repl/GenericReplTest.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerApiTest.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerApiTest.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt": [
 105,
 108,
 186,
@@ -255,128 +255,128 @@
 670,
 673,
 772,
-775,
+775
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/generators/tests/GenerateCompilerTests.kt':[
-62,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/generators/tests/GenerateCompilerTests.kt": [
+62
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/resolve/typeApproximation/CapturedTypeApproximationTest.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/resolve/typeApproximation/CapturedTypeApproximationTest.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaPackageScope.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaPackageScope.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaScope.kt':[
-173,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/descriptors/LazyJavaScope.kt": [
+173
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/specialBuiltinMembers.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/specialBuiltinMembers.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/typeEnhancement/predefinedEnhancementInfo.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/typeEnhancement/predefinedEnhancementInfo.kt": [
 40,
 51,
-79,
+79
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/JvmBuiltInsSettings.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/JvmBuiltInsSettings.kt": [
 128,
 358,
-396,
+396
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/TypeAliasConstructorDescriptor.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/TypeAliasConstructorDescriptor.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/deserialization/ClassMapperLite.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/deserialization/ClassMapperLite.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KClassImpl.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KClassImpl.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KFunctionImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KFunctionImpl.kt": [
 59,
-93,
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KTypeImpl.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KTypeImpl.kt": [
 72,
-78,
+78
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/jdi/test/jdiTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/jdi/test/jdiTest.kt": [
 63,
-104,
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/test/main.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/test/org/jetbrains/eval4j/test/main.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/arguments/GenerateGradleOptions.kt':[
-186,
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/arguments/GenerateGradleOptions.kt": [
+186
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt": [
 168,
 812,
 923,
 973,
 1054,
-1092,
+1092
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt": [
 49,
 62,
 107,
 191,
-362,
+362
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/PerModulePackageCacheService.kt':[
-238,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/PerModulePackageCacheService.kt": [
+238
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/KotlinCacheServiceImpl.kt':[
-299,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/KotlinCacheServiceImpl.kt": [
+299
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/codeInsight/shorten/delayedRequestsWaitingSet.kt':[
-91,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/codeInsight/shorten/delayedRequestsWaitingSet.kt": [
+91
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/KotlinReferenceContributor.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/KotlinReferenceContributor.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt": [
 211,
-857,
+857
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt": [
 291,
 414,
 437,
-559,
+559
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/FromUnresolvedNamesCompletion.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/FromUnresolvedNamesCompletion.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/handlerUtils.kt':[
-142,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/handlerUtils.kt": [
+142
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt':[
-113,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt": [
+113
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletionSession.kt':[
-101,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletionSession.kt": [
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt':[
-274,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt": [
+274
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ShortenReferences.kt':[
-88,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ShortenReferences.kt": [
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/generateUtil.kt':[
-163,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/generateUtil.kt": [
+163
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDefinitionsManager.kt':[
-172,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDefinitionsManager.kt": [
+172
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinBuildScriptManipulator.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinBuildScriptManipulator.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleConfiguratorTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleConfiguratorTest.kt": [
 82,
 83,
 142,
@@ -402,392 +402,392 @@
 873,
 874,
 954,
-955,
+955
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleMultiplatformRunTest.kt':[
-131,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleMultiplatformRunTest.kt": [
+131
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jps-common/src/org/jetbrains/kotlin/config/facetSerialization.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jps-common/src/org/jetbrains/kotlin/config/facetSerialization.kt": [
 40,
-103,
+103
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinNotificationManager.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinNotificationManager.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinAlternativeSourceNotificationProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinAlternativeSourceNotificationProvider.kt": [
 122,
-123,
+123
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinCodeFragmentFactory.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinCodeFragmentFactory.kt": [
 86,
-116,
+116
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinEvaluationBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinEvaluationBuilder.kt": [
 391,
 446,
-522,
+522
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/internal/makeBackup/CreateIncrementalCompilationBackup.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/internal/makeBackup/CreateIncrementalCompilationBackup.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/compile/KtCompilingExecutor.kt':[
-158,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/compile/KtCompilingExecutor.kt": [
+158
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/output/InlayScratchOutputHandler.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/output/InlayScratchOutputHandler.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/ReplOutputProcessor.kt':[
-106,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/ReplOutputProcessor.kt": [
+106
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-test-framework/test/org/jetbrains/kotlin/idea/test/ConfigLibraryUtil.kt':[
-132,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-test-framework/test/org/jetbrains/kotlin/idea/test/ConfigLibraryUtil.kt": [
+132
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/performanceTests/org/jetbrains/kotlin/idea/perf/WholeProjectPerformanceTest.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/performanceTests/org/jetbrains/kotlin/idea/perf/WholeProjectPerformanceTest.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateEqualsAndHashcodeAction.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateEqualsAndHashcodeAction.kt": [
 163,
 183,
-248,
+248
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateTestSupportActionBase.kt':[
-169,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateTestSupportActionBase.kt": [
+169
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeToInlineBuilder.kt':[
-149,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeToInlineBuilder.kt": [
+149
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/configuration/KotlinLanguageConfiguration.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/configuration/KotlinLanguageConfiguration.kt": [
 78,
 79,
-133,
+133
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt':[
-236,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt": [
+236
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinMultilineStringEnterHandler.kt':[
-133,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinMultilineStringEnterHandler.kt": [
+133
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/facet/facetUtils.kt':[
-244,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/facet/facetUtils.kt": [
+244
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/LeakingThisInspection.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/LeakingThisInspection.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantNotNullExtensionReceiverOfInlineInspection.kt':[
-61,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantNotNullExtensionReceiverOfInlineInspection.kt": [
+61
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantVisibilityModifierInspection.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantVisibilityModifierInspection.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/SimplifyCallChainFix.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/SimplifyCallChainFix.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionTypeParameterToReceiverIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertFunctionTypeParameterToReceiverIntention.kt": [
 186,
-187,
+187
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertObjectLiteralToClassIntention.kt':[
-89,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertObjectLiteralToClassIntention.kt": [
+89
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPrimaryConstructorToSecondaryIntention.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPrimaryConstructorToSecondaryIntention.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt": [
 97,
-98,
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertReceiverToParameterIntention.kt':[
-75,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertReceiverToParameterIntention.kt": [
+75
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/DestructureIntention.kt':[
-257,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/DestructureIntention.kt": [
+257
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/IterateExpressionIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/IterateExpressionIntention.kt": [
 72,
-73,
+73
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MoveMemberToCompanionObjectIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MoveMemberToCompanionObjectIntention.kt": [
 307,
 308,
-309,
+309
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ObjectLiteralToLambdaIntention.kt':[
-108,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ObjectLiteralToLambdaIntention.kt": [
+108
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/IfToWhenIntention.kt':[
-130,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/IfToWhenIntention.kt": [
+130
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/WhenToIfIntention.kt':[
-44,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/WhenToIfIntention.kt": [
+44
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessor.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessor.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocRenderer.kt':[
-198,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocRenderer.kt": [
+198
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinFunctionParameterInfoHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinFunctionParameterInfoHandler.kt": [
 177,
-255,
+255
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinTypeArgumentInfoHandler.kt':[
-161,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinTypeArgumentInfoHandler.kt": [
+161
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionParametersFix.kt':[
-90,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionParametersFix.kt": [
+90
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
 439,
 472,
 532,
-970,
+970
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableFromUsageFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableFromUsageFix.kt": [
 90,
-91,
+91
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateFunctionFromCallableReferenceActionFactory.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateFunctionFromCallableReferenceActionFactory.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createClass/CreateClassFromUsageFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createClass/CreateClassFromUsageFix.kt": [
 216,
-217,
+217
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createTypeParameter/CreateTypeParameterFromUsageFix.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createTypeParameter/CreateTypeParameterFromUsageFix.kt": [
 88,
 93,
-116,
+116
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/expectactual/CreateActualFix.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/expectactual/CreateActualFix.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/migration/MigrateExternalExtensionFix.kt':[
-126,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/migration/MigrateExternalExtensionFix.kt": [
+126
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt':[
-541,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt": [
+541
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureData.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureData.kt": [
 100,
-101,
+101
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/ui/KotlinChangePropertySignatureDialog.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/ui/KotlinChangePropertySignatureDialog.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt':[
-368,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt": [
+368
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/copy/CopyKotlinDeclarationsHandler.kt':[
-247,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/copy/CopyKotlinDeclarationsHandler.kt": [
+247
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractClass/ExtractSuperRefactoring.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractClass/ExtractSuperRefactoring.kt": [
 98,
 162,
-163,
+163
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractFunction/ui/ExtractFunctionParameterTablePanel.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractFunction/ui/ExtractFunctionParameterTablePanel.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractableAnalysisUtil.kt':[
-240,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractableAnalysisUtil.kt": [
+240
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractorUtil.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/extractorUtil.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt':[
-232,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/extractionEngine/inferParameterInfo.kt": [
+232
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinInplaceParameterIntroducer.kt':[
-119,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinInplaceParameterIntroducer.kt": [
+119
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinIntroduceParameterDialog.kt':[
-267,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinIntroduceParameterDialog.kt": [
+267
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceProperty/KotlinIntroducePropertyHandler.kt':[
-88,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceProperty/KotlinIntroducePropertyHandler.kt": [
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceTypeParameter/KotlinIntroduceTypeParameterHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceTypeParameter/KotlinIntroduceTypeParameterHandler.kt": [
 106,
-111,
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinIntroduceVariableHandler.kt": [
 533,
 568,
-592,
+592
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinVariableInplaceIntroducer.kt':[
-71,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceVariable/KotlinVariableInplaceIntroducer.kt": [
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsProcessor.kt':[
-193,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/MoveKotlinDeclarationsProcessor.kt": [
+193
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveFilesUtil.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveFilesUtil.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt':[
-192,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pullUp/KotlinPullUpHelper.kt": [
+192
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameConflictUtils.kt':[
-287,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameConflictUtils.kt": [
+287
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/KotlinSafeDeleteProcessor.kt':[
-156,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/KotlinSafeDeleteProcessor.kt": [
+156
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/testIntegration/KotlinCreateTestIntention.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/testIntegration/KotlinCreateTestIntention.kt": [
 160,
-164,
+164
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/versions/KotlinJvmMetadataVersionIndex.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/versions/KotlinJvmMetadataVersionIndex.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/ResolveElementCacheTest.kt':[
-154,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/ResolveElementCacheTest.kt": [
+154
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/AbstractIdeLightClassTest.kt':[
-251,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/AbstractIdeLightClassTest.kt": [
+251
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/MultiModuleHighlightingTest.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/MultiModuleHighlightingTest.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/PsiElementChecker.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/caches/resolve/PsiElementChecker.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractInspectionTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractInspectionTest.kt": [
 78,
-83,
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/KotlinDebuggerTestBase.kt':[
-298,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/KotlinDebuggerTestBase.kt": [
+298
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/evaluate/AbstractKotlinEvaluateExpressionTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/debugger/evaluate/AbstractKotlinEvaluateExpressionTest.kt": [
 135,
 315,
 450,
-460,
+460
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixMultiFileTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixMultiFileTest.kt": [
 148,
-216,
+216
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixMultiModuleTest.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixMultiModuleTest.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixTest.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/quickfix/AbstractQuickFixTest.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/introduce/AbstractExtractionTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/introduce/AbstractExtractionTest.kt": [
 99,
 151,
 224,
 274,
-301,
+301
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/move/AbstractMultiModuleMoveTest.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/move/AbstractMultiModuleMoveTest.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/pullUp/AbstractPullUpTest.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/pullUp/AbstractPullUpTest.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/rename/AbstractRenameTest.kt':[
-329,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/rename/AbstractRenameTest.kt": [
+329
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/slicer/AbstractSlicerTest.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/slicer/AbstractSlicerTest.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ConstructorConverter.kt':[
-192,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ConstructorConverter.kt": [
+192
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/incremental/AbstractProtoComparisonTest.kt':[
-50,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/incremental/AbstractProtoComparisonTest.kt": [
+50
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/DeadCodeElimination.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/DeadCodeElimination.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/DefaultErrorMessagesJs.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/DefaultErrorMessagesJs.kt": [
 24,
-25,
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutineBodyTransformer.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/coroutine/CoroutineBodyTransformer.kt": [
 176,
-243,
+243
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/FunctionReader.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/FunctionReader.kt": [
 91,
-94,
+94
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/GenerateJsTests.kt':[
-46,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/GenerateJsTests.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/generateTestDataForReservedWords.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/generators/tests/generateTestDataForReservedWords.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/AbstractJsLineNumberTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/AbstractJsLineNumberTest.kt": [
 47,
-55,
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt':[
-109,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt": [
+109
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/inlineCoroutineUtil.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/declaration/inlineCoroutineUtil.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/intrinsic/functions/factories/ArrayFIF.kt':[
-180,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/intrinsic/functions/factories/ArrayFIF.kt": [
+180
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/test/kotlinx/metadata/test/MetadataSmokeTest.kt':[
-93,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/jvm/test/kotlinx/metadata/test/MetadataSmokeTest.kt": [
+93
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/src/kotlinx/metadata/impl/writeUtils.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlinx-metadata/src/kotlinx/metadata/impl/writeUtils.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm-host/src/kotlin/script/experimental/jvmhost/impl/KJVMCompilerImpl.kt':[
-100,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm-host/src/kotlin/script/experimental/jvmhost/impl/KJVMCompilerImpl.kt": [
+100
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/text/StringTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/test/text/StringTest.kt": [
 408,
-939,
+939
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/gen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/gen.kt": [
 30,
-281,
+281
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/render.kt':[
-213,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/idl2k/src/main/kotlin/render.kt": [
+213
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/AbstractKotlinAndroidGradleTests.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/AbstractKotlinAndroidGradleTests.kt": [
 22,
-345,
+345
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt':[
-491,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt": [
+491
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildCacheIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildCacheIT.kt": [
 77,
-138,
+138
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildCacheRelocationIT.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildCacheRelocationIT.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt": [
 670,
-711,
+711
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MultiplatformGradleIT.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MultiplatformGradleIT.kt": [
 92,
 129,
 164,
-267,
+267
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt':[
-63,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt": [
+63
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt':[
-151,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt": [
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt": [
 75,
 232,
 235,
@@ -804,9 +804,9 @@
 678,
 746,
 803,
-840,
+840
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt": [
 193,
 226,
 254,
@@ -818,18 +818,18 @@
 498,
 614,
 624,
-652,
+652
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Comparables.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Comparables.kt": [
 63,
 105,
 136,
 180,
 250,
 294,
-365,
+365
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt": [
 43,
 96,
 151,
@@ -843,9 +843,9 @@
 575,
 621,
 672,
-716,
+716
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt": [
 38,
 47,
 124,
@@ -858,9 +858,9 @@
 582,
 836,
 874,
-904,
+904
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt": [
 40,
 95,
 163,
@@ -882,38 +882,38 @@
 983,
 1023,
 1063,
-1111,
+1111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Guards.kt':[
-16,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Guards.kt": [
+16
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Mapping.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Mapping.kt": [
 46,
 80,
 138,
 330,
-384,
+384
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Ordering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Ordering.kt": [
 15,
 41,
 74,
 102,
 194,
-248,
+248
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Ranges.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Ranges.kt": [
 51,
-88,
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Sequence.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Sequence.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Sets.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Sets.kt": [
 15,
-71,
+71
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt": [
 38,
 141,
 193,
@@ -921,54 +921,54 @@
 263,
 308,
 335,
-383,
+383
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Strings.kt':[
-15,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Strings.kt": [
+15
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/Writers.kt':[
-74,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/Writers.kt": [
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt':[
-327,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt": [
+327
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableCodegenExtension.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableCodegenExtension.kt": [
 146,
 236,
-347,
+347
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/descriptors/AndroidSyntheticPackageFragmentDescriptor.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/descriptors/AndroidSyntheticPackageFragmentDescriptor.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/parcel/AbstractParcelBoxTest.kt':[
-47,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/parcel/AbstractParcelBoxTest.kt": [
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/KotlinKapt3IntegrationTests.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/KotlinKapt3IntegrationTests.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/LazyScriptDefinitionFromDiscoveredClass.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/LazyScriptDefinitionFromDiscoveredClass.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt": [
 53,
-144,
+144
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/tests/org/jetbrains/kotlin/sourceSections/SourceSectionsTest.kt':[
-196,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/tests/org/jetbrains/kotlin/sourceSections/SourceSectionsTest.kt": [
+196
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt": [
 161,
 310,
 408,
-493,
+493
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/KotlinUSwitchExpression.kt':[
-60,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/expressions/KotlinUSwitchExpression.kt": [
+60
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastApiTest.kt':[
-312,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/KotlinUastApiTest.kt": [
+312
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/tests/org/jetbrains/kotlin/tests/GenerateUltimateTests.kt':[
-33,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/tests/org/jetbrains/kotlin/tests/GenerateUltimateTests.kt": [
+33
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6510.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6510.json
@@ -1,390 +1,390 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/build-common/test/org/jetbrains/kotlin/incremental/testingUtils/incrementalModificationUtils.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/test/org/jetbrains/kotlin/incremental/testingUtils/incrementalModificationUtils.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/AndroidTestGenerator.kt':[
-107,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/AndroidTestGenerator.kt": [
+107
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/InnerClassConsumer.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/InnerClassConsumer.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt':[
-243,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt": [
+243
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt':[
-387,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt": [
+387
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/ReifiedTypeInliner.kt':[
-130,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/ReifiedTypeInliner.kt": [
+130
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplFromTerminal.kt':[
-150,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplFromTerminal.kt": [
+150
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/JvmOverridesBackwardCompatibilityHelper.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/JvmOverridesBackwardCompatibilityHelper.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/contracts/parsing/PsiConditionParser.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/contracts/parsing/PsiConditionParser.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/PositioningStrategies.kt':[
-53,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/PositioningStrategies.kt": [
+53
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/QualifiedExpressionResolver.kt':[
-224,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/QualifiedExpressionResolver.kt": [
+224
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt':[
-769,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/TypeResolver.kt": [
+769
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt": [
 95,
-486,
+486
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyDeclarationResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyDeclarationResolver.kt": [
 131,
-219,
+219
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt": [
 284,
-493,
+493
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/DefaultArgumentStubGenerator.kt':[
-212,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/DefaultArgumentStubGenerator.kt": [
+212
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt": [
 207,
 216,
-228,
+228
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/wrappers/trees/treeBasedTypes.kt':[
-145,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/wrappers/trees/treeBasedTypes.kt": [
+145
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/EditCommaSeparatedListHelper.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/EditCommaSeparatedListHelper.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtDotQualifiedExpression.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtDotQualifiedExpression.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/TypeRefHelpers.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/TypeRefHelpers.kt": [
 36,
-64,
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/NewCommonSuperTypeCalculator.kt':[
-209,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/NewCommonSuperTypeCalculator.kt": [
+209
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ArgumentsToParametersMapper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ArgumentsToParametersMapper.kt": [
 48,
-123,
+123
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/TypeArgumentsToParametersMapper.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/TypeArgumentsToParametersMapper.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/NewTypeSubstitutor.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/NewTypeSubstitutor.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/ResultTypeResolver.kt':[
-68,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/ResultTypeResolver.kt": [
+68
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/TypeCheckerContextForConstraintSystem.kt':[
-72,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/TypeCheckerContextForConstraintSystem.kt": [
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/OverloadingConflictResolver.kt':[
-283,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/OverloadingConflictResolver.kt": [
+283
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/InvokeProcessors.kt':[
-228,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/InvokeProcessors.kt": [
+228
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/types/TypeApproximator.kt':[
-143,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/types/TypeApproximator.kt": [
+143
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/jvm/compiler/AbstractWriteSignatureTest.kt':[
-256,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/jvm/compiler/AbstractWriteSignatureTest.kt": [
+256
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewKotlinTypeChecker.kt':[
-233,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/types/checker/NewKotlinTypeChecker.kt": [
+233
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/util.runtime/src/org/jetbrains/kotlin/utils/addToStdlib.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/util.runtime/src/org/jetbrains/kotlin/utils/addToStdlib.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/jdi/jdiEval.kt':[
-64,
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/jdi/jdiEval.kt": [
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/codeInsight/ReferenceVariantsHelper.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/codeInsight/ReferenceVariantsHelper.kt": [
 236,
-295,
+295
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/kdoc/resolveKDocLink.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/kdoc/resolveKDocLink.kt": [
 64,
-199,
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/CallType.kt':[
-163,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/CallType.kt": [
+163
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/Utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/Utils.kt": [
 40,
-76,
+76
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/IDEKotlinAsJavaSupport.kt':[
-213,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/IDEKotlinAsJavaSupport.kt": [
+213
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/ResolveElementCache.kt": [
 154,
-257,
+257
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/referenceUtil.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/referenceUtil.kt": [
 120,
-240,
+240
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/OperatorReferenceSearcher.kt':[
-154,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/OperatorReferenceSearcher.kt": [
+154
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/idea-android-output-parser/src/org/jetbrains/kotlin/android/KotlinOutputParserHelper.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-android/idea-android-output-parser/src/org/jetbrains/kotlin/android/KotlinOutputParserHelper.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt':[
-308,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicLookupElementFactory.kt": [
+308
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KDocCompletionContributor.kt':[
-107,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KDocCompletionContributor.kt": [
+107
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt": [
 335,
-438,
+438
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/OverridesCompletion.kt':[
-155,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/OverridesCompletion.kt": [
+155
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/StaticMembersCompletion.kt':[
-121,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/StaticMembersCompletion.kt": [
+121
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/Statisticians.kt':[
-43,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/Statisticians.kt": [
+43
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/Weighers.kt':[
-247,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/Weighers.kt": [
+247
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/Utils.kt':[
-329,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/Utils.kt": [
+329
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/AbstractKeywordCompletionTest.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/AbstractKeywordCompletionTest.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ExpectedInfos.kt':[
-523,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ExpectedInfos.kt": [
+523
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt':[
-481,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt": [
+481
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/SmartCastCalculator.kt':[
-102,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/SmartCastCalculator.kt": [
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/descriptorUtils.kt':[
-67,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/descriptorUtils.kt": [
+67
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/overrideImplement/OverrideMemberChooserObject.kt':[
-212,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/overrideImplement/OverrideMemberChooserObject.kt": [
+212
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/util/DescriptorMemberChooserObject.kt':[
-84,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/util/DescriptorMemberChooserObject.kt": [
+84
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/InlineCallableUsagesSearcher.kt':[
-48,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/InlineCallableUsagesSearcher.kt": [
+48
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/injection/KotlinLanguageInjector.kt':[
-293,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/injection/KotlinLanguageInjector.kt": [
+293
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/FindImplicitNothingAction.kt':[
-115,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/internal/FindImplicitNothingAction.kt": [
+115
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/ClassUsageReplacementStrategy.kt':[
-57,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/ClassUsageReplacementStrategy.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/KotlinBreadcrumbsInfoProvider.kt": [
 193,
-361,
+361
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt':[
-191,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt": [
+191
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/hierarchy/calls/KotlinCallerTreeStructure.kt':[
-123,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/hierarchy/calls/KotlinCallerTreeStructure.kt": [
+123
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ConflictingExtensionPropertyInspection.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ConflictingExtensionPropertyInspection.kt": [
 111,
-135,
+135
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UseExpressionBodyInspection.kt':[
-112,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UseExpressionBodyInspection.kt": [
+112
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTwoComparisonsToRangeCheckIntention.kt':[
-113,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTwoComparisonsToRangeCheckIntention.kt": [
+113
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/InvertIfConditionIntention.kt':[
-209,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/InvertIfConditionIntention.kt": [
+209
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/JoinDeclarationAndAssignmentIntention.kt':[
-126,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/JoinDeclarationAndAssignmentIntention.kt": [
+126
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveBracesIntention.kt':[
-39,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveBracesIntention.kt": [
+39
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/UsePropertyAccessSyntaxIntention.kt':[
-254,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/UsePropertyAccessSyntaxIntention.kt": [
+254
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt':[
-279,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/FindTransformationMatcher.kt": [
+279
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/FilterTransformation.kt':[
-202,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/sequence/FilterTransformation.kt": [
+202
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/utils.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/utils.kt": [
 211,
-353,
+353
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessings.kt':[
-253,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/j2k/J2kPostProcessings.kt": [
+253
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddStarProjectionsFix.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddStarProjectionsFix.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeCallableReturnTypeFix.kt':[
-75,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeCallableReturnTypeFix.kt": [
+75
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ReplaceCallFix.kt':[
-87,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ReplaceCallFix.kt": [
+87
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageFixBase.kt':[
-147,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/replaceWith/DeprecatedSymbolUsageFixBase.kt": [
+147
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/inline/KotlinInlineValHandler.kt':[
-154,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/inline/KotlinInlineValHandler.kt": [
+154
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/inline/inlineUtils.kt':[
-143,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/inline/inlineUtils.kt": [
+143
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/KotlinSafeDeleteProcessor.kt':[
-440,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/safeDelete/KotlinSafeDeleteProcessor.kt": [
+440
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/findUsages/OptionsParser.kt':[
-147,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/findUsages/OptionsParser.kt": [
+147
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/AbstractCopyPasteTest.kt':[
-54,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/AbstractCopyPasteTest.kt": [
+54
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt':[
-331,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt": [
+331
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt": [
 201,
-693,
+693
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/usageProcessing/AccessorToPropertyProcessing.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/usageProcessing/AccessorToPropertyProcessing.kt": [
 43,
-72,
+72
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/usageProcessing/FieldToPropertyProcessing.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/usageProcessing/FieldToPropertyProcessing.kt": [
 61,
-92,
+92
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/usageProcessing/UsageProcessing.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/usageProcessing/UsageProcessing.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalJpsTest.kt':[
-158,
+"kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalJpsTest.kt": [
+158
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/ReachabilityTracker.kt':[
-75,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/ReachabilityTracker.kt": [
+75
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/util/collectUtils.kt':[
-371,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/util/collectUtils.kt": [
+371
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/expression/LoopTranslator.kt':[
-191,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/expression/LoopTranslator.kt": [
+191
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/reference/CallableReferenceTranslator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/reference/CallableReferenceTranslator.kt": [
 98,
-148,
+148
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Collections.kt": [
 167,
 203,
 327,
 409,
 459,
 506,
-1967,
+1967
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Sequences.kt": [
 1417,
-1437,
+1437
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/builtins.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/builtins.kt": [
 91,
-179,
+179
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/InternalHashCodeMap.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/InternalHashCodeMap.kt": [
 43,
 70,
 112,
-146,
+146
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/InternalStringMap.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/InternalStringMap.kt": [
 51,
-64,
+64
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/LinkedHashMap.kt':[
-222,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/LinkedHashMap.kt": [
+222
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/regex.kt':[
-83,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/regex.kt": [
+83
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/stringsCode.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/stringsCode.kt": [
 20,
 30,
-40,
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/FilePathComponents.kt':[
-38,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/FilePathComponents.kt": [
+38
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/FileTreeWalk.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/io/files/FileTreeWalk.kt": [
 114,
 152,
-183,
+183
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/StringsJVM.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/text/StringsJVM.kt": [
 61,
 191,
 201,
 211,
 317,
-362,
+362
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/MutableCollections.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/MutableCollections.kt": [
 121,
 197,
 240,
-251,
+251
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/Strings.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/Strings.kt": [
 718,
 728,
-738,
+738
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/AndroidSubplugin.kt':[
-242,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/AndroidSubplugin.kt": [
+242
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt':[
-814,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt": [
+814
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/MemberBuilder.kt':[
-274,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/MemberBuilder.kt": [
+274
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-js-merger/src/FileMerger.kt':[
-104,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-js-merger/src/FileMerger.kt": [
+104
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/declarations/KotlinUVariable.kt':[
-196,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/declarations/KotlinUVariable.kt": [
+196
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6511.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6511.json
@@ -1,129 +1,129 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ScriptCodegen.kt':[
-223,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/ScriptCodegen.kt": [
+223
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt": [
 207,
-492,
+492
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/TypeIntrinsics.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/TypeIntrinsics.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-runner/src/org/jetbrains/kotlin/runner/Main.kt':[
-59,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-runner/src/org/jetbrains/kotlin/runner/Main.kt": [
+59
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplFromTerminal.kt':[
-135,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplFromTerminal.kt": [
+135
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmDefaultChecker.kt':[
-30,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/JvmDefaultChecker.kt": [
+30
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/annotationCheckers.kt':[
-98,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/annotationCheckers.kt": [
+98
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/declarationCheckers.kt':[
-195,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/declarationCheckers.kt": [
+195
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt':[
-624,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt": [
+624
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt':[
-303,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowProcessor.kt": [
+303
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt':[
-701,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationsChecker.kt": [
+701
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverloadResolver.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverloadResolver.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/LateinitIntrinsicApplicabilityChecker.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/LateinitIntrinsicApplicabilityChecker.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt':[
-155,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt": [
+155
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt": [
+209
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt": [
+71
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/EffectiveVisibility.kt": [
+211
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/protobuf/GenerateProtoBufCompare.kt": [
 209,
+300
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/javac-wrapper/src/org/jetbrains/kotlin/javac/resolve/ConstantEvaluator.kt':[
-71,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/TypeUtils.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/EffectiveVisibility.kt':[
-211,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/TypeKindHighlightingVisitor.kt": [
+49
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/generators/tests/org/jetbrains/kotlin/generators/protobuf/GenerateProtoBufCompare.kt':[
-209,
-300,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/intentions/OperatorToFunctionIntention.kt": [
+158
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/util/TypeUtils.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/PsiBasedClassResolver.kt": [
+205
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/TypeKindHighlightingVisitor.kt':[
-49,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinReferencesSearcher.kt": [
+220
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/intentions/OperatorToFunctionIntention.kt':[
-158,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionUtils.kt": [
+217
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/PsiBasedClassResolver.kt':[
-205,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/generateUtil.kt": [
+183
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/ideaExtensions/KotlinReferencesSearcher.kt':[
-220,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-test-framework/test/org/jetbrains/kotlin/idea/test/KotlinLightCodeInsightFixtureTestCase.kt": [
+111
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionUtils.kt':[
-217,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinQuickDocumentationProvider.kt": [
+194
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/generateUtil.kt':[
-183,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/UselessCallOnNotNullInspection.kt": [
+52
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-test-framework/test/org/jetbrains/kotlin/idea/test/KotlinLightCodeInsightFixtureTestCase.kt':[
-111,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt": [
+477
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinQuickDocumentationProvider.kt':[
-194,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/ui/KotlinChangeSignatureDialog.kt": [
+184
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/UselessCallOnNotNullInspection.kt':[
-52,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementSelectionUtils.kt": [
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt':[
-477,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt": [
+117
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/ui/KotlinChangeSignatureDialog.kt':[
-184,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt": [
+742
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/elementSelectionUtils.kt':[
-117,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt':[
-117,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt':[
-742,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/TypeConverter.kt": [
 327,
-440,
+440
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Context.kt':[
-192,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.dce/src/org/jetbrains/kotlin/js/dce/Context.kt": [
+192
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsExternalChecker.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsExternalChecker.kt": [
 50,
-151,
+151
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/IfStatementReduction.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.inliner/src/org/jetbrains/kotlin/js/inline/clean/IfStatementReduction.kt": [
+40
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/context/UsageTracker.kt':[
-55,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/context/UsageTracker.kt": [
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/Main.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/Main.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/AbstractAndroidExtensionsExpressionCodegenExtension.kt':[
-120,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/codegen/AbstractAndroidExtensionsExpressionCodegenExtension.kt": [
+120
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt':[
-556,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt": [
+556
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6517.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6517.json
@@ -1,514 +1,514 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/InnerClassConsumer.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/InnerClassConsumer.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/PackagePartRegistry.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/PackagePartRegistry.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/extensions/ClassBuilderInterceptorExtension.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/extensions/ClassBuilderInterceptorExtension.kt": [
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/PopBackwardPropagationTransformer.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/PopBackwardPropagationTransformer.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/TrackedReferenceValue.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/TrackedReferenceValue.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InExpressionGenerator.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/inExpression/InExpressionGenerator.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/IncompatibleClassTracker.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/state/IncompatibleClassTracker.kt": [
+26
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/ReplApi.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/ReplApi.kt": [
 50,
 56,
 81,
 116,
 164,
 173,
-205,
+205
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-runner/src/org/jetbrains/kotlin/runner/Runner.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-runner/src/org/jetbrains/kotlin/runner/Runner.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/DiagnosticMessageReporter.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/DiagnosticMessageReporter.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/common/performanceMeasurements.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/common/performanceMeasurements.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplExceptionReporter.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/ReplExceptionReporter.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/configuration/SnippetExecutionInterceptor.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/configuration/SnippetExecutionInterceptor.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Container.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Container.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Descriptors.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Descriptors.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Resolve.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/container/src/org/jetbrains/kotlin/container/Resolve.kt": [
 25,
-29,
+29
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/report/DaemonMessageReporter.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/report/DaemonMessageReporter.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/sam/SamWithReceiverResolver.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/sam/SamWithReceiverResolver.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/extensions/PackageFragmentProviderExtension.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/extensions/PackageFragmentProviderExtension.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/jvmSignature/KotlinToJvmSignatureMapper.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/jvmSignature/KotlinToJvmSignatureMapper.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/modules/JavaModuleFinder.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/modules/JavaModuleFinder.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/modules/JavaModuleResolver.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/modules/JavaModuleResolver.kt": [
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/ScriptReportSink.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/ScriptReportSink.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/scriptTemplate.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/scriptTemplate.kt": [
 66,
-80,
+80
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/analyzer/AnalyzerFacade.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/analyzer/AnalyzerFacade.kt": [
 392,
 400,
-420,
+420
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/PseudoValue.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/pseudocode/PseudoValue.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/contracts/parsing/PsiEffectParser.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/contracts/parsing/PsiEffectParser.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/DiagnosticParameterRenderer.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/DiagnosticParameterRenderer.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/diagnosticsWithParameterRenderers.kt':[
-88,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/diagnosticsWithParameterRenderers.kt": [
+88
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/extensions/CompilerConfigurationExtension.kt':[
-10,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/extensions/CompilerConfigurationExtension.kt": [
+10
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/extensions/StorageComponentContainerContributor.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/extensions/StorageComponentContainerContributor.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/load/kotlin/MetadataFinderFactory.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/load/kotlin/MetadataFinderFactory.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationChecker.kt':[
-385,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/AnnotationChecker.kt": [
+385
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/BodyResolveCache.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/BodyResolveCache.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationReturnTypeSanitizer.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationReturnTypeSanitizer.kt": [
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegationResolver.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegationResolver.kt": [
 106,
-110,
+110
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/FilePreprocessor.kt':[
-13,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/FilePreprocessor.kt": [
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/ModifiersChecker.kt':[
-458,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/ModifiersChecker.kt": [
+458
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/ModuleAnnotationsResolver.kt':[
-13,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/ModuleAnnotationsResolver.kt": [
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverloadFilter.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverloadFilter.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverridesBackwardCompatibilityHelper.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/OverridesBackwardCompatibilityHelper.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/CallChecker.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/CallChecker.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/RttiExpressionChecker.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/RttiExpressionChecker.kt": [
+24
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/model/ArgumentMapping.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/model/ArgumentMapping.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/ClassifierUsageChecker.kt':[
-31,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/ClassifierUsageChecker.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/DeclarationChecker.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/DeclarationChecker.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/diagnostics/KotlinSuppressCache.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/diagnostics/KotlinSuppressCache.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/inline/ReasonableInlineRule.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/inline/ReasonableInlineRule.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/AbsentDescriptorHandler.kt':[
-13,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/AbsentDescriptorHandler.kt": [
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/DelegationFilter.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/DelegationFilter.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/FileScopeProvider.kt':[
-56,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/FileScopeProvider.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LocalDescriptorResolver.kt':[
-25,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LocalDescriptorResolver.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyClassMemberScope.kt':[
-127,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/descriptors/LazyClassMemberScope.kt": [
+127
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/ClassLiteralChecker.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/ClassLiteralChecker.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/multiproject/ModulesApiHistory.kt':[
-15,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/multiproject/ModulesApiHistory.kt": [
+15
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/snapshots/FileSnapshotProvider.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/snapshots/FileSnapshotProvider.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/Lower.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/Lower.kt": [
 29,
 33,
 37,
 41,
-45,
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt':[
-41,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt": [
+41
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/Psi2IrTranslator.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/Psi2IrTranslator.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/intermediate/Values.kt':[
-37,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/intermediate/Values.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/SourceManager.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/SourceManager.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/builder/LightClassDataProvider.kt':[
-157,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/builder/LightClassDataProvider.kt": [
+157
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForSourceDeclaration.kt':[
-482,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/KtLightClassForSourceDeclaration.kt": [
+482
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/plugin-api/src/org/jetbrains/kotlin/compiler/plugin/ComponentRegistrar.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/plugin-api/src/org/jetbrains/kotlin/compiler/plugin/ComponentRegistrar.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtFileClassProvider.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtFileClassProvider.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/description/ContractDescription.kt':[
-35,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/description/ContractDescription.kt": [
+35
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/interpretation/EffectDeclarationInterpreter.kt':[
-28,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/interpretation/EffectDeclarationInterpreter.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/model/ESExpressions.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/model/ESExpressions.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/model/Functor.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/contracts/model/Functor.kt": [
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/ResultTypeResolver.kt':[
-32,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/ResultTypeResolver.kt": [
+32
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/ResolutionCandidate.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/model/ResolutionCandidate.kt": [
+43
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/FlatSignature.kt": [
+29,
+33
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/TowerResolver.kt": [
+40
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/scopes/LexicalScopeStorage.kt": [
+29
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/SerializerExtension.kt": [
+22
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTemplateTest.kt": [
+469
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/util/src/org/jetbrains/kotlin/load/kotlin/incremental/components/IncrementalCompilationComponents.kt": [
+21
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/util/src/org/jetbrains/kotlin/progress/CancelationStatus.kt": [
+24
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/native/kotlin/Collections.kt": [
+26
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/native/kotlin/Comparable.kt": [
+22
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/components/JavaPropertyInitializerEvaluator.kt": [
+23
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/components/SamConversionResolver.kt": [
+22
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/ModuleClassResolver.kt": [
+24
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/resolvers.kt": [
+26
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/sources/JavaSourceElementFactory.kt": [
+22
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/BuiltInsLoader.kt": [
+27
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/Substitutable.kt": [
+21
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/SupertypeLoopChecker.kt": [
+22
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/deserialization/PlatformDependentDeclarationFilter.kt": [
+23
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/incremental/components/ExpectActualTracker.kt": [
+23
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/ClassifierNamePolicy.kt": [
+24
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/util/ModuleVisibilityHelper.kt": [
+21
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/ContractDeserializer.kt": [
+23
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/FlexibleTypeDeserializer.kt": [
+23
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/script.runtime/src/kotlin/script/dependencies/resolvers_deprecated.kt": [
+27
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/core/util.runtime/src/org/jetbrains/kotlin/storage/storage.kt": [
+46,
+50
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt": [
+27
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinSpacingBuilder.kt": [
+41
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/kdoc/SampleResolutionService.kt": [
+24
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/LibraryDependenciesCache.kt": [
+29
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/compiler/configuration/BaseKotlinCompilerSettings.kt": [
+95
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/configuration/BuildSystemType.kt": [
+16
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/textBuilder/DecompiledText.kt": [
+25
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/framework/LibraryEffectiveKindProvider.kt": [
+13
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/quickfix/QuickFixes.kt": [
+60
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt": [
+117
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionInformationProvider.kt": [
+22
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/ContextVariablesProvider.kt": [
+32
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordValues.kt": [
+41
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt": [
+52
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/NotPropertiesService.kt": [
+24
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/extension/KotlinIndicesHelperExtension.kt": [
+24
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/classLoading/AndroidDexer.kt": [
+21
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/KotlinMavenImporter.kt": [
+59
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/CommandHistory.kt": [
+57
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/performanceTests/org/jetbrains/kotlin/idea/perf/WholeProjectFileProvider.kt": [
+11
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/UsageReplacementStrategy.kt": [
+47
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/facet/KotlinFacetConfigurationExtension.kt": [
+24
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/markers/KotlinLineMarkerProvider.kt": [
+150
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/internal/KotlinDecompilerService.kt": [
+24
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeMemberFunctionSignatureFix.kt": [
+248
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinIntroduceParameterHandler.kt": [
+207
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/KotlinPushDownHandler.kt": [
+49
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/AbstractMultifileRefactoringTest.kt": [
+46
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/DocCommentConverter.kt": [
+24
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt": [
 43,
+47
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/results/FlatSignature.kt':[
-29,
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/JavaToKotlinConverter.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/TowerResolver.kt':[
-40,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/JavaToKotlinConverterServices.kt": [
+46
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/scopes/LexicalScopeStorage.kt':[
-29,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ResolverForConverter.kt": [
+22
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/serialization/src/org/jetbrains/kotlin/serialization/SerializerExtension.kt':[
-22,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTemplateTest.kt':[
-469,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/util/src/org/jetbrains/kotlin/load/kotlin/incremental/components/IncrementalCompilationComponents.kt':[
-21,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/util/src/org/jetbrains/kotlin/progress/CancelationStatus.kt':[
-24,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/native/kotlin/Collections.kt':[
-26,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/builtins/native/kotlin/Comparable.kt':[
-22,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/components/JavaPropertyInitializerEvaluator.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/StatementConverter.kt": [
 23,
+27
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/components/SamConversionResolver.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/usageProcessing/UsageProcessing.kt": [
+37
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/ModuleClassResolver.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/extensions/JsSyntheticTranslateExtension.kt": [
+25
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/resolvers.kt':[
-26,
+"kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/intrinsic/objects/objectsIntrinsics.kt": [
+57
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/sources/JavaSourceElementFactory.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/Assertions.kt": [
+219
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/builtins/BuiltInsLoader.kt':[
-27,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/api/scriptCompilation.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/Substitutable.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/api/scriptEvaluation.kt": [
+28
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/SupertypeLoopChecker.kt':[
-22,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/api/scriptingEnvironment.kt": [
+31
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/deserialization/PlatformDependentDeclarationFilter.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/jvmScriptCompilation.kt": [
+56
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/incremental/components/ExpectActualTracker.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/kotlin/KotlinH.kt": [
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/renderer/ClassifierNamePolicy.kt':[
-24,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/Comparator.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/util/ModuleVisibilityHelper.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.events.kt": [
+482
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/ContractDeserializer.kt':[
-23,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/FlexibleTypeDeserializer.kt':[
-23,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/script.runtime/src/kotlin/script/dependencies/resolvers_deprecated.kt':[
-27,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/core/util.runtime/src/org/jetbrains/kotlin/storage/storage.kt':[
-46,
-50,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt':[
-27,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinSpacingBuilder.kt':[
-41,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/kdoc/SampleResolutionService.kt':[
-24,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/LibraryDependenciesCache.kt':[
-29,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/compiler/configuration/BaseKotlinCompilerSettings.kt':[
-95,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/configuration/BuildSystemType.kt':[
-16,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/decompiler/textBuilder/DecompiledText.kt':[
-25,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/framework/LibraryEffectiveKindProvider.kt':[
-13,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/quickfix/QuickFixes.kt':[
-60,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/ExpressionsOfTypeProcessor.kt':[
-117,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionInformationProvider.kt':[
-22,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/ContextVariablesProvider.kt':[
-32,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordValues.kt':[
-41,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/smart/SmartCompletion.kt':[
-52,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/NotPropertiesService.kt':[
-24,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/extension/KotlinIndicesHelperExtension.kt':[
-24,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/evaluate/classLoading/AndroidDexer.kt':[
-21,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/KotlinMavenImporter.kt':[
-59,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-repl/src/org/jetbrains/kotlin/console/CommandHistory.kt':[
-57,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/performanceTests/org/jetbrains/kotlin/idea/perf/WholeProjectFileProvider.kt':[
-11,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/UsageReplacementStrategy.kt':[
-47,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/facet/KotlinFacetConfigurationExtension.kt':[
-24,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/markers/KotlinLineMarkerProvider.kt':[
-150,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/internal/KotlinDecompilerService.kt':[
-24,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeMemberFunctionSignatureFix.kt':[
-248,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinIntroduceParameterHandler.kt':[
-207,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/pushDown/KotlinPushDownHandler.kt':[
-49,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/refactoring/AbstractMultifileRefactoringTest.kt':[
-46,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/DocCommentConverter.kt':[
-24,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt':[
-43,
-47,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/JavaToKotlinConverter.kt':[
-57,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/JavaToKotlinConverterServices.kt':[
-46,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/ResolverForConverter.kt':[
-22,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/StatementConverter.kt':[
-23,
-27,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/j2k/src/org/jetbrains/kotlin/j2k/usageProcessing/UsageProcessing.kt':[
-37,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/extensions/JsSyntheticTranslateExtension.kt':[
-25,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/js/js.translator/src/org/jetbrains/kotlin/js/translate/intrinsic/objects/objectsIntrinsics.kt':[
-57,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/Assertions.kt':[
-219,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/api/scriptCompilation.kt':[
-8,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/api/scriptEvaluation.kt':[
-28,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/api/scriptingEnvironment.kt':[
-31,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/jvmScriptCompilation.kt':[
-56,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/kotlin/KotlinH.kt':[
-13,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/Comparator.kt':[
-9,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.events.kt':[
-482,
-],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt": [
 2871,
-3400,
+3400
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.svg.kt':[
-439,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/org.w3c/org.w3c.dom.svg.kt": [
+439
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Sequence.kt':[
-21,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Sequence.kt": [
+21
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/internal/contracts/Effect.kt':[
-20,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/internal/contracts/Effect.kt": [
+20
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/properties/Interfaces.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/properties/Interfaces.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/interfaces/interfaceWithImpls.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/interfaces/interfaceWithImpls.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/jvmTarget/src/helloWorld.kt':[
-1,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/jvmTarget/src/helloWorld.kt": [
+1
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/src/main/java/com/example/databinding/EnumAdapter.kt':[
-13,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/src/main/java/com/example/databinding/EnumAdapter.kt": [
+13
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt15001/app/src/main/java/MyComponent.kt':[
-8,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt15001/app/src/main/java/MyComponent.kt": [
+8
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressWarnings/src/helloWorld.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressWarnings/src/helloWorld.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinSourceSetProvider.kt':[
-19,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinSourceSetProvider.kt": [
+19
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/CoffeeApp.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/CoffeeApp.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/Pump.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/main/kotlin/Pump.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/test/kotlin/hello/tests/ExampleTest.kt':[
-15,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-dagger-maven-example/src/test/kotlin/hello/tests/ExampleTest.kt": [
+15
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-js-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-jvmTarget/src/main/kotlin/main.kt':[
-1,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-jvmTarget/src/main/kotlin/main.kt": [
+1
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/CoffeeApp.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/CoffeeApp.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/Pump.kt':[
-3,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/main/kotlin/Pump.kt": [
+3
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/test/kotlin/hello/tests/ExampleTest.kt':[
-15,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-kapt-allopen/src/test/kotlin/hello/tests/ExampleTest.kt": [
+15
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt':[
-9,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-suppressWarnings/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
+9
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/resolvers/basic.kt':[
-23,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/resolvers/basic.kt": [
+23
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt':[
-512,
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt": [
+512
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/org/jetbrains/uast/test/common/ResolveTestBase.kt':[
-25,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/uast-kotlin/tests/org/jetbrains/uast/test/common/ResolveTestBase.kt": [
+25
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6558.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6558.json
@@ -1,60 +1,60 @@
 {
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/Parameters.kt':[
-42,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/Parameters.kt": [
+42
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CliKotlinAsJavaSupport.kt':[
-86,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CliKotlinAsJavaSupport.kt": [
+86
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/InputsCache.kt':[
-77,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/InputsCache.kt": [
+77
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-java8/tests/org/jetbrains/kotlin/serialization/builtins/AdditionalBuiltInsMembersSignatureListsTest.kt':[
-51,
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-java8/tests/org/jetbrains/kotlin/serialization/builtins/AdditionalBuiltInsMembersSignatureListsTest.kt": [
+51
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/jvm/compiler/MultiModuleJavaAnalysisCustomTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests/org/jetbrains/kotlin/jvm/compiler/MultiModuleJavaAnalysisCustomTest.kt": [
 62,
-102,
+102
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/LightMemberOriginForCompiledElement.kt':[
-159,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/lightClasses/LightMemberOriginForCompiledElement.kt": [
+159
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/core/script/GradleScriptTemplateProvider.kt':[
-199,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/src/org/jetbrains/kotlin/idea/core/script/GradleScriptTemplateProvider.kt": [
+199
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToStringTemplateIntention.kt':[
-33,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToStringTemplateIntention.kt": [
+33
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/IfThenToElvisIntention.kt':[
-36,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/IfThenToElvisIntention.kt": [
+36
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinFunctionProcessor.kt':[
-194,
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinFunctionProcessor.kt": [
+194
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractInspectionTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/tests/org/jetbrains/kotlin/idea/codeInsight/AbstractInspectionTest.kt": [
 81,
-81,
+81
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk8/test/collections/StreamsTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk8/test/collections/StreamsTest.kt": [
 53,
-55,
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jre8/test/collections/StreamsTest.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jre8/test/collections/StreamsTest.kt": [
 53,
-55,
+55
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/FileTreeWalks.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/FileTreeWalks.kt": [
 294,
 307,
-320,
+320
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/Files.kt':[
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/io/Files.kt": [
 71,
-74,
+74
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/synthetic/test/AbstractAndroidBoxTest.kt':[
-45,
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/synthetic/test/AbstractAndroidBoxTest.kt": [
+45
 ],
-'kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/synthetic/test/CompilerTestUtils.kt':[
-71,
-],
+"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/android/synthetic/test/CompilerTestUtils.kt": [
+71
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S100.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S100.json
@@ -1,46 +1,46 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/HeadersJvmTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/HeadersJvmTest.kt": [
 253,
 262,
 271,
-280,
+280
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/Strings.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/Strings.kt": [
 23,
 47,
 76,
-110,
+110
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt": [
 32,
 75,
 122,
 215,
 299,
-420,
+420
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/Strings.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/Strings.kt": [
 20,
 63,
 105,
 129,
 158,
-196,
+196
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/darwin/src/io/ktor/network/util/SocketUtilsDarwin.kt':[
-11,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/darwin/src/io/ktor/network/util/SocketUtilsDarwin.kt": [
+11
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ios/src/io/ktor/network/util/SocketUtilsIos.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ios/src/io/ktor/network/util/SocketUtilsIos.kt": [
 9,
-16,
+16
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Hashes.kt':[
-16,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Hashes.kt": [
+16
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ClientCertificateRequestTest.kt':[
-13,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ClientCertificateRequestTest.kt": [
+13
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/CertificatesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/CertificatesTest.kt": [
 24,
 41,
 54,
@@ -52,42 +52,42 @@
 135,
 148,
 162,
-176,
+176
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/KeyStoreBuilderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/KeyStoreBuilderTest.kt": [
 23,
 44,
 59,
 74,
 93,
-108,
+108
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/linuxX64/src/io/ktor/network/util/SocketUtilsLinux.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/linuxX64/src/io/ktor/network/util/SocketUtilsLinux.kt": [
 11,
 18,
-26,
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/macos/src/io/ktor/network/util/SocketUtilsMacos.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/macos/src/io/ktor/network/util/SocketUtilsMacos.kt": [
 10,
-18,
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/SocketUtils.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/SocketUtils.kt": [
 96,
 103,
-105,
+105
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/tvos/src/io/ktor/network/util/SocketUtilsTvos.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/tvos/src/io/ktor/network/util/SocketUtilsTvos.kt": [
 9,
-16,
+16
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/watchos/src/io/ktor/network/util/SocketUtilsWatchos.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/watchos/src/io/ktor/network/util/SocketUtilsWatchos.kt": [
 9,
-16,
+16
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOClientCertTest.kt':[
-13,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOClientCertTest.kt": [
+13
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/ApplicationPluginTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/ApplicationPluginTest.kt": [
 22,
 38,
 70,
@@ -95,12 +95,12 @@
 161,
 187,
 243,
-290,
+290
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/AutoReloadUtils.kt':[
-68,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/AutoReloadUtils.kt": [
+68
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ApplicationEngineEnvironmentReloadingTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ApplicationEngineEnvironmentReloadingTests.kt": [
 27,
 49,
 70,
@@ -120,21 +120,21 @@
 366,
 472,
 480,
-495,
+495
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/MultipleDispatchOnTimeout.kt':[
-29,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/MultipleDispatchOnTimeout.kt": [
+29
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/MultipleDispatchOnTimeout.kt':[
-29,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/MultipleDispatchOnTimeout.kt": [
+29
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/MultipleDispatchOnTimeout.kt':[
-29,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/MultipleDispatchOnTimeout.kt": [
+29
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/MultipleDispatchOnTimeout.kt':[
-29,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/MultipleDispatchOnTimeout.kt": [
+29
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt": [
 21,
 32,
 44,
@@ -144,9 +144,9 @@
 105,
 118,
 131,
-144,
+144
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt": [
 69,
 98,
 107,
@@ -162,14 +162,14 @@
 367,
 396,
 412,
-438,
+438
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/CustomLocationsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/CustomLocationsTest.kt": [
 51,
 64,
-78,
+78
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt": [
 30,
 62,
 95,
@@ -202,9 +202,9 @@
 625,
 637,
 643,
-654,
+654
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt": [
 40,
 72,
 107,
@@ -220,26 +220,26 @@
 332,
 341,
 355,
-385,
+385
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/test/io/ktor/server/metrics/dropwizard/DropwizardMetricsTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/test/io/ktor/server/metrics/dropwizard/DropwizardMetricsTests.kt": [
 27,
 48,
 71,
 83,
 104,
-129,
+129
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/test/io/ktor/server/mustache/MustacheTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/test/io/ktor/server/mustache/MustacheTest.kt": [
 31,
 53,
 73,
 89,
 111,
 139,
-155,
+155
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test/io/ktor/server/pebble/PebbleTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test/io/ktor/server/pebble/PebbleTest.kt": [
 31,
 53,
 73,
@@ -250,48 +250,48 @@
 176,
 197,
 218,
-237,
+237
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt':[
-283,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt": [
+283
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/BaseTestNix.kt':[
-28,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/BaseTestNix.kt": [
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ClientCertTestSuite.kt':[
-41,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ClientCertTestSuite.kt": [
+41
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CookiesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CookiesTest.kt": [
 28,
 40,
 49,
-78,
+78
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/ApplicationRequestHeaderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/ApplicationRequestHeaderTest.kt": [
 19,
 49,
-111,
+111
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/HandlerTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/HandlerTest.kt": [
 18,
 28,
 39,
 50,
-65,
+65
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/UrlEncodedTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/UrlEncodedTest.kt": [
 23,
 35,
 48,
 61,
-74,
+74
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/Base64EncodingCookiesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/Base64EncodingCookiesTest.kt": [
 12,
 17,
-22,
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CookiesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CookiesTest.kt": [
 17,
 25,
 33,
@@ -305,14 +305,14 @@
 90,
 97,
 104,
-114,
+114
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/DQuotesCookiesEncodingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/DQuotesCookiesEncodingTest.kt": [
 12,
 17,
-22,
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/URIEncodingCookiesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/URIEncodingCookiesTest.kt": [
 12,
 17,
 22,
@@ -321,12 +321,12 @@
 40,
 45,
 50,
-55,
+55
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingBuildTest.kt':[
-13,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingBuildTest.kt": [
+13
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingResolveTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingResolveTest.kt": [
 49,
 96,
 170,
@@ -344,20 +344,20 @@
 570,
 622,
 650,
-688,
+688
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/FileChannelTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/FileChannelTest.kt": [
 74,
 88,
-108,
+108
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/mingwX64/src/io/ktor/util/date/DateMingw.kt':[
-11,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/mingwX64/src/io/ktor/util/date/DateMingw.kt": [
+11
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/nix/src/io/ktor/util/date/DateNix.kt':[
-12,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/nix/src/io/ktor/util/date/DateNix.kt": [
+12
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/date/DateNative.kt':[
-73,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/date/DateNative.kt": [
+73
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S101.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S101.json
@@ -1,10 +1,10 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/CustomLocationsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/CustomLocationsTest.kt": [
 38,
 39,
-42,
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt": [
 28,
 45,
 60,
@@ -32,9 +32,9 @@
 612,
 615,
 631,
-633,
+633
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt": [
 34,
 51,
 64,
@@ -63,6 +63,6 @@
 388,
 422,
 427,
-495,
-],
+495
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S103.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S103.json
@@ -1,9 +1,9 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/fetch/LibDom.kt':[
-24,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/fetch/LibDom.kt": [
+24
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MockedTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MockedTests.kt": [
 53,
-56,
-],
+56
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S104.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S104.json
@@ -1,14 +1,14 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Mimes.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Mimes.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CORSTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CORSTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingResolveTest.kt':[
-0,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingResolveTest.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S105.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S105.json
@@ -1,8 +1,5 @@
 {
 "kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Mimes.kt": [
 0
-],
-"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jte-classes/gg/jte/generated/ondemand/JtetestGenerated.kt": [
-0
 ]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S105.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S105.json
@@ -1,5 +1,8 @@
 {
 "kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Mimes.kt": [
 0
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jte-classes/gg/jte/generated/ondemand/JtetestGenerated.kt": [
+0
 ]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S105.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S105.json
@@ -1,5 +1,5 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Mimes.kt':[
-0,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Mimes.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1066.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1066.json
@@ -1,28 +1,28 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt':[
-60,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt": [
+60
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt':[
-47,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt": [
+47
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
-1695,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
+1695
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/HostsRoutingBuilder.kt':[
-122,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/HostsRoutingBuilder.kt": [
+122
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt':[
-115,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt": [
+115
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatEngineTest.kt':[
-107,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatEngineTest.kt": [
+107
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt':[
-107,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt": [
+107
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/internal/LockFreeLinkedList.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/internal/LockFreeLinkedList.kt": [
 163,
 587,
-751,
-],
+751
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1067.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1067.json
@@ -1,49 +1,49 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/TargetsConfig.kt':[
-22,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/TargetsConfig.kt": [
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt':[
-99,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt": [
+99
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyPinnedCertificate.kt':[
-71,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyPinnedCertificate.kt": [
+71
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/DarwinLegacyUrlUtils.kt':[
-18,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/DarwinLegacyUrlUtils.kt": [
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/PinnedCertificate.kt':[
-71,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/PinnedCertificate.kt": [
+71
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt':[
-18,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt": [
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/CacheControl.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/CacheControl.kt": [
 101,
-102,
+102
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/CookieUtils.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/CookieUtils.kt": [
 66,
-76,
+76
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLParser.kt':[
-222,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLParser.kt": [
+222
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt':[
-34,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt": [
+34
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
 1952,
-2193,
+2193
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketOptionsPlatformCapabilities.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketOptionsPlatformCapabilities.kt": [
 35,
 52,
-70,
+70
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSUtils.kt':[
-89,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSUtils.kt": [
+89
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt':[
-506,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt": [
+506
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S107.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S107.json
@@ -1,45 +1,45 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/utils.kt':[
-38,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/utils.kt": [
+38
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Cookie.kt':[
-138,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Cookie.kt": [
+138
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Url.kt':[
-128,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Url.kt": [
+128
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt": [
 84,
 131,
 195,
-325,
+325
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt": [
 431,
-472,
+472
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseCookies.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseCookies.kt": [
 40,
-58,
+58
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth1a.kt':[
-153,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth1a.kt": [
+153
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt':[
-417,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt": [
+417
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt':[
-157,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt": [
+157
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt':[
-584,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt": [
+584
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt": [
 159,
-183,
+183
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt": [
 609,
-636,
-],
+636
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S108.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S108.json
@@ -1,304 +1,304 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt':[
-133,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt": [
+133
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheRequestProducer.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheRequestProducer.kt": [
 69,
-70,
+70
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt": [
 58,
 59,
-60,
+60
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt": [
 57,
 73,
 102,
 129,
-182,
+182
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt": [
 48,
 114,
-192,
+192
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/observer/ResponseObserver.kt':[
-71,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/observer/ResponseObserver.kt": [
+71
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt':[
-124,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt": [
+124
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt':[
-36,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt": [
+36
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpResponseBodyHandler.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpResponseBodyHandler.kt": [
+73
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt": [
 73,
+77
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt':[
-73,
-77,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt": [
+126
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt':[
-126,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt": [
 94,
-223,
+223
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/jvm/test/TracingWrapperTest.kt':[
-110,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/jvm/test/TracingWrapperTest.kt": [
+110
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketTest.kt':[
-37,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketTest.kt": [
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CallValidatorTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CallValidatorTest.kt": [
 88,
 113,
-137,
+137
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/EventsTest.kt':[
-67,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/EventsTest.kt": [
+67
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt':[
-144,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt": [
+144
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/DateUtils.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/DateUtils.kt": [
 34,
-50,
+50
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CodecTest.kt':[
-32,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CodecTest.kt": [
+32
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt':[
-279,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt": [
+279
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteBufferChannelScenarioTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteBufferChannelScenarioTest.kt": [
 143,
 183,
-198,
+198
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt": [
 424,
 425,
 456,
-457,
+457
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketBuildTest.kt':[
-184,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketBuildTest.kt": [
+184
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/DecodeBuffer.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/DecodeBuffer.kt": [
 24,
 43,
-56,
+56
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/CancellableReusableContinuationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/CancellableReusableContinuationTest.kt": [
 65,
 82,
-102,
+102
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/JvmByteChannelSmokeTest.kt':[
-45,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/JvmByteChannelSmokeTest.kt": [
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/SelectorManagerSupport.kt':[
-162,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/SelectorManagerSupport.kt": [
+162
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt": [
 69,
-125,
+125
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt": [
 69,
-129,
+129
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt':[
-53,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt": [
+53
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt": [
 118,
 124,
 125,
-126,
+126
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/Sockets.kt':[
-24,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/Sockets.kt": [
+24
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt':[
-84,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt": [
+84
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt':[
-64,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt": [
+64
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSHandshakeType.kt':[
-82,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSHandshakeType.kt": [
+82
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ConnectionTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ConnectionTest.kt": [
 99,
-133,
+133
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SignalPoint.kt':[
-92,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SignalPoint.kt": [
+92
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/ConnectUtilsNative.kt':[
-39,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/ConnectUtilsNative.kt": [
+39
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/DatagramSocketNative.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/DatagramSocketNative.kt": [
 49,
-50,
+50
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ClassCastExceptionTest.kt':[
-58,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ClassCastExceptionTest.kt": [
+58
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/TestHttpServer.kt':[
-46,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/TestHttpServer.kt": [
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/WeakTimeoutQueueTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/WeakTimeoutQueueTest.kt": [
 55,
 79,
-95,
+95
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/TestConnectorInterfaceUsed.kt':[
-29,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/TestConnectorInterfaceUsed.kt": [
+29
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineEnvironmentReloading.kt':[
-364,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineEnvironmentReloading.kt": [
+364
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt':[
-87,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt": [
+87
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultEnginePipeline.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultEnginePipeline.kt": [
 44,
-82,
+82
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt": [
 98,
-107,
+107
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt": [
 98,
-107,
+107
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt':[
-321,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt": [
+321
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt": [
 190,
-197,
+197
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt':[
-159,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt": [
+159
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt':[
-39,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt": [
+39
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt": [
 31,
-64,
+64
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt':[
-102,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt": [
+102
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt':[
-194,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt": [
+194
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/Webjars.kt':[
-61,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/Webjars.kt": [
+61
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/WebSocketUpgrade.kt':[
-100,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/WebSocketUpgrade.kt": [
+100
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/DefaultWebSocketTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/DefaultWebSocketTest.kt": [
 139,
-144,
+144
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/RawWebSocketTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/RawWebSocketTest.kt": [
 161,
-168,
+168
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServlet.kt':[
-97,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServlet.kt": [
+97
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletReader.kt':[
-108,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletReader.kt": [
+108
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletUpgrade.kt':[
-125,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletUpgrade.kt": [
+125
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletWriter.kt':[
-111,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletWriter.kt": [
+111
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt':[
-98,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt": [
+98
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletReader.kt':[
-108,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletReader.kt": [
+108
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt':[
-126,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt": [
+126
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletWriter.kt':[
-111,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletWriter.kt": [
+111
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBaseJvm.kt':[
-341,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBaseJvm.kt": [
+341
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt": [
 152,
-578,
+578
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestEngineWebsocketSession.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestEngineWebsocketSession.kt": [
 22,
-25,
+25
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationEngine.kt':[
-117,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationEngine.kt": [
+117
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt':[
-129,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt": [
+129
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt": [
 288,
 324,
 371,
 499,
-664,
+664
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ServerGsonBlockingTest.kt':[
-90,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ServerGsonBlockingTest.kt": [
+90
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonBlockingTest.kt':[
-91,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonBlockingTest.kt": [
+91
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt": [
 208,
 230,
 231,
 232,
-233,
+233
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt": [
 34,
 99,
 100,
-101,
+101
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt':[
-81,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt": [
+81
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketSession.kt':[
-122,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketSession.kt": [
+122
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketReader.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketReader.kt": [
 41,
-42,
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketWriter.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketWriter.kt": [
 76,
 78,
 81,
-86,
+86
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/DeflaterReadChannelTest.kt':[
-161,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/DeflaterReadChannelTest.kt": [
+161
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1110.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1110.json
@@ -1,8 +1,8 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Codecs.kt':[
-10,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Codecs.kt": [
+10
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/HashFunction.kt':[
-81,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/HashFunction.kt": [
+81
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1125.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1125.json
@@ -1,8 +1,8 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt':[
-122,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt": [
+122
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/HostsRoutingBuilder.kt':[
-115,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/HostsRoutingBuilder.kt": [
+115
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1128.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1128.json
@@ -1,8 +1,8 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/TestServerPlugin.kt':[
-9,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/TestServerPlugin.kt": [
+9
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ByteReadChannelNative.kt':[
-6,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ByteReadChannelNative.kt": [
+6
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1133.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1133.json
@@ -1,111 +1,111 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt':[
-144,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt": [
+144
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngineConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngineConfig.kt": [
 89,
-106,
+106
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/Compatibility.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/Compatibility.kt": [
 17,
 26,
-37,
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/HttpClientCall.kt':[
-137,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/HttpClientCall.kt": [
+137
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultResponseValidation.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultResponseValidation.kt": [
 77,
 90,
 106,
-121,
+121
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpCallValidator.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpCallValidator.kt": [
 80,
-91,
+91
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRequestRetry.kt':[
-165,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRequestRetry.kt": [
+165
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpSend.kt':[
-60,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpSend.kt": [
+60
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt": [
 45,
 47,
 74,
-88,
+88
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt": [
 26,
-106,
+106
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/observer/DelegatedCall.kt':[
-26,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/observer/DelegatedCall.kt": [
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/Compatibility.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/Compatibility.kt": [
 20,
 28,
-45,
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt':[
-147,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt": [
+147
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientJvmEngine.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientJvmEngine.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/CIOJvm.kt':[
-23,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/CIOJvm.kt": [
+23
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/WebSocketTest.kt':[
-38,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/WebSocketTest.kt": [
+38
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlClientEngine.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlClientEngine.kt": [
 66,
-70,
+70
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngineConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngineConfig.kt": [
 34,
 46,
-99,
+99
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt": [
 35,
 47,
-100,
+100
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt':[
-139,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt": [
+139
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/ios/Ios.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/ios/Ios.kt": [
 13,
 19,
-25,
+25
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/ios/certificates/CertificatePinner.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/ios/certificates/CertificatePinner.kt": [
 11,
-17,
+17
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt':[
-206,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt": [
+206
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt':[
-155,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt": [
+155
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/AuthProvider.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/AuthProvider.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt": [
 35,
 41,
 47,
 98,
-113,
+113
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt':[
-97,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt": [
+97
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt": [
 40,
 46,
 82,
@@ -113,62 +113,62 @@
 87,
 99,
 103,
-108,
+108
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonPlugin.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonPlugin.kt": [
 55,
-233,
+233
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonSerializer.kt':[
-18,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonSerializer.kt": [
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/plugins/gson/GsonSerializer.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/plugins/gson/GsonSerializer.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/plugins/jackson/JacksonSerializer.kt':[
-20,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/plugins/jackson/JacksonSerializer.kt": [
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/plugins/kotlinx/serializer/KotlinxSerializer.kt':[
-25,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/plugins/kotlinx/serializer/KotlinxSerializer.kt": [
+25
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Headers.kt':[
-51,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Headers.kt": [
+51
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpHeaders.kt':[
-135,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpHeaders.kt": [
+135
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt": [
 22,
+27
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt": [
+128
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/RequestConnectionPoint.kt": [
 27,
+43
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt':[
-128,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/RequestConnectionPoint.kt':[
-27,
-43,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLBuilder.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLBuilder.kt": [
 290,
 294,
 301,
-307,
+307
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Url.kt':[
-128,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Url.kt": [
+128
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/Multipart.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/Multipart.kt": [
 88,
-97,
+97
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ChunkedTransferEncoding.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ChunkedTransferEncoding.kt": [
 37,
-69,
+69
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpBody.kt':[
-120,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpBody.kt": [
+120
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt": [
 77,
 109,
 129,
@@ -176,44 +176,44 @@
 188,
 233,
 277,
-453,
+453
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteChannelSequential.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteChannelSequential.kt": [
 255,
 680,
-696,
+696
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteReadChannel.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteReadChannel.kt": [
 112,
-120,
+120
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteWriteChannel.kt':[
-62,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteWriteChannel.kt": [
+62
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/Coroutines.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/Coroutines.kt": [
 48,
 62,
 88,
-102,
+102
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ReadSession.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ReadSession.kt": [
 38,
-68,
+68
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/WriterSession.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/WriterSession.kt": [
 34,
-42,
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/charsets/Encoding.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/charsets/Encoding.kt": [
 32,
-47,
+47
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/concurrent/Shared.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/concurrent/Shared.kt": [
 24,
 36,
-45,
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferCompatibility.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferCompatibility.kt": [
 34,
 46,
 53,
@@ -224,100 +224,100 @@
 109,
 121,
 129,
-148,
+148
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Packet.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Packet.kt": [
 15,
-26,
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt": [
 227,
 254,
-274,
+274
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/pool/Pool.kt':[
-151,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/pool/Pool.kt": [
+151
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/ByteReadChannelJs.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/ByteReadChannelJs.kt": [
 120,
-128,
+128
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/ByteWriteChannelJs.kt':[
-63,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/ByteWriteChannelJs.kt": [
+63
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/TextDecoders.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/TextDecoders.kt": [
 15,
-26,
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
 1610,
 1621,
 1762,
 1783,
-1824,
+1824
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteChannelSequentialJVM.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteChannelSequentialJVM.kt": [
 153,
-157,
+157
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt": [
 132,
 140,
 144,
-148,
+148
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteWriteChannel.kt':[
-100,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteWriteChannel.kt": [
+100
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/LookAheadSession.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/LookAheadSession.kt": [
 6,
-27,
+27
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/ByteBuffers.kt':[
-101,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/ByteBuffers.kt": [
+101
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/PacketJVM.kt':[
-28,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/PacketJVM.kt": [
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Channels.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Channels.kt": [
 119,
-145,
+145
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ByteReadChannelNative.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ByteReadChannelNative.kt": [
 169,
-177,
+177
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ByteWriteChannelNative.kt':[
-101,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ByteWriteChannelNative.kt": [
+101
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/pool/DefaultPool.kt':[
-13,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/pool/DefaultPool.kt": [
+13
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/util/Pools.kt':[
-36,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/util/Pools.kt": [
+36
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SelectUtils.kt':[
-208,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SelectUtils.kt": [
+208
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationRequest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationRequest.kt": [
 64,
-70,
+70
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/HttpServer.kt':[
-44,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/HttpServer.kt": [
+44
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/Pipeline.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/Pipeline.kt": [
 25,
 35,
-45,
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/HttpDateJvm.kt':[
-26,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/HttpDateJvm.kt": [
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt':[
-27,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt": [
+27
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt": [
 264,
 270,
 277,
@@ -329,145 +329,145 @@
 338,
 359,
 376,
-394,
+394
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationCallPipeline.kt':[
-68,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationCallPipeline.kt": [
+68
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationEvents.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationEvents.kt": [
 15,
 25,
-40,
+40
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationPlugin.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationPlugin.kt": [
 182,
 196,
 211,
 222,
-238,
+238
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/CreatePluginUtils.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/CreatePluginUtils.kt": [
 324,
 331,
-339,
+339
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/MergedApplicationConfig.kt':[
-12,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/MergedApplicationConfig.kt": [
+12
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/HttpDate.kt':[
-18,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/HttpDate.kt": [
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/plugins/OriginConnectionPoint.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/plugins/OriginConnectionPoint.kt": [
 28,
 49,
 56,
 89,
-101,
+101
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/request/ApplicationReceiveFunctions.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/request/ApplicationReceiveFunctions.kt": [
 61,
 134,
-154,
+154
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseCookies.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseCookies.kt": [
 40,
-96,
+96
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/Route.kt':[
-37,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/Route.kt": [
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RouteSelector.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RouteSelector.kt": [
 47,
 182,
 182,
 312,
 360,
 395,
-442,
+442
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingBuilder.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingBuilder.kt": [
 89,
 372,
-391,
+391
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingResolveResult.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingResolveResult.kt": [
 30,
-46,
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ReceiveBlockingPrimitiveTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ReceiveBlockingPrimitiveTest.kt": [
 80,
-87,
+87
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyConnectionPoint.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyConnectionPoint.kt": [
 31,
-37,
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/Http2LocalConnectionPoint.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/Http2LocalConnectionPoint.kt": [
 28,
-32,
+32
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth.kt": [
 72,
 86,
 116,
-136,
+136
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth1a.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth1a.kt": [
 206,
 242,
 278,
 307,
-355,
+355
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationContext.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationContext.kt": [
 29,
-41,
+41
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationFailedCause.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationFailedCause.kt": [
 28,
-34,
+34
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuthCommon.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuthCommon.kt": [
 90,
 121,
 239,
 250,
 261,
-278,
+278
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/nix/src/OAuthNative.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/nix/src/OAuthNative.kt": [
 29,
 40,
 51,
-68,
+68
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Config.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Config.kt": [
 107,
-148,
+148
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-conditional-headers/jvmAndNix/src/io/ktor/server/plugins/conditionalheaders/ConditionalHeaders.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-conditional-headers/jvmAndNix/src/io/ktor/server/plugins/conditionalheaders/ConditionalHeaders.kt": [
 128,
-148,
+148
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt':[
-36,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt": [
+36
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/src/io/ktor/server/html/RespondHtml.kt':[
-34,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/src/io/ktor/server/html/RespondHtml.kt": [
+34
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/Location.kt':[
-256,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/Location.kt": [
+256
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/src/io/ktor/server/plugins/openapi/OpenAPI.kt':[
-64,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/src/io/ktor/server/plugins/openapi/OpenAPI.kt": [
+64
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt": [
 29,
 41,
 62,
-67,
+67
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionsBuilder.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionsBuilder.kt": [
 14,
 70,
 87,
@@ -479,112 +479,112 @@
 301,
 332,
 375,
-412,
+412
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt": [
 114,
-126,
+126
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/Routing.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/Routing.kt": [
 132,
-175,
+175
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletConnectionPoint.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletConnectionPoint.kt": [
 27,
-31,
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/WebResources.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/WebResources.kt": [
+27
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletConnectionPoint.kt": [
 27,
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletConnectionPoint.kt':[
-27,
-31,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/WebResources.kt": [
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/WebResources.kt':[
-26,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestEngineWebsocketSession.kt": [
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestEngineWebsocketSession.kt':[
-46,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt": [
+101
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt':[
-101,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationCall.kt": [
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationCall.kt':[
-31,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationRequest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationRequest.kt": [
 52,
-58,
+58
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestEngine.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestEngine.kt": [
 48,
 66,
 74,
-85,
+85
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/common/src/ContentConverter.kt':[
-45,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/common/src/ContentConverter.kt": [
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/src/GsonConverter.kt':[
-35,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/src/GsonConverter.kt": [
+35
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt": [
 40,
 48,
-170,
+170
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/KotlinxSerializationConverter.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/KotlinxSerializationConverter.kt": [
+42
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/CloseReason.kt": [
 42,
+63
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/CloseReason.kt':[
-42,
-63,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt": [
+153
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt':[
-153,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt": [
+138
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt':[
-138,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketSession.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketSession.kt": [
 76,
-130,
+130
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/RawWebSocketJvm.kt':[
-95,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/RawWebSocketJvm.kt": [
+95
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketWriter.kt':[
-169,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketWriter.kt": [
+169
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Annotations.kt':[
-49,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Annotations.kt": [
+49
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Attributes.kt':[
-47,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Attributes.kt": [
+47
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/NonceManager.kt':[
-47,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/NonceManager.kt": [
+47
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Ranges.kt':[
-11,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Ranges.kt": [
+11
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/collections/CollectionUtils.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/collections/CollectionUtils.kt": [
 8,
 11,
-14,
+14
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/ByteBufferPool.kt':[
-27,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/ByteBufferPool.kt": [
+27
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/OutputStreamAdapters.kt':[
-20,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/OutputStreamAdapters.kt": [
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/Semaphore.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/Semaphore.kt": [
 15,
 24,
-38,
+38
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/reflect/TypeInfoJvm.kt':[
-13,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/reflect/TypeInfoJvm.kt": [
+13
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1135.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1135.json
@@ -1,127 +1,127 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/RangesSpecifier.kt':[
-42,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/RangesSpecifier.kt": [
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/URIFileContent.kt':[
-27,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/URIFileContent.kt": [
+27
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpHeadersMap.kt':[
-56,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpHeadersMap.kt": [
+56
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt':[
-74,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt": [
+74
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt':[
-264,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt": [
+264
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteChannelCtor.kt':[
-61,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteChannelCtor.kt": [
+61
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/bits/MemoryFactory.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/bits/MemoryFactory.kt": [
 7,
-15,
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Output.kt':[
-153,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Output.kt": [
+153
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/UTF8.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/UTF8.kt": [
 142,
-312,
+312
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/internal/AwaitingSlot.kt':[
-15,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/internal/AwaitingSlot.kt": [
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReverseByteOrderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReverseByteOrderTest.kt": [
 65,
-72,
+72
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/PrimitiveArraysJs.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/PrimitiveArraysJs.kt": [
 25,
-219,
+219
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/VerifyingObjectPool.kt':[
-9,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/VerifyingObjectPool.kt": [
+9
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
 82,
-1218,
+1218
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt':[
-322,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt": [
+322
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Channels.kt':[
-121,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Channels.kt": [
+121
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/pool/DefaultPool.kt':[
-110,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/pool/DefaultPool.kt": [
+110
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/SelectorManagerSupport.kt':[
-43,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/SelectorManagerSupport.kt": [
+43
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/NIOSocketImpl.kt':[
-143,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/NIOSocketImpl.kt": [
+143
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt": [
 195,
-254,
+254
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/GCMCipher.kt':[
-104,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/GCMCipher.kt": [
+104
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/TLSCommon.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/TLSCommon.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt':[
-102,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt": [
+102
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/LocalFileContent.kt':[
-36,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/LocalFileContent.kt": [
+36
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/PluginBuilder.kt':[
-138,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/PluginBuilder.kt": [
+138
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/OverridingClassLoader.kt':[
-58,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/OverridingClassLoader.kt": [
+58
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt": [
 82,
-180,
+180
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt':[
-75,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt": [
+75
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt':[
-75,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt": [
+75
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt':[
-154,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt": [
+154
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth1a.kt':[
-143,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth1a.kt": [
+143
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt':[
-296,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt": [
+296
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/SimpleAuth.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/SimpleAuth.kt": [
+41
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt": [
+77
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/BaseTestJvm.kt": [
+19
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/BaseTest.kt": [
+12
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/AutoSerializerTest.kt": [
+47
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-events/common/src/io/ktor/events/Events.kt": [
+81
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/AttributesJvm.kt": [
 41,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt':[
-77,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/BaseTestJvm.kt':[
-19,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/BaseTest.kt':[
-12,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/AutoSerializerTest.kt':[
-47,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-events/common/src/io/ktor/events/Events.kt':[
-81,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/AttributesJvm.kt':[
-41,
-58,
-],
+58
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1143.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1143.json
@@ -1,17 +1,17 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt':[
-115,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt": [
+115
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt':[
-85,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt": [
+85
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/PacketDirect.kt':[
-19,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/PacketDirect.kt": [
+19
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt':[
-103,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt": [
+103
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/collections/LockFreeMPSCQueueNative.kt':[
-39,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/collections/LockFreeMPSCQueueNative.kt": [
+39
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1144.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1144.json
@@ -1,17 +1,17 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Input.kt':[
-545,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Input.kt": [
+545
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadUntilDelimiterTest.kt':[
-295,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadUntilDelimiterTest.kt": [
+295
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
-1892,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
+1892
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/PartialContentTest.kt':[
-177,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/PartialContentTest.kt": [
+177
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/sessions/SessionTest.kt':[
-704,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/sessions/SessionTest.kt": [
+704
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1151.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1151.json
@@ -1,54 +1,54 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt':[
-91,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt": [
+91
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Codecs.kt':[
-215,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Codecs.kt": [
+215
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt':[
-487,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt": [
+487
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/UTF8.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/UTF8.kt": [
 136,
-160,
+160
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt": [
 174,
 260,
 348,
 374,
 460,
-485,
+485
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt": [
 245,
-247,
+247
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultTransform.kt':[
-43,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultTransform.kt": [
+43
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/ServerInitializer.kt':[
-44,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/ServerInitializer.kt": [
+44
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt':[
-44,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt": [
+44
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt':[
-123,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt": [
+123
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestAuth.kt':[
-65,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestAuth.kt": [
+65
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth.kt':[
-162,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth.kt": [
+162
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt": [
 202,
 223,
 242,
-244,
+244
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt':[
-179,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt": [
+179
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S117.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S117.json
@@ -1,70 +1,70 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/CommonConfig.kt':[
-8,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/CommonConfig.kt": [
+8
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/JvmConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/JvmConfig.kt": [
 18,
 19,
 20,
-21,
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Train.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Train.kt": [
 9,
 50,
 55,
 56,
 57,
-60,
+60
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpCallValidator.kt':[
-138,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpCallValidator.kt": [
+138
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt':[
-137,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt": [
+137
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt": [
 66,
 71,
-72,
+72
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CodecTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CodecTest.kt": [
 71,
-72,
+72
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/ByteChannelNativeConcurrentTest.kt':[
-38,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/ByteChannelNativeConcurrentTest.kt": [
+38
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Hashes.kt':[
-19,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Hashes.kt": [
+19
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/util/Paths.kt':[
-98,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/util/Paths.kt": [
+98
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/ApplicationPluginTest.kt':[
-291,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/ApplicationPluginTest.kt": [
+291
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/HooksTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/HooksTest.kt": [
 131,
-148,
+148
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-id/jvmAndNix/src/io/ktor/server/plugins/callid/CallId.kt':[
-160,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-id/jvmAndNix/src/io/ktor/server/plugins/callid/CallId.kt": [
+160
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt':[
-233,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt": [
+233
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-default-headers/jvm/src/io/ktor/server/plugins/defaultheaders/DefaultHeaders.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-default-headers/jvm/src/io/ktor/server/plugins/defaultheaders/DefaultHeaders.kt": [
 72,
-73,
+73
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt':[
-416,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt": [
+416
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityToolsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityToolsTest.kt": [
 84,
-85,
+85
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationTest.kt':[
-134,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationTest.kt": [
+134
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1172.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1172.json
@@ -1,153 +1,153 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/nix/src/io/ktor/client/engine/cio/ExceptionUtilsNative.kt':[
-9,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/nix/src/io/ktor/client/engine/cio/ExceptionUtilsNative.kt": [
+9
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/network.sockets/TimeoutExceptionsJs.kt':[
-31,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/network.sockets/TimeoutExceptionsJs.kt": [
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/DefaultTransformJs.kt':[
-13,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/DefaultTransformJs.kt": [
+13
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/utils/CoroutineUtilsJs.kt':[
-15,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/utils/CoroutineUtilsJs.kt": [
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/CoroutineDispatcherUtils.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/CoroutineDispatcherUtils.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/network.sockets/TimeoutExceptionsNative.kt':[
-31,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/network.sockets/TimeoutExceptionsNative.kt": [
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/plugins/DefaultTransformIos.kt':[
-13,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/plugins/DefaultTransformIos.kt": [
+13
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt": [
 102,
-115,
+115
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/CloseableJS.kt':[
-8,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/CloseableJS.kt": [
+8
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt':[
-143,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt": [
+143
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt": [
 199,
-280,
+280
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/CloseableNative.kt':[
-8,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/CloseableNative.kt": [
+8
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ios/src/io/ktor/network/util/SocketUtilsIos.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ios/src/io/ktor/network/util/SocketUtilsIos.kt": [
 11,
-18,
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSClientSessionNative.kt':[
-12,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSClientSessionNative.kt": [
+12
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSConfigBuilderNative.kt':[
-26,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSConfigBuilderNative.kt": [
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SelectorManager.kt':[
-12,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SelectorManager.kt": [
+12
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/tvos/src/io/ktor/network/util/SocketUtilsTvos.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/tvos/src/io/ktor/network/util/SocketUtilsTvos.kt": [
 11,
-18,
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/watchos/src/io/ktor/network/util/SocketUtilsWatchos.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/watchos/src/io/ktor/network/util/SocketUtilsWatchos.kt": [
 11,
-18,
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/DefaultTransformJvm.kt':[
-17,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/DefaultTransformJvm.kt": [
+17
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/util/Parameters.kt':[
-30,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/util/Parameters.kt": [
+30
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/nix/src/io/ktor/server/http/content/NixDefaultTransform.kt':[
-12,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/nix/src/io/ktor/server/http/content/NixDefaultTransform.kt": [
+12
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/DefaultTransformNix.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/DefaultTransformNix.kt": [
 16,
-19,
+19
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/EnvironmentUtilsNix.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/EnvironmentUtilsNix.kt": [
 12,
-22,
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/internal/ApplicationUtilsNix.kt':[
-20,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/internal/ApplicationUtilsNix.kt": [
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/nix/src/OAuthNative.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/nix/src/OAuthNative.kt": [
 17,
 41,
 52,
-69,
+69
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/nix/src/io/ktor/server/plugins/partialcontent/MultipleRangeWriterNix.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/nix/src/io/ktor/server/plugins/partialcontent/MultipleRangeWriterNix.kt": [
 11,
-19,
+19
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/nix/src/io/ktor/server/sessions/CacheStorageNix.kt':[
-7,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/nix/src/io/ktor/server/sessions/CacheStorageNix.kt": [
+7
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/TestEngineNix.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/TestEngineNix.kt": [
+9
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/js/src/io/ktor/serialization/kotlinx/json/JsonExtensionsJs.kt": [
+12
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/posix/src/io/ktor/serialization/kotlinx/json/JsonExtensionsNative.kt": [
+24
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/darwin/src/TestDarwin.kt": [
+19
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/linuxX64/src/TestLinuxX64.kt": [
+11
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/mingwX64/src/TestMingwX64.kt": [
+11
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/AttributesJs.kt": [
+11
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/StackFramesJs.kt": [
+20
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/converters/ConversionServiceJs.kt": [
 9,
+10
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/js/src/io/ktor/serialization/kotlinx/json/JsonExtensionsJs.kt':[
-12,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/internal/ExceptionUtilsJs.kt": [
+10
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/posix/src/io/ktor/serialization/kotlinx/json/JsonExtensionsNative.kt':[
-24,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/logging/KtorSimpleLoggerJs.kt": [
+8
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/darwin/src/TestDarwin.kt':[
-19,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/pipeline/StackTraceRecoverJs.kt": [
+7
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/linuxX64/src/TestLinuxX64.kt':[
-11,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/mingwX64/src/io/ktor/util/ThreadInfoMingw.kt": [
+9
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/mingwX64/src/TestMingwX64.kt':[
-11,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/AttributesNative.kt": [
+14
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/AttributesJs.kt':[
-11,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/CryptoNative.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/StackFramesJs.kt':[
-20,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/StackFramesNative.kt": [
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/converters/ConversionServiceJs.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/converters/ConversionServiceNative.kt": [
 9,
-10,
+10
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/internal/ExceptionUtilsJs.kt':[
-10,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/internal/ExceptionUtilsPosix.kt": [
+10
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/logging/KtorSimpleLoggerJs.kt':[
-8,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/pipeline/StackTraceRecoverJs.kt':[
-7,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/mingwX64/src/io/ktor/util/ThreadInfoMingw.kt':[
-9,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/AttributesNative.kt':[
-14,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/CryptoNative.kt':[
-21,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/StackFramesNative.kt':[
-20,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/converters/ConversionServiceNative.kt':[
-9,
-10,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/internal/ExceptionUtilsPosix.kt':[
-10,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/pipeline/StackTraceRecoverNative.kt':[
-7,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/pipeline/StackTraceRecoverNative.kt": [
+7
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1186.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1186.json
@@ -1,319 +1,319 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt": [
 28,
 29,
-30,
+30
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt": [
 69,
-72,
+72
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheResponseConsumer.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheResponseConsumer.kt": [
 93,
-98,
+98
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/NoOpControl.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/NoOpControl.kt": [
 10,
 13,
 16,
 19,
-22,
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/RequestProducerTest.kt':[
-261,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/RequestProducerTest.kt": [
+261
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheHttpRequest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheHttpRequest.kt": [
 30,
 31,
-32,
+32
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt": [
 59,
-154,
+154
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/LoaderJvm.kt':[
-7,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/LoaderJvm.kt": [
+7
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/DisabledCacheStorage.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/DisabledCacheStorage.kt": [
 12,
-20,
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/AcceptAllCookiesStorage.kt':[
-44,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/AcceptAllCookiesStorage.kt": [
+44
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/ConstantCookiesStorage.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/ConstantCookiesStorage.kt": [
 17,
-19,
+19
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/TestEngine.kt':[
-25,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/TestEngine.kt": [
+25
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/DefaultTransformJs.kt':[
-18,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/DefaultTransformJs.kt": [
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt':[
-140,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt": [
+140
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/plugins/DefaultTransformIos.kt':[
-18,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/plugins/DefaultTransformIos.kt": [
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt':[
-132,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt": [
+132
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequestBodyPublisher.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequestBodyPublisher.kt": [
 162,
-163,
+163
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt':[
-198,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt": [
+198
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestProducerTest.kt':[
-74,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestProducerTest.kt": [
+74
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt':[
-140,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt": [
+140
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logger.kt':[
-34,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logger.kt": [
+34
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/jvm/test/TracingWrapperTest.kt':[
-279,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/jvm/test/TracingWrapperTest.kt": [
+279
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/SslOverProxyTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/SslOverProxyTest.kt": [
 27,
-28,
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferCompatibility.kt':[
-66,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferCompatibility.kt": [
+66
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BytePacketBuilder.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BytePacketBuilder.kt": [
 55,
-61,
+61
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/ByteReadPacket.kt':[
-37,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/ByteReadPacket.kt": [
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/ChunkBuffer.kt':[
-157,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/ChunkBuffer.kt": [
+157
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/pool/Pool.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/pool/Pool.kt": [
 43,
-46,
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/OutputTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/OutputTest.kt": [
 14,
-35,
+35
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/PeekCharTest.kt':[
-158,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/PeekCharTest.kt": [
+158
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/VerifyingChunkBufferPool.kt':[
-31,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/VerifyingChunkBufferPool.kt": [
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/MemoryFactoryJs.kt':[
-55,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/MemoryFactoryJs.kt": [
+55
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/CloseableJS.kt':[
-8,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/CloseableJS.kt": [
+8
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/pool/DefaultPool.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/pool/DefaultPool.kt": [
 10,
-13,
+13
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryFactoryJvm.kt':[
-45,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryFactoryJvm.kt": [
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/pool/DefaultPool.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/pool/DefaultPool.kt": [
 32,
-35,
+35
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/streams/Streams.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/streams/Streams.kt": [
 134,
 148,
-151,
+151
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/CloseableNative.kt':[
-8,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/CloseableNative.kt": [
+8
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/pool/DefaultPool.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/pool/DefaultPool.kt": [
 19,
-22,
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSConfigBuilderNative.kt':[
-26,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSConfigBuilderNative.kt": [
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/jvmAndNix/src/Stub.kt':[
-6,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/jvmAndNix/src/Stub.kt": [
+6
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOEngineTestJvm.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOEngineTestJvm.kt": [
 32,
-36,
+36
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/nix/src/io/ktor/server/cio/internal/WeakTimeoutQueueNix.kt':[
-22,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/nix/src/io/ktor/server/cio/internal/WeakTimeoutQueueNix.kt": [
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ApplicationEngineEnvironmentReloadingTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ApplicationEngineEnvironmentReloadingTests.kt": [
 396,
-406,
+406
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/EnvironmentUtilsNix.kt':[
-22,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/EnvironmentUtilsNix.kt": [
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyAsyncServletContainerTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyAsyncServletContainerTest.kt": [
 31,
-35,
+35
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyBlockingServletContainerTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyBlockingServletContainerTest.kt": [
 32,
 36,
-40,
+40
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyEngineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyEngineTest.kt": [
 80,
-84,
+84
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyEngineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyEngineTest.kt": [
 27,
-31,
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletAsyncTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletAsyncTest.kt": [
 31,
-35,
+35
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletBlockingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletBlockingTest.kt": [
 32,
 36,
-40,
+40
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyAsyncServletContainerTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyAsyncServletContainerTest.kt": [
 31,
-35,
+35
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyBlockingServletContainerTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyBlockingServletContainerTest.kt": [
 32,
 36,
-40,
+40
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyEngineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyEngineTest.kt": [
 80,
-84,
+84
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyEngineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyEngineTest.kt": [
 27,
-31,
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletAsyncTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletAsyncTest.kt": [
 31,
-35,
+35
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletBlockingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletBlockingTest.kt": [
 32,
 36,
-40,
+40
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequest.kt':[
-47,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequest.kt": [
+47
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/ByteArrayCache.kt':[
-50,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/ByteArrayCache.kt": [
+50
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/DirectoryStorage.kt':[
-24,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/DirectoryStorage.kt": [
+24
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/DirectorySessionStorageTest.kt':[
-24,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/DirectorySessionStorageTest.kt": [
+24
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTransportHeader.kt':[
-34,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTransportHeader.kt": [
+34
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBaseJvm.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBaseJvm.kt": [
 350,
-351,
+351
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestEngineWebsocketSession.kt':[
-30,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestEngineWebsocketSession.kt": [
+30
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationResponse.kt':[
-65,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationResponse.kt": [
+65
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/src/Stub.kt':[
-6,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/src/Stub.kt": [
+6
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatEngineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatEngineTest.kt": [
 48,
 52,
 136,
-140,
+140
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatWebSocketTest.kt':[
-15,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatWebSocketTest.kt": [
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt": [
 48,
 52,
 136,
-140,
+140
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ClientGsonTest.kt':[
-25,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ClientGsonTest.kt": [
+25
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/GsonContentNegotiationTest.kt':[
-11,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/GsonContentNegotiationTest.kt": [
+11
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ClientJacksonTest.kt':[
-109,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ClientJacksonTest.kt": [
+109
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/common/test/CborSerializationTest.kt':[
-23,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/common/test/CborSerializationTest.kt": [
+23
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/jvm/test/CborClientKotlinxSerializationTest.kt':[
-46,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/jvm/test/CborClientKotlinxSerializationTest.kt": [
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/jvm/test/CborServerKotlinxSerializationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/jvm/test/CborServerKotlinxSerializationTest.kt": [
 36,
 40,
 44,
-48,
+48
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/JsonServerKotlinxSerializationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/JsonServerKotlinxSerializationTest.kt": [
 35,
-39,
+39
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/jvm/test/ProtoBufClientKotlinxSerializationTest.kt':[
-42,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/jvm/test/ProtoBufClientKotlinxSerializationTest.kt": [
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/jvm/test/ProtoBufServerKotlinxSerializationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/jvm/test/ProtoBufServerKotlinxSerializationTest.kt": [
 31,
 35,
 39,
-43,
+43
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/jvm/test/XmlClientKotlinxSerializationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/jvm/test/XmlClientKotlinxSerializationTest.kt": [
 25,
 30,
 35,
-40,
+40
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/jvm/test/XmlServerKotlinxSerializationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/jvm/test/XmlServerKotlinxSerializationTest.kt": [
 33,
 37,
 41,
-45,
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/FrameCommon.kt':[
-170,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/FrameCommon.kt": [
+170
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/StringValues.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/StringValues.kt": [
 281,
-284,
+284
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/Pipeline.kt':[
-168,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/Pipeline.kt": [
+168
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/internal/ExceptionUtilsJs.kt':[
-10,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/internal/ExceptionUtilsJs.kt": [
+10
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/internal/ExceptionUtilsPosix.kt':[
-10,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/internal/ExceptionUtilsPosix.kt": [
+10
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1192.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1192.json
@@ -1,114 +1,114 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Auth.kt':[
-36,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Auth.kt": [
+36
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Cookies.kt':[
-17,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Cookies.kt": [
+17
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt':[
-52,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt": [
+52
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/Compatibility.kt':[
-17,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/Compatibility.kt": [
+17
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/CacheExpiresTest.kt':[
-124,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/CacheExpiresTest.kt": [
+124
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/ClientPluginsTest.kt':[
-50,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/ClientPluginsTest.kt": [
+50
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/CookiesTest.kt':[
-19,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/CookiesTest.kt": [
+19
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/DefaultRequestTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/DefaultRequestTest.kt": [
 34,
 35,
 151,
-152,
+152
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/MultiPartFormDataContentTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/MultiPartFormDataContentTest.kt": [
 46,
 47,
 50,
 117,
-139,
+139
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/ProxyConfigJs.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/ProxyConfigJs.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/CachingCacheStorageTest.kt':[
-16,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/CachingCacheStorageTest.kt": [
+16
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/ExceptionsTest.kt':[
-46,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/ExceptionsTest.kt": [
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/WebSocketTest.kt':[
-23,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/WebSocketTest.kt": [
+23
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt':[
-29,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt": [
+29
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/JavaEngineTests.kt':[
-39,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/JavaEngineTests.kt": [
+39
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt": [
 27,
-30,
+30
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt": [
 63,
-129,
+129
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/IgnoreTypesTest.kt':[
-26,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/IgnoreTypesTest.kt": [
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/AbstractClientContentNegotiationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/AbstractClientContentNegotiationTest.kt": [
 97,
-104,
+104
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/JsonContentNegotiationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/JsonContentNegotiationTest.kt": [
 47,
 47,
-103,
+103
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt':[
-31,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt": [
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/test/JsonPluginTest.kt':[
-22,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/test/JsonPluginTest.kt": [
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-json-tests/jvm/src/io/ktor/client/plugins/json/tests/JsonTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-json-tests/jvm/src/io/ktor/client/plugins/json/tests/JsonTest.kt": [
 60,
-63,
+63
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-resources/common/test/ResourcesTest.kt':[
-50,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-resources/common/test/ResourcesTest.kt": [
+50
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CallValidatorTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CallValidatorTest.kt": [
 185,
 186,
 244,
-375,
+375
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CharsetTest.kt':[
-44,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CharsetTest.kt": [
+44
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTypeTest.kt':[
-33,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTypeTest.kt": [
+33
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/FullFormTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/FullFormTest.kt": [
 21,
 23,
-28,
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRequestRetryTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRequestRetryTest.kt": [
 73,
-239,
+239
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt':[
-447,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt": [
+447
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingMockedTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingMockedTests.kt": [
 24,
 25,
 26,
@@ -119,9 +119,9 @@
 31,
 33,
 57,
-79,
+79
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTest.kt": [
 51,
 53,
 54,
@@ -145,84 +145,84 @@
 255,
 261,
 269,
-322,
+322
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CookiesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CookiesTest.kt": [
 127,
-158,
+158
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/SerializationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/SerializationTest.kt": [
 21,
-47,
+47
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/CookiesAndRedirectMockedTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/CookiesAndRedirectMockedTest.kt": [
 33,
 50,
-58,
+58
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/DefaultTransformJvmTest.kt':[
-36,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/DefaultTransformJvmTest.kt": [
+36
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/HttpRedirectMockedTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/HttpRedirectMockedTest.kt": [
 25,
 27,
 59,
 94,
-141,
+141
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Cookie.kt':[
-65,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Cookie.kt": [
+65
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt": [
 13,
-30,
+30
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/ContentTypeMatchTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/ContentTypeMatchTest.kt": [
 13,
 35,
-37,
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CookieDateParserTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CookieDateParserTest.kt": [
 50,
-54,
+54
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/QueryParametersTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/QueryParametersTest.kt": [
 20,
-37,
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt": [
 102,
 186,
 227,
 282,
 284,
 450,
-491,
+491
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlDecodedParametersBuilderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlDecodedParametersBuilderTest.kt": [
 29,
 30,
 30,
 54,
 55,
-65,
+65
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt':[
-35,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt": [
+35
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/test/io/ktor/tests/http/URLBuilderTest.kt':[
-68,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/test/io/ktor/tests/http/URLBuilderTest.kt": [
+68
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ConnectionOptions.kt':[
-39,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ConnectionOptions.kt": [
+39
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HeaderParserTest.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HeaderParserTest.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt':[
-511,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt": [
+511
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt": [
 65,
 68,
 71,
@@ -237,177 +237,177 @@
 345,
 346,
 347,
-348,
+348
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/concurrent/Shared.kt':[
-24,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/concurrent/Shared.kt": [
+24
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferCompatibility.kt':[
-102,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferCompatibility.kt": [
+102
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferPrimitives.kt':[
-533,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferPrimitives.kt": [
+533
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteBufferChannelScenarioTest.kt':[
-142,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteBufferChannelScenarioTest.kt": [
+142
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSessionsTest.kt':[
-50,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSessionsTest.kt": [
+50
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketReadTest.kt':[
-26,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketReadTest.kt": [
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketStringTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketStringTest.kt": [
 101,
 114,
-341,
+341
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadTextCommonTest.kt':[
-132,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadTextCommonTest.kt": [
+132
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadUntilDelimiterTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadUntilDelimiterTest.kt": [
 27,
 67,
-69,
+69
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/StringsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/StringsTest.kt": [
 17,
-47,
+47
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt": [
 34,
-34,
+34
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/ChunkBufferNativeTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/ChunkBufferNativeTest.kt": [
 121,
-122,
+122
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/TextDecoderFallbackTest.kt':[
-18,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/TextDecoderFallbackTest.kt": [
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
-627,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
+627
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteChannelSequentialJVM.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteChannelSequentialJVM.kt": [
 64,
-117,
+117
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/BytePacketReaderWriterTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/BytePacketReaderWriterTest.kt": [
 57,
 67,
-121,
+121
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt": [
 17,
-18,
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketOptionsPlatformCapabilities.kt':[
-31,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketOptionsPlatformCapabilities.kt": [
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt':[
-195,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt": [
+195
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/CipherSuites.kt':[
-91,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/CipherSuites.kt": [
+91
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt':[
-56,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt": [
+56
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/CertificatesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/CertificatesTest.kt": [
 35,
 149,
-165,
+165
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt':[
-76,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt": [
+76
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ServerPipelineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ServerPipelineTest.kt": [
 56,
-75,
+75
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/jvmAndNix/test/YamlConfigTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/jvmAndNix/test/YamlConfigTest.kt": [
 41,
-118,
+118
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/ApplicationPluginTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/ApplicationPluginTest.kt": [
 29,
 153,
 204,
 215,
 246,
 254,
-261,
+261
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/RouteScopedPluginTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/RouteScopedPluginTest.kt": [
 39,
 83,
 100,
 102,
-134,
+134
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/config/MapApplicationConfigTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/config/MapApplicationConfigTest.kt": [
 14,
 14,
 15,
 23,
 103,
-103,
+103
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/routing/RegexRoutingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/routing/RegexRoutingTest.kt": [
 81,
 86,
 92,
 93,
-94,
+94
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ApplicationEngineEnvironmentReloadingTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ApplicationEngineEnvironmentReloadingTests.kt": [
 34,
 35,
-299,
+299
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/BuildApplicationConfigJvmTest.kt':[
-13,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/BuildApplicationConfigJvmTest.kt": [
+13
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt':[
-65,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt": [
+65
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ReceiveBlockingPrimitiveTest.kt':[
-68,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ReceiveBlockingPrimitiveTest.kt": [
+68
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/test/BuildApplicationConfigNixTest.kt':[
-13,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/test/BuildApplicationConfigNixTest.kt": [
+13
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp2ApplicationResponseTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp2ApplicationResponseTest.kt": [
 19,
-30,
+30
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTAuthTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTAuthTest.kt": [
 54,
-273,
+273
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LdapAuthTest.kt':[
-76,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LdapAuthTest.kt": [
+76
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/AuthWithPlugins.kt':[
-27,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/AuthWithPlugins.kt": [
+27
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt": [
 30,
 77,
-117,
+117
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt": [
 32,
 113,
-198,
+198
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2JvmTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2JvmTest.kt": [
 99,
 115,
 163,
-232,
+232
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthBuildersTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthBuildersTest.kt": [
 80,
 82,
 87,
@@ -422,13 +422,13 @@
 758,
 860,
 925,
-1028,
+1028
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BasicAuthTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BasicAuthTest.kt": [
 45,
-53,
+53
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt": [
 37,
 38,
 109,
@@ -442,147 +442,147 @@
 363,
 373,
 377,
-381,
+381
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/nix/src/OAuthNative.kt':[
-34,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/nix/src/OAuthNative.kt": [
+34
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt": [
 103,
 117,
 210,
-220,
+220
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/ContentNegotiationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/ContentNegotiationTest.kt": [
 355,
 590,
-596,
+596
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/nix/src/io/ktor/server/plugins/doublereceive/FileCacheNix.kt':[
-17,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/nix/src/io/ktor/server/plugins/doublereceive/FileCacheNix.kt": [
+17
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-freemarker/jvm/test/io/ktor/tests/freemarker/FreeMarkerTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-freemarker/jvm/test/io/ktor/tests/freemarker/FreeMarkerTest.kt": [
 37,
 40,
 48,
-48,
+48
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/test/io/ktor/tests/jte/JteTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/test/io/ktor/tests/jte/JteTest.kt": [
 39,
 42,
 50,
-50,
+50
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt": [
 39,
 165,
 209,
 210,
 600,
-606,
+606
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt':[
-65,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt": [
+65
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvm/test/io/ktor/tests/ByteRangesChannelTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvm/test/io/ktor/tests/ByteRangesChannelTest.kt": [
 25,
-26,
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test/io/ktor/server/pebble/PebbleTest.kt':[
-191,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test/io/ktor/server/pebble/PebbleTest.kt": [
+191
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/test/io/ktor/server/plugins/requestvalidation/RequestValidationTest.kt':[
-112,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/test/io/ktor/server/plugins/requestvalidation/RequestValidationTest.kt": [
+112
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt": [
 45,
 141,
 142,
 179,
-180,
+180
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionsBuilder.kt':[
-303,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionsBuilder.kt": [
+303
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt": [
 41,
 52,
 313,
 314,
 316,
-319,
+319
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/test/io/ktor/server/thymeleaf/ThymeleafTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/test/io/ktor/server/thymeleaf/ThymeleafTest.kt": [
 37,
 48,
 48,
 144,
-167,
+167
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt": [
 37,
 40,
 46,
-46,
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityToolsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityToolsTest.kt": [
 31,
 34,
 45,
-46,
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/test/io/ktor/server/webjars/WebjarsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/test/io/ktor/server/webjars/WebjarsTest.kt": [
 56,
-56,
+56
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/test/TestApplicationTestJvm.kt':[
-32,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/test/TestApplicationTestJvm.kt": [
+32
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationTest.kt": [
 107,
-136,
+136
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt": [
 48,
 49,
 120,
-246,
+246
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ServerPluginsTestSuite.kt':[
-84,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ServerPluginsTestSuite.kt": [
+84
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt": [
 51,
 530,
 532,
 551,
-784,
+784
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/HttpServerCommonTestSuite.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/HttpServerCommonTestSuite.kt": [
 366,
 375,
 426,
-452,
+452
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt':[
-304,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt": [
+304
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/SinglePageApplicationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/SinglePageApplicationTest.kt": [
 21,
 23,
 29,
 106,
 126,
-152,
+152
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt": [
 84,
 229,
 235,
 236,
-521,
+521
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/StaticContentTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/StaticContentTest.kt": [
 42,
 44,
 122,
@@ -598,39 +598,39 @@
 518,
 519,
 627,
-884,
+884
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/SessionTestJvm.kt':[
-116,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/SessionTestJvm.kt": [
+116
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/testing/TestApplicationEngineTest.kt':[
-102,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/testing/TestApplicationEngineTest.kt": [
+102
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/ApplicationRequestHeaderTest.kt':[
-42,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/ApplicationRequestHeaderTest.kt": [
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/HandlerTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/HandlerTest.kt": [
 19,
-21,
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ServerURLBuilderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ServerURLBuilderTest.kt": [
 23,
-186,
+186
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt':[
-38,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt": [
+38
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/UrlEncodedTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/UrlEncodedTest.kt": [
 26,
-29,
+29
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/AutoHeadResponseTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/AutoHeadResponseTest.kt": [
 113,
 120,
 121,
-123,
+123
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CORSTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CORSTest.kt": [
 91,
 101,
 109,
@@ -643,20 +643,20 @@
 1052,
 1125,
 1126,
-1194,
+1194
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CallIdTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CallIdTest.kt": [
 53,
 148,
-155,
+155
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/ConditionalHeadersTests.kt':[
-42,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/ConditionalHeadersTests.kt": [
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/HSTSTest.kt':[
-39,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/HSTSTest.kt": [
+39
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/OriginConnectionPointTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/OriginConnectionPointTest.kt": [
 33,
 135,
 243,
@@ -665,25 +665,25 @@
 387,
 388,
 389,
-390,
+390
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/ParserServerSetCookieTest.kt':[
-20,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/ParserServerSetCookieTest.kt": [
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/PartialContentTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/PartialContentTest.kt": [
 93,
-120,
+120
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/RateLimitTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/RateLimitTest.kt": [
 139,
 142,
 476,
-477,
+477
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/XHttpMethodOverrideTest.kt':[
-166,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/XHttpMethodOverrideTest.kt": [
+166
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt": [
 26,
 117,
 203,
@@ -697,9 +697,9 @@
 477,
 482,
 517,
-544,
+544
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingResolveTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingResolveTest.kt": [
 51,
 87,
 88,
@@ -726,59 +726,59 @@
 1212,
 1221,
 1223,
-1226,
+1226
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingTracingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingTracingTest.kt": [
 48,
 78,
 108,
 138,
-200,
+200
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/sessions/SessionTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/sessions/SessionTest.kt": [
 40,
 88,
 94,
 109,
 296,
 322,
-324,
+324
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatEngineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatEngineTest.kt": [
 28,
 28,
-28,
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt": [
 28,
 28,
-28,
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/test/io/ktor/tests/resources/PathPatternSerializationTest.kt':[
-33,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/test/io/ktor/tests/resources/PathPatternSerializationTest.kt": [
+33
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt':[
-60,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt": [
+60
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-tests/jvm/src/AbstractServerSerializationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-tests/jvm/src/AbstractServerSerializationTest.kt": [
 54,
-152,
+152
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/test/WebSocketDeflateTest.kt':[
-45,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/test/WebSocketDeflateTest.kt": [
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/ChannelTest.kt':[
-69,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/ChannelTest.kt": [
+69
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/converters/DataConversionTest.kt':[
-65,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/converters/DataConversionTest.kt": [
+65
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/PipelineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/PipelineTest.kt": [
 38,
 38,
 81,
 165,
 165,
-250,
-],
+250
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1206.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1206.json
@@ -1,5 +1,5 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Parameters.kt':[
-114,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Parameters.kt": [
+114
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S122.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S122.json
@@ -1,13 +1,13 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngineConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngineConfig.kt": [
 67,
-75,
+75
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5EngineConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5EngineConfig.kt": [
 59,
-67,
+67
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/builders.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/builders.kt": [
 332,
 343,
 354,
@@ -21,91 +21,91 @@
 434,
 443,
 452,
-461,
+461
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Parameters.kt':[
-96,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Parameters.kt": [
+96
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/TakeWhileTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/TakeWhileTest.kt": [
 78,
 93,
-103,
+103
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryJvm.kt':[
-212,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryJvm.kt": [
+212
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Channels.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Channels.kt": [
+86
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationResponse.kt": [
+99
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt": [
+37
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTAuthTest.kt": [
 86,
+94
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationResponse.kt':[
-99,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-http-redirect/jvmAndNix/src/io/ktor/server/plugins/httpsredirect/HttpsRedirect.kt": [
+82
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt':[
-37,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTAuthTest.kt':[
-86,
-94,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-http-redirect/jvmAndNix/src/io/ktor/server/plugins/httpsredirect/HttpsRedirect.kt':[
-82,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/CacheJvm.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/CacheJvm.kt": [
 25,
 26,
-112,
+112
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt": [
 219,
-238,
+238
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/CacheTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/CacheTest.kt": [
 21,
-36,
+36
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/test/io/ktor/server/sessions/CacheTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/test/io/ktor/server/sessions/CacheTest.kt": [
 15,
 32,
 56,
-80,
+80
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt':[
-177,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt": [
+177
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt':[
-711,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt": [
+711
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/RespondFunctionsJvmTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/RespondFunctionsJvmTest.kt": [
 20,
-23,
+23
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/RespondFunctionsTest.kt':[
-28,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/RespondFunctionsTest.kt": [
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ServerURLBuilderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ServerURLBuilderTest.kt": [
 105,
 106,
 112,
-113,
+113
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CallIdTest.kt':[
-245,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CallIdTest.kt": [
+245
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/StringValues.kt':[
-289,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/StringValues.kt": [
+289
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/internal/LockFreeLinkedList.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/internal/LockFreeLinkedList.kt": [
 584,
-585,
+585
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/PipelineContractsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/PipelineContractsTest.kt": [
 23,
-24,
+24
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/CacheTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/CacheTest.kt": [
 18,
 31,
 50,
-71,
-],
+71
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S125.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S125.json
@@ -1,36 +1,36 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt':[
-66,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt": [
+66
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt':[
-120,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt": [
+120
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/test/io/ktor/client/engine/curl/test/CurlProxyTest.kt':[
-44,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/test/io/ktor/client/engine/curl/test/CurlProxyTest.kt": [
+44
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/StringsTest.kt':[
-172,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/StringsTest.kt": [
+172
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt':[
-326,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt": [
+326
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt':[
-134,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt": [
+134
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt": [
 375,
 450,
 476,
 512,
-553,
+553
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt':[
-45,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt": [
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt':[
-486,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt": [
+486
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt':[
-76,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt": [
+76
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S126.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S126.json
@@ -1,38 +1,38 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt':[
-430,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt": [
+430
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Input.kt':[
-368,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Input.kt": [
+368
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt": [
 65,
-108,
+108
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/Strings.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/Strings.kt": [
 54,
-96,
+96
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt':[
-94,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt": [
+94
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt':[
-27,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt": [
+27
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt':[
-151,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt": [
+151
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt':[
-454,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt": [
+454
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/SessionsBackwardCompatibleEncoder.kt':[
-58,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/SessionsBackwardCompatibleEncoder.kt": [
+58
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt':[
-125,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt": [
+125
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt": [
 97,
-103,
-],
+103
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1313.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1313.json
@@ -1,6 +1,6 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt": [
 63,
-68,
-],
+68
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S134.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S134.json
@@ -1,32 +1,32 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt':[
-107,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt": [
+107
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt':[
-72,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt": [
+72
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Codecs.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Codecs.kt": [
 224,
-232,
+232
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLParser.kt':[
-67,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLParser.kt": [
+67
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt": [
 641,
-642,
+642
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Input.kt':[
-854,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Input.kt": [
+854
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/UTF8.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/UTF8.kt": [
 143,
-166,
+166
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadUntilDelimiterTest.kt':[
-280,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadUntilDelimiterTest.kt": [
+280
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
 1193,
 1213,
 1217,
@@ -35,101 +35,101 @@
 1249,
 1254,
 1265,
-1807,
+1807
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/Delimited.kt':[
-133,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/Delimited.kt": [
+133
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt": [
 73,
-93,
+93
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt": [
 364,
 395,
 475,
-506,
+506
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/Utils.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/Utils.kt": [
 24,
-25,
+25
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt':[
-137,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt": [
+137
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt": [
 41,
 64,
 109,
-120,
+120
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt": [
 47,
 64,
 98,
 106,
-124,
+124
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketImpl.kt':[
-54,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketImpl.kt": [
+54
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt": [
 69,
 78,
 108,
-273,
+273
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/CipherUtils.kt':[
-34,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/CipherUtils.kt": [
+34
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt": [
 94,
 147,
-157,
+157
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt':[
-45,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt": [
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/src/io/ktor/server/auth/ldap/Ldap.kt':[
-103,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/src/io/ktor/server/auth/ldap/Ldap.kt": [
+103
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/CacheJvm.kt':[
-207,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/CacheJvm.kt": [
+207
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt':[
-335,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt": [
+335
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt": [
 438,
 460,
 493,
-544,
+544
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt':[
-391,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt": [
+391
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt':[
-497,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt": [
+497
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt':[
-183,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt": [
+183
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt':[
-80,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt": [
+80
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt':[
-62,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt": [
+62
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketReader.kt':[
-87,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketReader.kt": [
+87
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketWriter.kt':[
-48,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketWriter.kt": [
+48
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/Pipeline.kt':[
-198,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/Pipeline.kt": [
+198
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S138.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S138.json
@@ -1,39 +1,39 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Publication.kt':[
-56,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Publication.kt": [
+56
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/TargetsConfig.kt':[
-24,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/TargetsConfig.kt": [
+24
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Auth.kt':[
-17,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Auth.kt": [
+17
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketOptions.kt':[
-24,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketOptions.kt": [
+24
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt':[
-33,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt": [
+33
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/RouteScopedPluginTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/RouteScopedPluginTest.kt": [
 31,
-259,
+259
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLineJvm.kt':[
-20,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLineJvm.kt": [
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt':[
-429,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt": [
+429
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthBuildersTest.kt':[
-915,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthBuildersTest.kt": [
+915
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/ContentNegotiationTest.kt':[
-250,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/ContentNegotiationTest.kt": [
+250
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt':[
-40,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt": [
+40
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt':[
-415,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt": [
+415
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1451.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1451.json
@@ -1,5564 +1,5564 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Codestyle.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Codestyle.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/CommonConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/CommonConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Compilations.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Compilations.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/IdeUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/IdeUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/JsConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/JsConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/JvmConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/JvmConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/KotlinExtensions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/KotlinExtensions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/KtorBuildProperties.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/KtorBuildProperties.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/NativeUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/NativeUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Publication.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Publication.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/TargetsConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/TargetsConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Train.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Train.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/ClientTestServer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/ClientTestServer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/ServerUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/ServerUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/TestServer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/TestServer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/TestServerPlugin.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/TestServerPlugin.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/TestTcpServer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/TestTcpServer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Auth.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Auth.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Builders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Builders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Cache.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Cache.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/CloseableGroup.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/CloseableGroup.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Content.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Content.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Cookies.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Cookies.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Download.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Download.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Encoding.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Encoding.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Events.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Events.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Features.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Features.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Forms.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Forms.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Headers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Headers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Json.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Json.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Logging.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Logging.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/MultiPartFormData.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/MultiPartFormData.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Multithreaded.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Multithreaded.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Redirect.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Redirect.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Serialization.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Serialization.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Tcp.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Tcp.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Timeout.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Timeout.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Upload.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Upload.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/WebSockets.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/WebSockets.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/Android.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/Android.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidEngineConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidEngineConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidURLConnectionUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidURLConnectionUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/AndroidHttpsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/AndroidHttpsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/AndroidProxyTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/AndroidProxyTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/CommonTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/CommonTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/UrlConnectionUtilsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/UrlConnectionUtilsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/Apache.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/Apache.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngineConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngineConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheHttpRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheResponseConsumer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheResponseConsumer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/InterestControllerHolder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/InterestControllerHolder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ReactorLoopDispatcher.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ReactorLoopDispatcher.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/CommonTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/CommonTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/NoOpControl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/NoOpControl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/RequestProducerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/RequestProducerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/ResponseConsumerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/ResponseConsumerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5Engine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5Engine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5EngineConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5EngineConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheHttpRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheHttpRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheRequestProducer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheRequestProducer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/test/io/ktor/client/engine/apache5/CommonTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/test/io/ktor/client/engine/apache5/CommonTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngineContainer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/CIOEngineContainer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/Exceptions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/Exceptions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/LoaderJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/LoaderJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/plugins/websocket/cio/buildersCio.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/plugins/websocket/cio/buildersCio.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/BuildersTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/BuildersTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CommonTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CommonTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngineConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngineConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/ConnectionFactory.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/ConnectionFactory.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/ConnectionPipelineCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/ConnectionPipelineCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/EngineTasks.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/EngineTasks.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Loader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Loader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/test/CIOEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/test/CIOEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/nix/src/io/ktor/client/engine/cio/ConnectionPipelineNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/nix/src/io/ktor/client/engine/cio/ConnectionPipelineNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/nix/src/io/ktor/client/engine/cio/ExceptionUtilsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/nix/src/io/ktor/client/engine/cio/ExceptionUtilsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/nix/src/io/ktor/client/engine/cio/LoaderNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/nix/src/io/ktor/client/engine/cio/LoaderNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClientConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClientConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/Compatibility.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/Compatibility.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/HttpClientCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/HttpClientCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/SavedCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/SavedCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/call/utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/content/ObservableContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/content/ObservableContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineBase.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineBase.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineCapability.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineCapability.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngineConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/ProxyConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/ProxyConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/Utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/network.sockets/TimeoutExceptionsCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/network.sockets/TimeoutExceptionsCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/BodyProgress.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/BodyProgress.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DataConversion.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DataConversion.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultResponseValidation.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultResponseValidation.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpCallValidator.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpCallValidator.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpClientPlugin.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpClientPlugin.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpPlainText.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpPlainText.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRedirect.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRedirect.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRequestLifecycle.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRequestLifecycle.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRequestRetry.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRequestRetry.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpSend.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpSend.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpTimeout.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpTimeout.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/UserAgent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/UserAgent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/ClientHook.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/ClientHook.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/ClientPluginBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/ClientPluginBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/ClientPluginInstance.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/ClientPluginInstance.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/CommonHooks.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/CommonHooks.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/CreatePluginUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/CreatePluginUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/KtorCallContexts.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/KtorCallContexts.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheLegacy.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheLegacy.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/DisabledCacheStorage.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/DisabledCacheStorage.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/HttpCacheStorage.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/storage/UnlimitedCacheStorage.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/AcceptAllCookiesStorage.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/AcceptAllCookiesStorage.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/ConstantCookiesStorage.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/ConstantCookiesStorage.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/CookiesStorage.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/CookiesStorage.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/HttpCookies.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/HttpCookies.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/observer/DelegatedCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/observer/DelegatedCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/observer/ResponseObserver.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/observer/ResponseObserver.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/ClientSessions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/ClientSessions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSocketContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSocketContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/WebSockets.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/builders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/websocket/builders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/ClientUpgradeContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/ClientUpgradeContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/DefaultHttpRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/DefaultHttpRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequestPipeline.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequestPipeline.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/RequestBody.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/RequestBody.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/builders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/builders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/buildersWithUrl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/buildersWithUrl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/FormDataContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/FormDataContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formBuilders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formBuilders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/Compatibility.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/Compatibility.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/DefaultHttpResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/DefaultHttpResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponsePipeline.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponsePipeline.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpStatement.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/Readers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/Readers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/ByteChannelUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/ByteChannelUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/CIO.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/CIO.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/CacheControl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/CacheControl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/ClientEvents.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/ClientEvents.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/Content.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/Content.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/CoroutineUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/CoroutineUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/ExceptionUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/ExceptionUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/headers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/utils/headers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/CacheExpiresTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/CacheExpiresTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/ClientPluginsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/ClientPluginsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/CookiesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/CookiesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/DefaultRequestTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/DefaultRequestTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/FormDslTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/FormDslTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/HttpRequestBuilderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/HttpRequestBuilderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/HttpStatementTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/HttpStatementTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/MultiPartFormDataContentTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/MultiPartFormDataContentTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/ShouldValidateTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/ShouldValidateTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/TestEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/TestEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/HttpClientJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/HttpClientJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/ProxyConfigJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/ProxyConfigJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/Js.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/Js.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/ReadableStream.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/ReadableStream.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/browser/BrowserFetch.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/browser/BrowserFetch.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/compatibility/Utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/node/NodeFetch.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/node/NodeFetch.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/fetch/LibDom.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/fetch/LibDom.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/fetch/LibEs5.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/fetch/LibEs5.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/network.sockets/TimeoutExceptionsJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/network.sockets/TimeoutExceptionsJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/DefaultTransformJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/DefaultTransformJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/observer/ResponseObserverContextJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/observer/ResponseObserverContextJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/utils/CoroutineUtilsJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/utils/CoroutineUtilsJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/utils/ExceptionUtilsJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/utils/ExceptionUtilsJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/HttpClientJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/HttpClientJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/content/LocalFileContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/content/LocalFileContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientJvmEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/HttpClientJvmEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/ProxyConfigJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/engine/ProxyConfigJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/network/sockets/TimeoutExceptions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/network/sockets/TimeoutExceptions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/DefaultTransformersJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/DefaultTransformersJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/observer/ResponseObserverContextJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/observer/ResponseObserverContextJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/request/HttpRequestJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/request/HttpRequestJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/request/buildersJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/request/buildersJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/CIOJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/CIOJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/CoroutineDispatcherUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/CoroutineDispatcherUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/ExceptionUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/utils/ExceptionUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/CachingCacheStorageTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/CachingCacheStorageTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/ExceptionsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/ExceptionsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/WebSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/test/WebSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/HttpClient.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/HttpClient.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/engine/Loader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/engine/Loader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/engine/ProxyConfigNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/engine/ProxyConfigNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/network.sockets/TimeoutExceptionsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/network.sockets/TimeoutExceptionsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/plugins/DefaultTransformIos.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/plugins/DefaultTransformIos.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/plugins/observer/ResponseObserverContextPosix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/plugins/observer/ResponseObserverContextPosix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/utils/CoroutineUtilsPosix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/utils/CoroutineUtilsPosix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/utils/ExceptionUtilsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/posix/src/io/ktor/client/utils/ExceptionUtilsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/Curl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/Curl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlClientEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlClientEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlClientEngineConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlClientEngineConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlProcessor.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/CurlProcessor.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/ResponseUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/ResponseUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlAdapters.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlAdapters.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlCallbacks.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlCallbacks.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlRaw.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlRaw.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/NativeUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/NativeUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/test/io/ktor/client/engine/curl/test/CurlNativeTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/test/io/ktor/client/engine/curl/test/CurlNativeTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/test/io/ktor/client/engine/curl/test/CurlProxyTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/test/io/ktor/client/engine/curl/test/CurlProxyTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacy.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacy.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngineConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngineConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/KtorLegacyNSURLSessionDelegate.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/KtorLegacyNSURLSessionDelegate.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/ProxySupportLegacyCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/ProxySupportLegacyCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/TimeoutUtilsLegacy.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/TimeoutUtilsLegacy.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyCertificatePinner.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyCertificatePinner.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyCertificatesInfo.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyCertificatesInfo.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyPinnedCertificate.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyPinnedCertificate.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/DarwinLegacyRequestUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/DarwinLegacyRequestUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/DarwinLegacyResponseUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/DarwinLegacyResponseUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/DarwinLegacySession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/DarwinLegacySession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/DarwinLegacyTaskHandler.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/DarwinLegacyTaskHandler.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/DarwinLegacyUrlUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/internal/DarwinLegacyUrlUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/test/DarwinLegacyEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/test/DarwinLegacyEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/Darwin.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/Darwin.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/KtorNSURLSessionDelegate.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/KtorNSURLSessionDelegate.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/ProxySupportCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/ProxySupportCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/TimeoutUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/TimeoutUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatesInfo.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatesInfo.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/PinnedCertificate.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/PinnedCertificate.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinRequestUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinRequestUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinResponseUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinResponseUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinSession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinTaskHandler.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinTaskHandler.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinUrlUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/ios/Ios.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/ios/Ios.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/ios/certificates/CertificatePinner.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/ios/certificates/CertificatePinner.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-ios/darwin/src/Stub.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-ios/darwin/src/Stub.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/Java.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/Java.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequestBodyPublisher.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpRequestBodyPublisher.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpResponseBodyHandler.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpResponseBodyHandler.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/CommonTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/CommonTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/JavaEngineTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/JavaEngineTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestProducerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestProducerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/ResponseConsumerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/ResponseConsumerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/Jetty.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/Jetty.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/JettyEngineConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/JettyEngineConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/JettyHttp2Engine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/JettyHttp2Engine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/JettyHttp2Request.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/JettyHttp2Request.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/JettyHttpRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/JettyHttpRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/JettyResponseListener.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/JettyResponseListener.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/src/io/ktor/client/engine/jetty/jakarta/utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/test/io/ktor/client/engine/jetty/jakarta/JettyHttp2EngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/test/io/ktor/client/engine/jetty/jakarta/JettyHttp2EngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/Jetty.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/Jetty.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyEngineConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyEngineConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Engine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Engine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Request.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttp2Request.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttpRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyHttpRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/JettyResponseListener.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/src/io/ktor/client/engine/jetty/utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/test/io/ktor/client/engine/jetty/JettyHttp2EngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/test/io/ktor/client/engine/jetty/JettyHttp2EngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-js/js/src/Js.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-js/js/src/Js.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngineConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngineConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/test/MockEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/test/MockEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/test/MockUtilsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/test/MockUtilsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineExtendedTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineExtendedTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttp.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttp.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/StreamRequestBody.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/CommonTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/CommonTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpEngineTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpEngineTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpWebsocketSessionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/OkHttpWebsocketSessionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/RequestTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/RequestTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/StreamRequestBodyTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/test/io/ktor/client/engine/okhttp/StreamRequestBodyTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/Auth.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/Auth.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/AuthProvider.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/AuthProvider.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/AuthTokenHolder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/AuthTokenHolder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BasicAuthProvider.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/BearerAuthProvider.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/providers/DigestAuthProvider.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTokenHolderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTokenHolderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/BasicProviderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/BasicProviderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/DigestProviderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/DigestProviderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/ContentNegotiation.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/src/io/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/IgnoreTypesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/IgnoreTypesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/TestContentConverter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/TestContentConverter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/js/src/DefaultIgnoredTypesJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/js/src/DefaultIgnoredTypesJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/jvm/src/DefaultIgnoredTypesJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/jvm/src/DefaultIgnoredTypesJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/AbstractClientContentNegotiationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/AbstractClientContentNegotiationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/JsonContentNegotiationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/JsonContentNegotiationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/JsonWebsocketsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/JsonWebsocketsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/posix/src/DefaultIgnoredTypesNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/posix/src/DefaultIgnoredTypesNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/common/src/ContentEncoder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/common/src/ContentEncoder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/common/src/ContentEncoding.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/common/src/ContentEncoding.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/common/test/ContentEncodingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/js/src/ContentEncodersJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/js/src/ContentEncodersJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/jvm/src/ContentEncodersJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/jvm/src/ContentEncodersJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/posix/src/ContentEncodersNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-encoding/posix/src/ContentEncodersNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonContentTypeMatcher.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonContentTypeMatcher.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonPlugin.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonPlugin.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonSerializer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/src/io/ktor/client/plugins/json/JsonSerializer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/test/JsonPluginMockTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/test/JsonPluginMockTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/test/JsonPluginTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/test/JsonPluginTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/test/KotlinxSerializerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/test/KotlinxSerializerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/js/src/io/ktor/client/plugins/json/DefaultJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/js/src/io/ktor/client/plugins/json/DefaultJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/js/src/io/ktor/client/plugins/json/JsonPluginJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/js/src/io/ktor/client/plugins/json/JsonPluginJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/jvm/src/io/ktor/client/plugins/json/DefaultJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/jvm/src/io/ktor/client/plugins/json/DefaultJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/jvm/src/io/ktor/client/plugins/json/JsonPluginJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/jvm/src/io/ktor/client/plugins/json/JsonPluginJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/plugins/gson/GsonSerializer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/src/io/ktor/client/plugins/gson/GsonSerializer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/test/io/ktor/client/plugins/gson/tests/GsonTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-gson/jvm/test/io/ktor/client/plugins/gson/tests/GsonTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/plugins/jackson/JacksonSerializer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/jvm/src/io/ktor/client/plugins/jackson/JacksonSerializer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/jvm/test/io/ktor/client/plugins/jackson/tests/JacksonTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-jackson/jvm/test/io/ktor/client/plugins/jackson/tests/JacksonTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-json-tests/jvm/src/io/ktor/client/plugins/json/tests/JsonTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-json-tests/jvm/src/io/ktor/client/plugins/json/tests/JsonTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-json-tests/jvm/test/DefaultSerializerJsonTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-json-tests/jvm/test/DefaultSerializerJsonTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/plugins/kotlinx/serializer/KotlinxSerializer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/src/io/ktor/client/plugins/kotlinx/serializer/KotlinxSerializer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/test/CollectionsSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/test/CollectionsSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/test/ContextualSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/common/test/ContextualSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/js/src/SerializerInitializer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/js/src/SerializerInitializer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/jvm/test/KotlinxSerializerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/jvm/test/KotlinxSerializerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/posix/src/SerializerInitializer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-serialization/posix/src/SerializerInitializer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/posix/src/io/ktor/client/plugins/json/DefaultPosix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/posix/src/io/ktor/client/plugins/json/DefaultPosix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/posix/src/io/ktor/client/plugins/json/JsonPluginPosix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/posix/src/io/ktor/client/plugins/json/JsonPluginPosix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/HttpClientCallLogger.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/HttpClientCallLogger.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/LogLevel.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/LogLevel.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/LoggedContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/LoggedContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logger.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logger.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/LoggingUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/LoggingUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/ObservingUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/ObservingUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/js/src/io/ktor/client/plugins/logging/LoggerJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/js/src/io/ktor/client/plugins/logging/LoggerJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/src/io/ktor/client/plugins/logging/LoggerJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/src/io/ktor/client/plugins/logging/LoggerJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/test/io/ktor/client/plugins/logging/AndroidLoggerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/test/io/ktor/client/plugins/logging/AndroidLoggerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/test/io/ktor/client/plugins/logging/LoggingJsonTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/test/io/ktor/client/plugins/logging/LoggingJsonTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/test/io/ktor/client/plugins/logging/LoggingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/test/io/ktor/client/plugins/logging/LoggingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/posix/src/io/ktor/client/plugins/logging/LoggerIos.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/posix/src/io/ktor/client/plugins/logging/LoggerIos.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/Resources.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/Resources.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-resources/common/src/io/ktor/client/plugins/resources/builders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-resources/common/test/ResourcesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-resources/common/test/ResourcesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/common/src/EngineWIthTracer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/common/src/EngineWIthTracer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/common/src/IncomingChannelTracer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/common/src/IncomingChannelTracer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/common/src/OutgoingChannelTracer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/common/src/OutgoingChannelTracer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/common/src/Tracer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/common/src/Tracer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/common/src/TracingWrapper.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/common/src/TracingWrapper.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/common/src/WebSocketSessionTracer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/common/src/WebSocketSessionTracer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/jvm/test/TestTracer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/jvm/test/TestTracer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/jvm/test/TracingWrapperTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/jvm/test/TracingWrapperTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/KtorInspectorWebSocketFrame.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/KtorInspectorWebSocketFrame.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/KtorInspectorWebSocketRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/KtorInspectorWebSocketRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/KtorInspectorWebSocketResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/KtorInspectorWebSocketResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/KtorInterceptorHeaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/KtorInterceptorHeaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/KtorInterceptorRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/KtorInterceptorRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/KtorInterceptorResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/KtorInterceptorResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/StethoTracer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/src/io/ktor/client/features/tracing/StethoTracer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/test/io/ktor/client/features/tracing/StethoTracerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/ktor-client-tracing-stetho/android/test/io/ktor/client/features/tracing/StethoTracerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-websockets/common/src/Empty.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-websockets/common/src/Empty.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketRemoteTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketRemoteTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-websockets/common/test/io/ktor/client/tests/plugins/WebSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/Assertions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/Assertions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/ClientLoader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/ClientLoader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/CommonClientTestUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/CommonClientTestUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/Generators.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/Generators.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/TestInfo.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/TestInfo.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/AttributesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/AttributesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/BodyProgressTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/BodyProgressTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CallValidatorTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CallValidatorTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CharsetTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CharsetTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ClientHeadersTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ClientHeadersTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ClientPipelinesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ClientPipelinesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CommonHttpClientTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CommonHttpClientTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ConnectionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ConnectionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTypeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTypeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DefaultEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DefaultEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DefaultTransformTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DefaultTransformTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DownloadTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/DownloadTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/EventsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/EventsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/FullFormTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/FullFormTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpClientCallTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpClientCallTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRedirectTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRequestRetryTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRequestRetryTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpStatementTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpStatementTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpTimeoutTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/JsonTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/JsonTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingMockedTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingMockedTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MockedTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MockedTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MultiPartFormDataTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MultiPartFormDataTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PluginsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PluginsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ProxyTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ProxyTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ResponseObserverTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ResponseObserverTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/UploadTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/UploadTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/engine/UtilsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/engine/UtilsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheLegacyStorageTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheLegacyStorageTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CookiesMockTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CookiesMockTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CookiesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CookiesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/SerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/SerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/UserAgentTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/UserAgentTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/Asserter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/Asserter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/FrameLogger.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/FrameLogger.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/JobUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/JobUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/LogMatcher.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/LogMatcher.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/LoggerDsl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/LoggerDsl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/Logging.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/Logging.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/TestDataGenerators.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/utils/TestDataGenerators.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/js/src/io/ktor/client/tests/utils/AssertionsJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/js/src/io/ktor/client/tests/utils/AssertionsJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/js/src/io/ktor/client/tests/utils/ClientLoaderJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/js/src/io/ktor/client/tests/utils/ClientLoaderJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/AssertionsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/AssertionsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/HttpClientTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/HttpClientTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/SslOverProxyTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/SslOverProxyTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientLoaderJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientLoaderJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/TestWithKtor.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/TestWithKtor.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/BuildersTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/BuildersTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/CookiesAndRedirectMockedTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/CookiesAndRedirectMockedTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/DefaultTransformJvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/DefaultTransformJvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/ExceptionsJvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/ExceptionsJvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/FileCacheTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/FileCacheTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/FormsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/FormsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/HttpRedirectMockedTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/HttpRedirectMockedTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/JvmContentTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/JvmContentTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/LoggingTestJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/LoggingTestJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/MultithreadedTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/MultithreadedTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/WebSocketJvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/WebSocketJvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/posix/src/io/ktor/client/tests/utils/AssertionsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/posix/src/io/ktor/client/tests/utils/AssertionsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/posix/src/io/ktor/client/tests/utils/ClientLoaderNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/posix/src/io/ktor/client/tests/utils/ClientLoaderNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/content/Compatibility.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/content/Compatibility.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ApplicationResponseProperties.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ApplicationResponseProperties.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/CacheControl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/CacheControl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Codecs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Codecs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ContentDisposition.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ContentDisposition.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ContentRange.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ContentRange.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ContentTypeMatcher.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ContentTypeMatcher.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ContentTypes.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ContentTypes.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Cookie.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Cookie.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/CookieUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/CookieUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/DateUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/DateUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/FileContentType.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/FileContentType.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HeaderValueWithParameters.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Headers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Headers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpHeaderValueParser.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpHeaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpHeaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpMessage.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpMessage.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpMethod.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpMethod.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpProtocolVersion.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpProtocolVersion.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpStatusCode.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpUrlEncoded.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/IpParser.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/IpParser.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/LinkHeader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/LinkHeader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Mimes.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Mimes.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Parameters.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Parameters.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Query.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Query.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Ranges.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Ranges.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/RangesSpecifier.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/RangesSpecifier.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/RequestConnectionPoint.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/RequestConnectionPoint.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLParser.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLParser.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLProtocol.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLProtocol.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Url.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Url.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/UrlDecodedParametersBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/UrlDecodedParametersBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/auth/AuthScheme.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/auth/AuthScheme.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/auth/HeaderValueEncoding.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/auth/HeaderValueEncoding.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/ByteArrayContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/ByteArrayContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/CachingOptions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/CachingOptions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/ChannelWriterContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/ChannelWriterContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/Multipart.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/Multipart.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/OutgoingContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/OutgoingContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/TextContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/TextContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/Versions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/Versions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/Debug.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/Debug.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/GrammarBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/GrammarBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/ParseException.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/ParseException.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/Parser.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/Parser.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/ParserDsl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/ParserDsl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/Primitives.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/Primitives.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/regex/RegexParser.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/regex/RegexParser.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/regex/RegexParserGenerator.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/regex/RegexParserGenerator.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/websocket/Utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/websocket/Utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/AuthHeaderParseTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/AuthHeaderParseTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CodecTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CodecTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CommonHeadersTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/ContentDispositionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/ContentDispositionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/ContentTypeLookupTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/ContentTypeLookupTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/ContentTypeMatchTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/ContentTypeMatchTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/ContentTypeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/ContentTypeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CookieDateParserTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/CookieDateParserTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/HttpStatusCodeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/HttpStatusCodeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/QueryParametersTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/QueryParametersTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/RangesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/RangesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/RenderSetCookieTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/RenderSetCookieTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlDecodedParametersBuilderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlDecodedParametersBuilderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlEncodeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlEncodeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/js/src/io/ktor/http/URLBuilderJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/js/src/io/ktor/http/URLBuilderJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/FileContentTypeJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/FileContentTypeJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/HttpMessagePropertiesJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/HttpMessagePropertiesJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/URLBuilderJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/URLBuilderJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/URLUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/URLUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/BlockingBridge.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/BlockingBridge.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/MultipartJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/MultipartJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/OutputStreamContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/OutputStreamContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/URIFileContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/URIFileContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/VersionsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/VersionsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/WriterContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/content/WriterContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/test/io/ktor/tests/http/BlockingContentParkingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/test/io/ktor/tests/http/BlockingContentParkingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/test/io/ktor/tests/http/URLBuilderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/test/io/ktor/tests/http/URLBuilderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/CIOHeaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/CIOHeaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ChunkedTransferEncoding.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ChunkedTransferEncoding.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ConnectionOptions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ConnectionOptions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpBody.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpBody.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpHeadersMap.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpHeadersMap.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpParser.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/RequestResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/RequestResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/RequestResponseBuilderCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/RequestResponseBuilderCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/AsciiCharTree.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/AsciiCharTree.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/CharArrayBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/CharArrayBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/CharArrayPool.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/CharArrayPool.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Chars.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Chars.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/MutableRange.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/MutableRange.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Tokenizer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Tokenizer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/CharArrayBuilderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/CharArrayBuilderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HeaderParserTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HeaderParserTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HttpParserTestUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/HttpParserTestUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/RequestParserTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/RequestParserTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/ResponseParserTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/ResponseParserTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/js/src/io/ktor/http/cio/RequestResponseBuilderJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/js/src/io/ktor/http/cio/RequestResponseBuilderJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/js/src/io/ktor/http/cio/internals/CharArrayPoolJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/js/src/io/ktor/http/cio/internals/CharArrayPoolJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/RequestResponseBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/RequestResponseBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/internals/CharArrayPoolJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/internals/CharArrayPoolJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/ChunkedTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/ChunkedTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/HeadersJvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/HeadersJvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/RequestResponseBuilderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/RequestResponseBuilderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TrySkipDelimiterTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/TrySkipDelimiterTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/posix/src/io/ktor/http/cio/RequestResponseBuilderNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/posix/src/io/ktor/http/cio/RequestResponseBuilderNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/posix/src/io/ktor/http/cio/internals/CharArrayPoolPosix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/posix/src/io/ktor/http/cio/internals/CharArrayPoolPosix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/posix/src/io/ktor/http/URLBuilderPosix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/posix/src/io/ktor/http/URLBuilderPosix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteChannelSequential.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteChannelSequential.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteReadChannel.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteReadChannel.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteWriteChannel.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ByteWriteChannel.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ChannelLittleEndian.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ChannelLittleEndian.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/CloseElement.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/CloseElement.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/Coroutines.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/Coroutines.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ExceptionUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ExceptionUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ReadSession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/ReadSession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/WriterSession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/WriterSession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/bits/ByteOrder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/bits/ByteOrder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/bits/Memory.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/bits/Memory.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/bits/MemoryFactory.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/bits/MemoryFactory.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/bits/MemoryPrimitives.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/bits/MemoryPrimitives.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/bits/PrimiteArrays.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/bits/PrimiteArrays.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/charsets/Encoding.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/charsets/Encoding.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/concurrent/Shared.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/concurrent/Shared.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Buffer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Buffer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferAppend.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferAppend.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferCompatibility.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferCompatibility.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferFactory.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferFactory.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferPrimitives.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferPrimitives.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Buffers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Buffers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Builder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Builder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/ByteOrder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/ByteOrder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BytePacketBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BytePacketBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/ByteReadPacket.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/ByteReadPacket.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Closeable.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Closeable.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Copy.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Copy.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Input.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Input.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/InputArrays.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/InputArrays.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/InputLittleEndian.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/InputLittleEndian.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/InputPrimitives.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/InputPrimitives.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Output.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Output.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/OutputLittleEndian.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/OutputLittleEndian.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/OutputPrimitives.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/OutputPrimitives.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Packet.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Packet.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/PacketDirect.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/PacketDirect.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Preview.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Preview.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Scanner.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Scanner.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/UnsignedTypes.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/UnsignedTypes.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/CharArraySequence.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/CharArraySequence.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/ChunkBuffer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/ChunkBuffer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/EncodeResult.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/EncodeResult.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/Numbers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/Numbers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/UTF8.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/UTF8.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/Unsafe.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/Unsafe.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/errors/Errors.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/errors/Errors.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/internal/AwaitingSlot.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/internal/AwaitingSlot.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/internal/SequentialCopyTo.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/internal/SequentialCopyTo.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/pool/ByteArrayPool.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/pool/ByteArrayPool.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/pool/Pool.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/pool/Pool.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/temporary.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/temporary.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BufferTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BufferTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteBufferChannelScenarioTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteBufferChannelScenarioTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelBuildersTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelBuildersTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelCloseTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelCloseTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSessionsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSessionsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelTestBase.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelTestBase.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketBuildTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketBuildTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketBuildTestPooled.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketBuildTestPooled.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketReadTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketReadTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketStringTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/BytePacketStringTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/CharsetsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/CharsetsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/DefaultPoolImplementationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/DefaultPoolImplementationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/DummyCoroutines.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/DummyCoroutines.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/InputTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/InputTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/OutputTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/OutputTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/PeekCharTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/PeekCharTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/PrimitiveCodecTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/PrimitiveCodecTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadBufferTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadBufferTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadTextCommonTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadTextCommonTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadUntilDelimiterTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadUntilDelimiterTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReaderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReaderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReverseByteOrderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReverseByteOrderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/StringsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/StringsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/StringsTestPooled.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/StringsTestPooled.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/TakeWhileTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/TakeWhileTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/UnconfinedTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/UnconfinedTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/UnicodeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/UnicodeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/VerifyingChunkBufferPool.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/VerifyingChunkBufferPool.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/VerifyingPoolBase.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/VerifyingPoolBase.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ViewPacketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ViewPacketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/ByteChannelJS.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/ByteChannelJS.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/ByteReadChannelJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/ByteReadChannelJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/ByteWriteChannelJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/ByteWriteChannelJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/ExceptionUtilsJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/ExceptionUtilsJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/ByteOrderJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/ByteOrderJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/MemoryFactoryJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/MemoryFactoryJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/MemoryJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/MemoryJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/MemoryPrimitivesJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/MemoryPrimitivesJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/PrimitiveArraysJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/PrimitiveArraysJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/DecodeBuffer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/DecodeBuffer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/ISO88591.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/ISO88591.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/BufferUtilsJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/BufferUtilsJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/ByteOrderJS.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/ByteOrderJS.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/ByteReadPacket.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/ByteReadPacket.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/CloseableJS.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/CloseableJS.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/InputArraysJS.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/InputArraysJS.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/PacketJS.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/PacketJS.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/ScannerJS.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/ScannerJS.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/StringsJS.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/StringsJS.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/errors/IOException.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/errors/IOException.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/Decoder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/Decoder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/TextDecoder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/TextDecoder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/TextDecoderFallback.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/TextDecoderFallback.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/TextDecoders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/TextDecoders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/TextEncoder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/TextEncoder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/TypedArrays.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/TypedArrays.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/WebSockets.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/WebSockets.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/XMLHttpRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/js/XMLHttpRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/pool/DefaultPool.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/pool/DefaultPool.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/ChunkBufferNativeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/ChunkBufferNativeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/ISOTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/ISOTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/JsByteChannelCloseTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/JsByteChannelCloseTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/TextDecoderFallbackTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/TextDecoderFallbackTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/VerifyingObjectPool.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/test/io/ktor/utils/io/VerifyingObjectPool.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteChannel.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteChannel.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteChannelSequentialJVM.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteChannelSequentialJVM.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteReadChannelJVM.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteWriteChannel.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteWriteChannel.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ConsumeEach.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ConsumeEach.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/Delimited.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/Delimited.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ExceptionUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ExceptionUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/LookAheadSession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/LookAheadSession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/ByteOrderJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/ByteOrderJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryFactoryJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryFactoryJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryPrimitivesJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryPrimitivesJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/PrimitiveArraysJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/PrimitiveArraysJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/Strings.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/Strings.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/BufferPrimitivesJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/BufferPrimitivesJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/BufferUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/BufferUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/ByteBuffers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/ByteBuffers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/ByteOrderJVM.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/ByteOrderJVM.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/ByteReadPacketExtensions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/ByteReadPacketExtensions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/CloseableJVM.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/CloseableJVM.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/InputArraysJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/InputArraysJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/OutputArraysJVM.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/OutputArraysJVM.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/PacketJVM.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/PacketJVM.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/ScannerJVM.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/ScannerJVM.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/StringsJVM.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/core/StringsJVM.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/errors/IOException.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/errors/IOException.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/ByteBufferChannelInternals.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/ByteBufferChannelInternals.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/CancellableReusableContinuation.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/CancellableReusableContinuation.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/ObjectPool.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/ObjectPool.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/ReadSessionImpl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/ReadSessionImpl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/ReadWriteBufferState.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/ReadWriteBufferState.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/RingBufferCapacity.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/RingBufferCapacity.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/Strings.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/Strings.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/Utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/Utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/WriteSessionImpl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/WriteSessionImpl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/jvm/Errors.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/jvm/Errors.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Pollers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Pollers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Reading.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Writing.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Writing.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/nio/Reading.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/nio/Reading.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/nio/Writing.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/nio/Writing.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Channels.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Channels.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Input.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Input.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Output.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Output.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/pool/ByteBufferPools.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/pool/ByteBufferPools.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/pool/DefaultPool.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/pool/DefaultPool.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/streams/ByteArrays.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/streams/ByteArrays.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/streams/Input.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/streams/Input.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/streams/Output.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/streams/Output.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/streams/Streams.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/streams/Streams.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/utils/Atomic.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/utils/Atomic.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/BlockingAdaptersOnProhibitedThreadTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/BlockingAdaptersOnProhibitedThreadTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelLookAheadTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelLookAheadTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ByteChannelSequentialScenarioTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ByteChannelSequentialScenarioTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ByteChannelSequentialTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ByteChannelSequentialTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/BytePacketBuildTestExtended.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/BytePacketBuildTestExtended.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/BytePacketReaderWriterTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/BytePacketReaderWriterTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/CancellableReusableContinuationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/CancellableReusableContinuationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ChannelsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ChannelsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ConsumeEachBufferRangeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ConsumeEachBufferRangeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/InputAdapterTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/InputAdapterTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/JvmByteChannelCloseTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/JvmByteChannelCloseTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/JvmByteChannelSmokeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/JvmByteChannelSmokeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/PacketInteropTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/PacketInteropTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/SkipDelimiterTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/SkipDelimiterTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/StreamTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/StreamTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/StringsSequentialTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/StringsSequentialTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ToByteReadChannelTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ToByteReadChannelTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/VerifyingObjectPool.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/VerifyingObjectPool.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ViewPacketNIOTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ViewPacketNIOTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/charsets/ByteChannelTextTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/charsets/ByteChannelTextTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/charsets/UTFTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/charsets/UTFTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ByteChannelNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ByteChannelNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ByteReadChannelNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ByteReadChannelNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ByteWriteChannelNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ByteWriteChannelNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ExceptionUtilsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/ExceptionUtilsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/bits/ByteOrderNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/bits/ByteOrderNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/bits/MemoryFactoryNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/bits/MemoryFactoryNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/bits/MemoryNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/bits/MemoryNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/bits/MemoryPrimitivesNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/bits/MemoryPrimitivesNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/bits/PrimitiveArraysNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/bits/PrimitiveArraysNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/BufferUtilsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/BufferUtilsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/ByteOrderNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/ByteOrderNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/BytePacketsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/BytePacketsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/ByteReadPacket.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/ByteReadPacket.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/CloseableNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/CloseableNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/InputArraysNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/InputArraysNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/OutputArraysNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/OutputArraysNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/Platform.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/Platform.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/ScannerNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/ScannerNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/StringsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/StringsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/errors/IOException.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/errors/IOException.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/errors/PosixErrors.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/errors/PosixErrors.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/pool/DefaultPool.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/pool/DefaultPool.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/ByteChannelNativeConcurrentTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/ByteChannelNativeConcurrentTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/ByteChannelNativeTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/ByteChannelNativeTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/BytePacketBuilderExtendedTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/BytePacketBuilderExtendedTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/ChunkBufferNativeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/ChunkBufferNativeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/MemoryTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/MemoryTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/PosixByteChannelCloseTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/PosixByteChannelCloseTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/PosixIoTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/PosixIoTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/VerifyingObjectPool.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/VerifyingObjectPool.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/darwin/src/io/ktor/network/selector/SelectUtilsDarwin.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/darwin/src/io/ktor/network/selector/SelectUtilsDarwin.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/darwin/src/io/ktor/network/util/SocketUtilsDarwin.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/darwin/src/io/ktor/network/util/SocketUtilsDarwin.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ios/src/io/ktor/network/util/SocketUtilsIos.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ios/src/io/ktor/network/util/SocketUtilsIos.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ios/test/io/ktor/network/sockets/tests/TestUtilsIos.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ios/test/io/ktor/network/sockets/tests/TestUtilsIos.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/InterestSuspensionsMap.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/InterestSuspensionsMap.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/JvmSelector.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/JvmSelector.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/LockFreeMPSCQueue.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/LockFreeMPSCQueue.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/SelectableJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/SelectableJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/SelectorManager.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/SelectorManager.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/SelectorManagerSupport.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/SelectorManagerSupport.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/ConnectUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/ConnectUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSendChannel.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSendChannel.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/DatagramSocketImpl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketAddressUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketAddressUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketOptions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketOptions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/NIOSocketImpl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/NIOSocketImpl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/ServerSocketImpl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/ServerSocketImpl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketAddressJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketAddressJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketImpl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketImpl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketOptionsPlatformCapabilities.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketOptionsPlatformCapabilities.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketTimeoutException.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketTimeoutException.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/TCPSocketBuilderJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/TCPSocketBuilderJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/UDPSocketBuilderJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/UDPSocketBuilderJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/util/Pools.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/util/Pools.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/util/Utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/util/Utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/selector/ActorSelectorManagerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/selector/ActorSelectorManagerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/ClientSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/ClientSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/TestUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/TestUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/UDPSocketTestJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/UDPSocketTestJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/util/StartTimeoutTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/util/StartTimeoutTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/selector/Selectable.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/selector/Selectable.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/selector/SelectorManagerCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/selector/SelectorManagerCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/Builders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/Builders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/ConnectUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/ConnectUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/Datagram.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/Datagram.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/SocketAddress.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/SocketAddress.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/SocketOptions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/SocketOptions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/Sockets.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/Sockets.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/TcpSocketBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/TcpSocketBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/TypeOfService.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/TypeOfService.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/UDPSocketBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/UDPSocketBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/TcpSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/TcpSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/TestUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/TestUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CertificateInfo.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CertificateInfo.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CertificateType.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CertificateType.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CipherSuitesJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/CipherSuitesJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/EncryptionInfo.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/EncryptionInfo.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Hashes.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Hashes.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Headers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Headers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Keys.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Keys.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Parser.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Parser.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Render.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Render.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLS.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLS.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSAlert.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSAlert.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSConfigJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSHandshakeType.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSHandshakeType.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSRecordType.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSRecordType.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSVersion.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSVersion.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/CBCCipher.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/CBCCipher.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/Cipher.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/Cipher.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/CipherUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/CipherUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/GCMCipher.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/GCMCipher.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/platform/PlatformVersion.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/platform/PlatformVersion.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ClientCertificateRequestTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ClientCertificateRequestTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ConnectionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/ConnectionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/TLSConfigBuilderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/test/io/ktor/network/tls/tests/TLSConfigBuilderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/CipherSuites.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/CipherSuites.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/OID.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/OID.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/TLSClientSession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/TLSClientSession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/TLSCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/TLSCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/TLSConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/TLSConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/TLSConfigBuilderCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/TLSConfigBuilderCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/extensions/NamedCurves.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/extensions/NamedCurves.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/extensions/PointFormat.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/extensions/PointFormat.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/extensions/SignatureAlgorithm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/extensions/SignatureAlgorithm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/extensions/TLSExtension.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvmAndNix/src/io/ktor/network/tls/extensions/TLSExtension.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/builders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/CertificatesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/CertificatesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/KeyStoreBuilderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/KeyStoreBuilderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/TestUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/TestUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/TimeMocks.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/TimeMocks.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/CipherSuitesNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/CipherSuitesNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSClientSessionNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSClientSessionNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSConfigBuilderNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSConfigBuilderNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSConfigNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSConfigNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/nix/src/io/ktor/network/tls/TLSNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/linuxX64/src/io/ktor/network/selector/SelectUtilsLinux.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/linuxX64/src/io/ktor/network/selector/SelectUtilsLinux.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/linuxX64/src/io/ktor/network/util/SocketUtilsLinux.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/linuxX64/src/io/ktor/network/util/SocketUtilsLinux.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/linuxX64/test/io/ktor/network/sockets/tests/TestUtilsLinux.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/linuxX64/test/io/ktor/network/sockets/tests/TestUtilsLinux.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/macos/src/io/ktor/network/util/SocketUtilsMacos.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/macos/src/io/ktor/network/util/SocketUtilsMacos.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/macos/test/io/ktor/network/sockets/tests/TestUtilsMacos.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/macos/test/io/ktor/network/sockets/tests/TestUtilsMacos.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/EventInfo.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/EventInfo.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SelectUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SelectUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SelectableNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SelectableNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SelectorManager.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SelectorManager.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SignalPoint.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SignalPoint.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/WorkerSelectorManager.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/WorkerSelectorManager.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/CIOReader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/CIOReader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/CIOWriter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/CIOWriter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/ConnectUtilsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/ConnectUtilsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/DatagramSendChannel.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/DatagramSendChannel.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/DatagramSocketNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/DatagramSocketNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/NativeSocketOptions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/NativeSocketOptions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/SocketAddressNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/SocketAddressNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/SocketTimeoutException.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/SocketTimeoutException.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/TCPServerSocketNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/TCPServerSocketNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/TCPSocketBuilderNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/TCPSocketBuilderNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/TCPSocketNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/TCPSocketNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/UDPSocketBuilderNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/UDPSocketBuilderNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/NativeSocketAddress.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/NativeSocketAddress.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/NativeUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/NativeUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/Pools.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/Pools.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/SocketAddressUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/SocketAddressUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/SocketUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/SocketUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/test/io/ktor/network/sockets/tests/TestUtilsNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/test/io/ktor/network/sockets/tests/TestUtilsNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/test/io/ktor/network/sockets/tests/UDPSocketTestPosix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/test/io/ktor/network/sockets/tests/UDPSocketTestPosix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/tvos/src/io/ktor/network/util/SocketUtilsTvos.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/tvos/src/io/ktor/network/util/SocketUtilsTvos.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/tvos/test/io/ktor/network/sockets/tests/TestUtilsTvos.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/tvos/test/io/ktor/network/sockets/tests/TestUtilsTvos.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/watchos/src/io/ktor/network/util/SocketUtilsWatchos.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/watchos/src/io/ktor/network/util/SocketUtilsWatchos.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/watchos/test/io/ktor/network/sockets/tests/TestUtilsWatchos.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/watchos/test/io/ktor/network/sockets/tests/TestUtilsWatchos.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/jvmAndNix/src/Stub.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/jvmAndNix/src/Stub.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/backend/SocketAddressUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/backend/SocketAddressUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/internal/CoroutineUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/internal/CoroutineUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/internal/WeakTimeoutQueueJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/internal/WeakTimeoutQueueJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOClientCertTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOClientCertTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOEngineTestJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOEngineTestJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ClassCastExceptionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ClassCastExceptionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/IntegrationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/IntegrationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ServerPipelineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ServerPipelineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/TestHttpServer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/TestHttpServer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/WeakTimeoutQueueTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/WeakTimeoutQueueTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIO.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIO.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/EngineMain.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/EngineMain.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/HttpServer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/HttpServer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/Pipeline.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/Pipeline.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerIncomingConnection.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerIncomingConnection.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerRequestScope.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerRequestScope.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/SocketAddressUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/SocketAddressUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/internal/CoroutineUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/internal/CoroutineUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/internal/WeakTimeoutQueue.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/internal/WeakTimeoutQueue.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CIOConnectionPointTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CIOConnectionPointTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CIOEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CIOEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CIOWebSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/CIOWebSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/RAWExample.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/RAWExample.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/TestConnectorInterfaceUsed.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/test/io/ktor/tests/server/cio/TestConnectorInterfaceUsed.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/nix/src/io/ktor/server/cio/backend/SocketAddressUtilsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/nix/src/io/ktor/server/cio/backend/SocketAddressUtilsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/nix/src/io/ktor/server/cio/internal/CoroutineUtilsNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/nix/src/io/ktor/server/cio/internal/CoroutineUtilsNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/nix/src/io/ktor/server/cio/internal/WeakTimeoutQueueNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/nix/src/io/ktor/server/cio/internal/WeakTimeoutQueueNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/jvm/src/io/ktor/server/config/yaml/YamlConfigJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/jvm/src/io/ktor/server/config/yaml/YamlConfigJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/jvm/test/YamlConfigTestJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/jvm/test/YamlConfigTestJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/jvmAndNix/src/io/ktor/server/config/yaml/YamlConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/jvmAndNix/src/io/ktor/server/config/yaml/YamlConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/jvmAndNix/test/YamlConfigTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/jvmAndNix/test/YamlConfigTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/nix/src/io/ktor/server/config/yaml/YamlConfigNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/nix/src/io/ktor/server/config/yaml/YamlConfigNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/nix/test/YamlConfigTestNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/nix/test/YamlConfigTestNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/application/ApplicationEnvironment.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/application/ApplicationEnvironment.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/application/internal/TypeUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/application/internal/TypeUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/config/ConfigLoadersJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/config/ConfigLoadersJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/config/HoconApplicationConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/config/HoconApplicationConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/HttpDateJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/HttpDateJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/CachingOptionsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/CachingOptionsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/DefaultTransformJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/DefaultTransformJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/JarFileContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/JarFileContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/LastModifiedJavaTime.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/LastModifiedJavaTime.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/LocalFileContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/LocalFileContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/PreCompressed.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/SinglePageApplication.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/SinglePageApplication.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContentResolution.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContentResolution.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/request/ApplicationReceiveFunctionsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/request/ApplicationReceiveFunctionsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/response/ApplicationResponseFunctionsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/response/ApplicationResponseFunctionsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/response/ApplicationResponsePropertiesJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/response/ApplicationResponsePropertiesJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/util/DateUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/util/DateUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/config/ConfigJvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/config/ConfigJvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/config/HoconConfigTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/config/HoconConfigTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/FindContainingJarFileTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/FindContainingJarFileTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/content/LocalFileContentTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/content/LocalFileContentTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/content/StaticContentResolutionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/content/StaticContentResolutionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/ApplicationPluginConfigurationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/ApplicationPluginConfigurationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/ConfigWithProperty.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/ConfigWithProperty.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/RoutingPluginConfigurationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/plugins/RoutingPluginConfigurationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/utils/DateJvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/utils/DateJvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/Application.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/Application.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationCallPipeline.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationCallPipeline.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationConfigExtensions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationConfigExtensions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationEvents.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationEvents.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationPlugin.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/ApplicationPlugin.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/CommonApplicationEnvironment.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/CommonApplicationEnvironment.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/CreatePluginUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/CreatePluginUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/DefaultApplicationEvents.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/DefaultApplicationEvents.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/Hook.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/Hook.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/Interceptions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/Interceptions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/KtorCallContexts.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/KtorCallContexts.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/PluginBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/PluginBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/PluginExceptions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/PluginExceptions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/PluginInstance.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/PluginInstance.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/RouteScopedPlugin.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/RouteScopedPlugin.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/RouteScopedPluginBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/RouteScopedPluginBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/debug/DebugPhaseNames.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/debug/DebugPhaseNames.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/debug/Utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/debug/Utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/hooks/CommonHooks.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/hooks/CommonHooks.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/internal/TypeUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/internal/TypeUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/ApplicationConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/ApplicationConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/ConfigLoaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/ConfigLoaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/MapApplicationConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/MapApplicationConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/MergedApplicationConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/MergedApplicationConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/HttpDate.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/HttpDate.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/LinkHeader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/LinkHeader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/Push.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/Push.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/content/DefaultTransform.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/content/DefaultTransform.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/content/HttpStatusCodeContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/content/HttpStatusCodeContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/content/SuppressionAttribute.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/http/content/SuppressionAttribute.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/logging/Logging.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/logging/Logging.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/plugins/Errors.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/plugins/Errors.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/plugins/OriginConnectionPoint.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/plugins/OriginConnectionPoint.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/request/ApplicationReceiveFunctions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/request/ApplicationReceiveFunctions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/request/ApplicationRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/request/ApplicationRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/request/ApplicationRequestProperties.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/request/ApplicationRequestProperties.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/request/RequestCookies.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/request/RequestCookies.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ApplicationResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ApplicationResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ApplicationResponseFunctions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ApplicationResponseFunctions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ApplicationResponseProperties.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ApplicationResponseProperties.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ApplicationSendPipeline.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ApplicationSendPipeline.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/DefaultResponsePushBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/DefaultResponsePushBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseCookies.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseCookies.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseHeaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseHeaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponsePushBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponsePushBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseType.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseType.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/UseHttp2Push.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/UseHttp2Push.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/HostsRoutingBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/HostsRoutingBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/IgnoreTrailingSlash.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/IgnoreTrailingSlash.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/LocalPortRoutingBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/LocalPortRoutingBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RegexRouting.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RegexRouting.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/Route.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/Route.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RouteSelector.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RouteSelector.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/Routing.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/Routing.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingApplicationCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingApplicationCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingPath.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingPath.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingResolveContext.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingResolveContext.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingResolveResult.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingResolveResult.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingResolveTrace.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingResolveTrace.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/util/CopyOnWriteHashMap.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/util/CopyOnWriteHashMap.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/util/Parameters.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/util/Parameters.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/util/Paths.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/util/Paths.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/util/URLBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/util/URLBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/ApplicationCallReceiveTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/ApplicationCallReceiveTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/ApplicationPluginTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/ApplicationPluginTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/HooksTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/HooksTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/RouteScopedPluginTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/RouteScopedPluginTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/config/MapApplicationConfigTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/config/MapApplicationConfigTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/config/MergedApplicationConfigTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/config/MergedApplicationConfigTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/http/ParametersTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/http/ParametersTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/http/PathNormalizationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/http/PathNormalizationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/logging/MDCProviderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/logging/MDCProviderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/routing/RegexRoutingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/routing/RegexRoutingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/routing/RouteSelectorTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/routing/RouteSelectorTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/routing/RouteTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/routing/RouteTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/utils/CopyOnWriteHashMapTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/utils/CopyOnWriteHashMapTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/nix/src/io/ktor/server/application/NixApplicationEnvironment.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/nix/src/io/ktor/server/application/NixApplicationEnvironment.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/nix/src/io/ktor/server/application/internal/TypeUtilsNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/nix/src/io/ktor/server/application/internal/TypeUtilsNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/nix/src/io/ktor/server/config/ConfigLoadersNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/nix/src/io/ktor/server/config/ConfigLoadersNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/nix/src/io/ktor/server/http/content/NixDefaultTransform.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/nix/src/io/ktor/server/http/content/NixDefaultTransform.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineEnvironmentJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineEnvironmentJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineEnvironmentReloading.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineEnvironmentReloading.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BlockingBridge.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/BlockingBridge.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ClassLoaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ClassLoaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLineJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLineJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultTransformJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/DefaultTransformJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineConnectorConfigJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EngineConnectorConfigJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EnvironmentUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EnvironmentUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/OverridingClassLoader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/OverridingClassLoader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ServerEngineUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ServerEngineUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ServerHostUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ServerHostUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ShutDownUrl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ShutDownUrl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ShutdownHookJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ShutdownHookJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/ApplicationUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/ApplicationUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/AutoReloadUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/AutoReloadUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/CallableUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/CallableUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/EngineUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/EngineUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/ExceptionUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/ExceptionUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/server/engine/OverridingClassLoaderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/server/engine/OverridingClassLoaderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ApplicationEngineEnvironmentReloadingTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ApplicationEngineEnvironmentReloadingTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/BuildApplicationConfigJvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/BuildApplicationConfigJvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ReceiveBlockingPrimitiveTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/ReceiveBlockingPrimitiveTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/ApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/ApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/ApplicationEngineEnvironment.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/ApplicationEngineEnvironment.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/CommandLine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/CommandLine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultEnginePipeline.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultEnginePipeline.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultTransform.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultTransform.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultUncaughtExceptionHandler.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultUncaughtExceptionHandler.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/EmbeddedServer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/EmbeddedServer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/EngineConnectorConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/EngineConnectorConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/EngineContextCancellationHelper.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/EngineContextCancellationHelper.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/EnginePipeline.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/EnginePipeline.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/Long.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/Long.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/ServerEngineUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/ServerEngineUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/ShutdownHook.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/ShutdownHook.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/internal/ApplicationUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/internal/ApplicationUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/internal/EngineUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/internal/EngineUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/internal/ExceptionUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/internal/ExceptionUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/ApplicationEngineEnvironmentNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/ApplicationEngineEnvironmentNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/DefaultTransformNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/DefaultTransformNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/EngineConnectorConfingNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/EngineConnectorConfingNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/EnvironmentUtilsNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/EnvironmentUtilsNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/NativeApplicationEngineEnvironment.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/NativeApplicationEngineEnvironment.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/ServerEngineUtilsNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/ServerEngineUtilsNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/ShutdownHookNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/ShutdownHookNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/internal/ApplicationUtilsNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/internal/ApplicationUtilsNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/internal/EngineUtilsNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/internal/EngineUtilsNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/internal/ExceptionUtilsNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/src/io/ktor/server/engine/internal/ExceptionUtilsNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/test/BuildApplicationConfigNixTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/nix/test/BuildApplicationConfigNixTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/Embedded.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/Embedded.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/EngineMain.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/EngineMain.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationEngineBase.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationEngineBase.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyApplicationResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/ServerInitializer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/ServerInitializer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/internal/EndPointChannels.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/internal/EndPointChannels.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/internal/JettyUpgradeImpl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/internal/JettyUpgradeImpl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyAsyncServletContainerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyAsyncServletContainerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyBlockingServletContainerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyBlockingServletContainerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyClientCertTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyClientCertTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyServletApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyServletApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyStressTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyStressTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyWebSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyWebSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/MultipleDispatchOnTimeout.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/MultipleDispatchOnTimeout.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/WebResourcesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/WebResourcesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletAsyncTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletAsyncTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletBlockingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletBlockingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletContainer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletContainer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/MultipleDispatchOnTimeout.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/MultipleDispatchOnTimeout.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/Embedded.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/Embedded.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/EngineMain.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/EngineMain.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationEngineBase.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyApplicationResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/internal/EndPointChannels.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/internal/EndPointChannels.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/internal/JettyUpgradeImpl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/internal/JettyUpgradeImpl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyAsyncServletContainerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyAsyncServletContainerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyBlockingServletContainerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyBlockingServletContainerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyClientCertTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyClientCertTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyServletApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyServletApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyStressTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyStressTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/MultipleDispatchOnTimeout.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/MultipleDispatchOnTimeout.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/WebResourcesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/WebResourcesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletAsyncTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletAsyncTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletBlockingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletBlockingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletContainer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletContainer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/MultipleDispatchOnTimeout.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/MultipleDispatchOnTimeout.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/CIO.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/CIO.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/Embedded.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/Embedded.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/EngineMain.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationCallHandler.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequestCookies.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequestCookies.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequestHeaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationRequestHeaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyChannelInitializer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyDirectDecoder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyDirectDecoder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyDirectEncoder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyDirectEncoder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyHttpHandlerState.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyConnectionPoint.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyConnectionPoint.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1ApplicationResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http1/NettyHttp1Handler.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/Http2LocalConnectionPoint.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/Http2LocalConnectionPoint.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/HttpFrameAdapter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2Handler.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/EngineMainTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/EngineMainTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyConfigurationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyConfigurationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyCustomChannelPipelineConfigurationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyCustomChannelPipelineConfigurationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp2ApplicationResponseTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp2ApplicationResponseTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp2LocalConnectionPointTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyHttp2LocalConnectionPointTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettySpecificTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyStressTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyStressTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyUtilityTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyUtilityTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyWebSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/test/io/ktor/tests/server/netty/NettyWebSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTAuth.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTAuth.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTAuthSchemes.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTAuthSchemes.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/src/io/ktor/server/auth/jwt/JWTUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTAuthTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTAuthTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTPayloadHolderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTPayloadHolderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/src/io/ktor/server/auth/ldap/Ldap.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/src/io/ktor/server/auth/ldap/Ldap.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LdapAuthTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LdapAuthTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LdapEscapeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LdapEscapeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestAuth.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestAuth.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth1a.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth1a.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/AuthWithPlugins.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/AuthWithPlugins.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2JvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2JvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Authentication.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Authentication.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationContext.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationContext.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationFailedCause.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationFailedCause.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationInterceptors.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationInterceptors.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationProcedureChallenge.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationProcedureChallenge.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationProvider.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationProvider.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BasicAuth.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BasicAuth.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BearerAuth.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BearerAuth.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/DynamicProviderConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/DynamicProviderConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/ForbiddenResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/ForbiddenResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/FormAuth.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/FormAuth.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Headers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Headers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuthCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuthCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuthProcedure.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuthProcedure.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Principal.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Principal.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/SessionAuth.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/SessionAuth.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/SimpleAuth.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/SimpleAuth.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/UnauthorizedResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/UnauthorizedResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthBuildersTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthBuildersTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthHeadersTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthHeadersTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthorizeHeaderParserTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthorizeHeaderParserTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BasicAuthTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BasicAuthTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BearerAuthTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/CryptoTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/CryptoTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/SessionAuthTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/SessionAuthTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/UserHashedTableAuthTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/UserHashedTableAuthTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/nix/src/OAuthNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/nix/src/OAuthNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auto-head-response/jvmAndNix/src/io/ktor/server/plugins/autohead/AutoHeadResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auto-head-response/jvmAndNix/src/io/ktor/server/plugins/autohead/AutoHeadResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-caching-headers/jvmAndNix/src/io/ktor/server/plugins/cachingheaders/CacheControlMerge.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-caching-headers/jvmAndNix/src/io/ktor/server/plugins/cachingheaders/CacheControlMerge.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-caching-headers/jvmAndNix/src/io/ktor/server/plugins/cachingheaders/CachingHeaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-caching-headers/jvmAndNix/src/io/ktor/server/plugins/cachingheaders/CachingHeaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-caching-headers/jvmAndNix/test/io/ktor/tests/CacheControlMergeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-caching-headers/jvmAndNix/test/io/ktor/tests/CacheControlMergeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-id/jvm/src/io/ktor/server/plugins/callid/CallIdJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-id/jvm/src/io/ktor/server/plugins/callid/CallIdJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-id/jvmAndNix/src/io/ktor/server/plugins/callid/CallId.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-id/jvmAndNix/src/io/ktor/server/plugins/callid/CallId.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLogging.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLogging.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLoggingConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLoggingConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/MDCEntryUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/MDCEntryUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/MDCHook.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/MDCHook.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/MDCProvider.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/MDCProvider.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Compression.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Compression.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Config.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Config.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Encoders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Encoders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-conditional-headers/jvmAndNix/src/io/ktor/server/plugins/conditionalheaders/ConditionalHeaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-conditional-headers/jvmAndNix/src/io/ktor/server/plugins/conditionalheaders/ConditionalHeaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/src/DefaultIgnoredTypesJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/src/DefaultIgnoredTypesJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/test/ContentNegotiationJvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/test/ContentNegotiationJvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/test/LogTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/test/LogTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/ContentNegotiation.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/ContentNegotiation.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/ContentNegotiationConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/ContentNegotiationConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/ContentNegotiationUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/ContentNegotiationUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/RequestConverter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/RequestConverter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/ResponseConverter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/ResponseConverter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/ContentNegotiationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/ContentNegotiationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/ContentNegotiationTestData.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/ContentNegotiationTestData.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/RequestConverterTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/RequestConverterTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/nix/src/DefaultIgnoredTypesNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/nix/src/DefaultIgnoredTypesNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/KotlinTimeJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/KotlinTimeJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/routing/CORS.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/routing/CORS.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-data-conversion/jvmAndNix/src/io/ktor/server/plugins/dataconversion/DataConversion.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-data-conversion/jvmAndNix/src/io/ktor/server/plugins/dataconversion/DataConversion.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-default-headers/jvm/src/io/ktor/server/plugins/defaultheaders/DefaultHeaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-default-headers/jvm/src/io/ktor/server/plugins/defaultheaders/DefaultHeaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-default-headers/jvm/test/io/ktor/tests/plugins/DefaultHeadersTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-default-headers/jvm/test/io/ktor/tests/plugins/DefaultHeadersTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvm/src/io/ktor/server/plugins/doublereceive/FileCacheJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvm/src/io/ktor/server/plugins/doublereceive/FileCacheJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvm/test/DoubleReceiveTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvm/test/DoubleReceiveTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/ByteArrayCache.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/ByteArrayCache.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/DoubleReceive.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/DoubleReceive.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/DoubleReceiveCache.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/DoubleReceiveCache.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/DoubleReceiveConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/DoubleReceiveConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/FileCache.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/FileCache.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/ReceiveHooks.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/ReceiveHooks.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/nix/src/io/ktor/server/plugins/doublereceive/FileCacheNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/nix/src/io/ktor/server/plugins/doublereceive/FileCacheNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-forwarded-header/jvmAndNix/src/io/ktor/server/plugins/forwardedheaders/ForwardedHeaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-forwarded-header/jvmAndNix/src/io/ktor/server/plugins/forwardedheaders/ForwardedHeaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-forwarded-header/jvmAndNix/src/io/ktor/server/plugins/forwardedheaders/XForwardedHeaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-forwarded-header/jvmAndNix/src/io/ktor/server/plugins/forwardedheaders/XForwardedHeaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-freemarker/jvm/src/io/ktor/server/freemarker/FreeMarker.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-freemarker/jvm/src/io/ktor/server/freemarker/FreeMarker.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-freemarker/jvm/src/io/ktor/server/freemarker/RespondTemplate.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-freemarker/jvm/src/io/ktor/server/freemarker/RespondTemplate.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-freemarker/jvm/test/io/ktor/tests/freemarker/FreeMarkerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-freemarker/jvm/test/io/ktor/tests/freemarker/FreeMarkerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-hsts/jvmAndNix/src/io/ktor/server/plugins/hsts/HSTS.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-hsts/jvmAndNix/src/io/ktor/server/plugins/hsts/HSTS.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-hsts/jvmAndNix/src/io/ktor/server/plugins/hsts/KotlinTimeJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-hsts/jvmAndNix/src/io/ktor/server/plugins/hsts/KotlinTimeJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/src/io/ktor/server/html/RespondHtml.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/src/io/ktor/server/html/RespondHtml.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/src/io/ktor/server/html/RespondHtmlTemplate.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/src/io/ktor/server/html/RespondHtmlTemplate.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/src/io/ktor/server/html/Template.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/src/io/ktor/server/html/Template.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/server/html/PlaceholderListTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/server/html/PlaceholderListTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/tests/html/HtmlBuilderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/tests/html/HtmlBuilderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/tests/html/HtmlContentTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/tests/html/HtmlContentTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/tests/html/HtmlTemplateTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/tests/html/HtmlTemplateTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-http-redirect/jvmAndNix/src/io/ktor/server/plugins/httpsredirect/HttpsRedirect.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-http-redirect/jvmAndNix/src/io/ktor/server/plugins/httpsredirect/HttpsRedirect.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/src/io/ktor/server/jte/Jte.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/src/io/ktor/server/jte/Jte.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/src/io/ktor/server/jte/RespondTemplate.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/src/io/ktor/server/jte/RespondTemplate.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/test/io/ktor/tests/jte/JteTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/test/io/ktor/tests/jte/JteTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/Location.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/Location.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/Locations.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/Locations.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/LocationsInfo.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/LocationsInfo.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/URLBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/URLBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/CustomLocationsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/CustomLocationsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/OAuthLocationsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/OAuthLocationsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/Verifiers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/Verifiers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-method-override/jvmAndNix/src/io/ktor/server/plugins/methodoverride/XHttpMethodOverride.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-method-override/jvmAndNix/src/io/ktor/server/plugins/methodoverride/XHttpMethodOverride.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetrics.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetrics.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetricsUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetricsUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/test/io/ktor/server/metrics/dropwizard/DropwizardMetricsTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/test/io/ktor/server/metrics/dropwizard/DropwizardMetricsTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/src/io/ktor/server/mustache/Mustache.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/src/io/ktor/server/mustache/Mustache.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/src/io/ktor/server/mustache/RespondTemplate.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/src/io/ktor/server/mustache/RespondTemplate.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/test/io/ktor/server/mustache/MustacheTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/test/io/ktor/server/mustache/MustacheTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/src/io/ktor/server/plugins/openapi/OpenAPI.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/src/io/ktor/server/plugins/openapi/OpenAPI.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/src/io/ktor/server/plugins/openapi/OpenAPIConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/src/io/ktor/server/plugins/openapi/OpenAPIConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/test/io/ktor/server/plugins/openapi/OpenAPITest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-openapi/jvm/test/io/ktor/server/plugins/openapi/OpenAPITest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvm/src/io/ktor/server/plugins/partialcontent/MultipleRangeWriter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvm/src/io/ktor/server/plugins/partialcontent/MultipleRangeWriter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvm/test/io/ktor/tests/ByteRangesChannelTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvm/test/io/ktor/tests/ByteRangesChannelTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/BodyTransformedHook.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/BodyTransformedHook.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/MultipleRangeWriter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/MultipleRangeWriter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/PartialContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/PartialContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/PartialContentUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/PartialContentUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/PartialOutgoingContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/PartialOutgoingContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/nix/src/io/ktor/server/plugins/partialcontent/MultipleRangeWriterNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/nix/src/io/ktor/server/plugins/partialcontent/MultipleRangeWriterNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/src/io/ktor/server/pebble/Pebble.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/src/io/ktor/server/pebble/Pebble.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/src/io/ktor/server/pebble/RespondTemplate.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/src/io/ktor/server/pebble/RespondTemplate.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test/io/ktor/server/pebble/PebbleTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-pebble/jvm/test/io/ktor/server/pebble/PebbleTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/DefaultRateLimiter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/DefaultRateLimiter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimit.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimit.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimitConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimitConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimitInterceptors.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimitInterceptors.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimiter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimiter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/Routing.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/Routing.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/src/io/ktor/server/plugins/requestvalidation/RequestValidation.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/src/io/ktor/server/plugins/requestvalidation/RequestValidation.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/src/io/ktor/server/plugins/requestvalidation/RequestValidationConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/src/io/ktor/server/plugins/requestvalidation/RequestValidationConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/test/io/ktor/server/plugins/requestvalidation/RequestValidationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/test/io/ktor/server/plugins/requestvalidation/RequestValidationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvm/test/io/ktor/tests/resources/ResourcesTestJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvm/test/io/ktor/tests/resources/ResourcesTestJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/src/io/ktor/server/resources/Resources.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/src/io/ktor/server/resources/Resources.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/src/io/ktor/server/resources/Routing.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/src/io/ktor/server/resources/Routing.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/Verifiers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/Verifiers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/CacheJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/CacheJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/CacheStorageJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/CacheStorageJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/DirectoryStorage.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/DirectoryStorage.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerEncrypt.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerEncrypt.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerMessageAuthentication.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionTransportTransformerMessageAuthentication.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/CacheTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/CacheTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/DirectorySessionStorageTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/DirectorySessionStorageTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/SessionsBackwardCompatibleFormatTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/test/io/ktor/tests/sessions/SessionsBackwardCompatibleFormatTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/BeforeSend.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/BeforeSend.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/Cache.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/Cache.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/CacheStorage.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/CacheStorage.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/KotlinTimeJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/KotlinTimeJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionData.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionData.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionIdProvider.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionIdProvider.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionProvider.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionProvider.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionSerializer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionSerializer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionStorage.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionStorage.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionStorageMemory.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionStorageMemory.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTracker.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTracker.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTrackerById.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTrackerById.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTrackerByValue.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTrackerByValue.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTransport.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTransport.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTransportCookie.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTransportCookie.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTransportHeader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTransportHeader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTransportTransformer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTransportTransformer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/Sessions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/Sessions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionsBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionsBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionsConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionsConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/KotlinxSessionSerializer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/KotlinxSessionSerializer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/ListLikeDecoder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/ListLikeDecoder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/MapDecoder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/MapDecoder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/SessionsBackwardCompatibleDecoder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/SessionsBackwardCompatibleDecoder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/SessionsBackwardCompatibleEncoder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/SessionsBackwardCompatibleEncoder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/test/io/ktor/server/sessions/CacheTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/test/io/ktor/server/sessions/CacheTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/test/io/ktor/server/sessions/SessionTransportCookieTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/test/io/ktor/server/sessions/SessionTransportCookieTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/test/io/ktor/server/sessions/SessionTransportTransformerKtTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/test/io/ktor/server/sessions/SessionTransportTransformerKtTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/nix/src/io/ktor/server/sessions/CacheStorageNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/nix/src/io/ktor/server/sessions/CacheStorageNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/nix/src/io/ktor/server/sessions/SessionSerializerNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/nix/src/io/ktor/server/sessions/SessionSerializerNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvm/src/io/ktor/server/plugins/statuspages/StatusPagesJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvm/src/io/ktor/server/plugins/statuspages/StatusPagesJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvm/src/io/ktor/server/plugins/statuspages/StatusPagesUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvm/src/io/ktor/server/plugins/statuspages/StatusPagesUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/src/io/ktor/server/plugins/statuspages/StatusPages.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/src/io/ktor/server/plugins/statuspages/StatusPages.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/src/io/ktor/server/plugins/statuspages/StatusPagesUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/src/io/ktor/server/plugins/statuspages/StatusPagesUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/nix/src/io/ktor/server/plugins/statuspages/StatusPagesUtilsNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/nix/src/io/ktor/server/plugins/statuspages/StatusPagesUtilsNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/SwaggerConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/SwaggerConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/test/io/ktor/server/plugins/swagger/SwaggerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/test/io/ktor/server/plugins/swagger/SwaggerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/RespondTemplate.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/RespondTemplate.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/Thymeleaf.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/src/io/ktor/server/thymeleaf/Thymeleaf.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/test/io/ktor/server/thymeleaf/ThymeleafTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/test/io/ktor/server/thymeleaf/ThymeleafTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/src/io/ktor/server/velocity/RespondTemplate.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/src/io/ktor/server/velocity/RespondTemplate.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/src/io/ktor/server/velocity/Velocity.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/src/io/ktor/server/velocity/Velocity.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/src/io/ktor/server/velocity/VelocityTools.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/src/io/ktor/server/velocity/VelocityTools.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityToolsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityToolsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/Webjars.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/Webjars.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/WebjarsUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/WebjarsUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/test/io/ktor/server/webjars/WebjarsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/test/io/ktor/server/webjars/WebjarsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/src/io/ktor/server/websocket/Durations.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/src/io/ktor/server/websocket/Durations.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/ParserTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/ParserTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketWithContentNegotiationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketWithContentNegotiationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WriterTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WriterTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/KotlinDurations.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/KotlinDurations.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/Routing.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/Routing.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/WebSocketServerSession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/WebSocketServerSession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/WebSocketUpgrade.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/WebSocketUpgrade.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/WebSockets.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/src/io/ktor/server/websocket/WebSockets.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/DefaultWebSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/DefaultWebSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/RawWebSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/RawWebSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/AsyncServlet.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/AsyncServlet.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/Attributes.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/Attributes.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/BlockingServlet.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/BlockingServlet.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/JAASBridge.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/JAASBridge.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServlet.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServlet.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationRequestCookies.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationRequestCookies.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationRequestHeaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationRequestHeaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletConnectionPoint.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletConnectionPoint.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletReader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletReader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletUpgrade.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletUpgrade.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletWriter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletWriter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/WebResources.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/WebResources.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/v4/Push.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/v4/Push.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/test/io/ktor/tests/servlet/jakarta/HoconTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/test/io/ktor/tests/servlet/jakarta/HoconTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/AsyncServlet.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/AsyncServlet.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/Attributes.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/Attributes.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/BlockingServlet.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/BlockingServlet.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/JAASBridge.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/JAASBridge.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequestCookies.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequestCookies.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequestHeaders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationRequestHeaders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletConnectionPoint.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletConnectionPoint.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletReader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletReader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletWriter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletWriter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/WebResources.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/WebResources.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/v4/Push.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/v4/Push.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/test/io/ktor/tests/servlet/HoconTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/test/io/ktor/tests/servlet/HoconTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/BaseTestJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/BaseTestJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBaseJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBaseJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/FreePorts.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/FreePorts.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/StressSuiteRunner.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/StressSuiteRunner.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngineJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationEngineJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationRequestJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationRequestJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponseJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestApplicationResponseJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestEngineJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/TestEngineJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestEngineWebsocketSession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestEngineWebsocketSession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngineBridgeJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/client/TestHttpClientEngineBridgeJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/internal/CoroutineUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/internal/CoroutineUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/test/TestApplicationTestJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/test/TestApplicationTestJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/BaseTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/BaseTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/EngineTestBase.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/EngineTestBase.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationCall.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationCall.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationRequest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationRequest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationResponse.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationResponse.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/Utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/Utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/DelegatingTestClientEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/DelegatingTestClientEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/TestHttpClientConfig.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/TestHttpClientConfig.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/TestHttpClientEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/client/TestHttpClientEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/internal/CoroutineUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/internal/CoroutineUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationRequestTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationRequestTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/BaseTestNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/BaseTestNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/EngineTestBaseNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/EngineTestBaseNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/TestEngineNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/TestEngineNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/client/TestHttpClientEngineBridgeNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/client/TestHttpClientEngineBridgeNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/internal/CoroutineUtilsNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/nix/src/io/ktor/server/testing/internal/CoroutineUtilsNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ClientCertTestSuite.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ClientCertTestSuite.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/CompressionTestSuite.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/CompressionTestSuite.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ConfigTestSuite.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ConfigTestSuite.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ConnectionTestSuite.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ConnectionTestSuite.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ServerPluginsTestSuite.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ServerPluginsTestSuite.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/Utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/Utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/HttpServerCommonTestSuite.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/HttpServerCommonTestSuite.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/ApplicationRequestContentTestJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/ApplicationRequestContentTestJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/RespondFunctionsJvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/RespondFunctionsJvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/RespondWriteTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/RespondWriteTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/Empty1.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/Empty1.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/Empty2.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/Empty2.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/Empty3.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/Empty3.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/SinglePageApplicationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/SinglePageApplicationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/AutoHeadResponseJvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/AutoHeadResponseJvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/ConditionalHeadersJvmTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/ConditionalHeadersJvmTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CookiesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CookiesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/DataConversionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/DataConversionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/PartialContentTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/PartialContentTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/StaticContentTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/StaticContentTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/AutoSerializerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/AutoSerializerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/SessionTestJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/SessionTestJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/testing/TestApplicationEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/testing/TestApplicationEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/src/Stub.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/src/Stub.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/ApplicationEventTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/ApplicationEventTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/ApplicationRequestHeaderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/ApplicationRequestHeaderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/HandlerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/HandlerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ApplicationRequestContentTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ApplicationRequestContentTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/DefaultPushTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/DefaultPushTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/HeadersServerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/HeadersServerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/RespondFunctionsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/RespondFunctionsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ServerURLBuilderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ServerURLBuilderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/UrlEncodedTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/UrlEncodedTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/AutoHeadResponseTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/AutoHeadResponseTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/Base64EncodingCookiesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/Base64EncodingCookiesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CORSTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CORSTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CachingHeadersTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CachingHeadersTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CallIdTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CallIdTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/ConditionalHeadersTests.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/ConditionalHeadersTests.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CookiesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CookiesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/DQuotesCookiesEncodingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/DQuotesCookiesEncodingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/DataConversionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/DataConversionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/HSTSTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/HSTSTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/HttpsRedirectPluginTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/HttpsRedirectPluginTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/OriginConnectionPointTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/OriginConnectionPointTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/ParserServerSetCookieTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/ParserServerSetCookieTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/PartialContentTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/PartialContentTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/RateLimitTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/RateLimitTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/RawCookieTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/RawCookieTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/URIEncodingCookiesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/URIEncodingCookiesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/XHttpMethodOverrideTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/XHttpMethodOverrideTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingBuildTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingBuildTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingResolveTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingResolveTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingTracingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingTracingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/sessions/SessionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/sessions/SessionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/Embedded.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/Embedded.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/EngineMain.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/EngineMain.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/TomcatApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/TomcatApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatWebSocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/test/io/ktor/tests/server/tomcat/jakarta/TomcatWebSocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/Embedded.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/Embedded.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/EngineMain.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/EngineMain.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/test/io/ktor/tests/server/tomcat/TomcatEngineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-events/common/src/io/ktor/events/Events.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-events/common/src/io/ktor/events/Events.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/Resource.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/Resource.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/ResourceSerializationException.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/ResourceSerializationException.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/Resources.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/Resources.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/UrlBuilder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/UrlBuilder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/serialization/Decoders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/serialization/Decoders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/serialization/ParametersEncoder.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/serialization/ParametersEncoder.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/serialization/ResourcesFormat.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/serialization/ResourcesFormat.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/test/io/ktor/tests/resources/ParametersSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/test/io/ktor/tests/resources/ParametersSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/test/io/ktor/tests/resources/PathPatternSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/test/io/ktor/tests/resources/PathPatternSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/test/io/ktor/tests/resources/ResourceUrlBuilderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/test/io/ktor/tests/resources/ResourceUrlBuilderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/common/src/ContentConvertException.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/common/src/ContentConvertException.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/common/src/ContentConverter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/common/src/ContentConverter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/common/src/WebsocketContentConverter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/common/src/WebsocketContentConverter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/src/GsonConverter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/src/GsonConverter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/src/GsonWebsocketContentConverter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/src/GsonWebsocketContentConverter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ClientGsonTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ClientGsonTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/GsonContentNegotiationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/GsonContentNegotiationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/GsonWebsocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/GsonWebsocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ServerGsonBlockingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ServerGsonBlockingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ServerGsonTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ServerGsonTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonConverter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonWebsocketContentConverter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/src/JacksonWebsocketContentConverter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ClientJacksonTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ClientJacksonTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/JacksonContentNegotiationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/JacksonContentNegotiationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/JacksonWebsocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/JacksonWebsocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonBlockingTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonBlockingTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/Extensions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/Extensions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/KotlinxSerializationConverter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/KotlinxSerializationConverter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/KotlinxWebsocketSerializationConverter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/KotlinxWebsocketSerializationConverter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/SerializerLookup.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/SerializerLookup.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/js/src/io/ktor/serialization/kotlinx/ExtensionsJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/js/src/io/ktor/serialization/kotlinx/ExtensionsJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/jvm/src/io/ktor/serialization/kotlinx/ExtensionsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/jvm/src/io/ktor/serialization/kotlinx/ExtensionsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/common/src/io/ktor/serialization/kotlinx/cbor/CborSupport.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/common/src/io/ktor/serialization/kotlinx/cbor/CborSupport.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/common/test/CborContextualSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/common/test/CborContextualSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/common/test/CborSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/common/test/CborSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/jvm/test/CborClientKotlinxSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/jvm/test/CborClientKotlinxSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/jvm/test/CborServerKotlinxSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-cbor/jvm/test/CborServerKotlinxSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/JsonSupport.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/JsonSupport.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/KotlinxSerializationJsonExtensions.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/src/io/ktor/serialization/kotlinx/json/KotlinxSerializationJsonExtensions.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/test/JsonContextualSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/test/JsonContextualSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/test/JsonSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/test/JsonSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/js/src/io/ktor/serialization/kotlinx/json/JsonExtensionsJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/js/src/io/ktor/serialization/kotlinx/json/JsonExtensionsJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/src/io/ktor/serialization/kotlinx/json/JsonExtensionsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/src/io/ktor/serialization/kotlinx/json/JsonExtensionsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/JsonClientKotlinxSerializationJsonJvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/JsonClientKotlinxSerializationJsonJvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/JsonClientKotlinxSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/JsonClientKotlinxSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/JsonServerKotlinxSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/JsonServerKotlinxSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/KotlinxContentNegotiationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/KotlinxContentNegotiationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/KotlinxJsonWebsocketTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/jvm/test/KotlinxJsonWebsocketTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/posix/src/io/ktor/serialization/kotlinx/json/JsonExtensionsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/posix/src/io/ktor/serialization/kotlinx/json/JsonExtensionsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/common/src/io/ktor/serialization/kotlinx/protobuf/ProtoBufSupport.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/common/src/io/ktor/serialization/kotlinx/protobuf/ProtoBufSupport.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/common/test/ProtoBufContextualSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/common/test/ProtoBufContextualSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/common/test/ProtoBufSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/common/test/ProtoBufSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/jvm/test/ProtoBufClientKotlinxSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/jvm/test/ProtoBufClientKotlinxSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/jvm/test/ProtoBufServerKotlinxSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-protobuf/jvm/test/ProtoBufServerKotlinxSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-tests/common/src/AbstractContextualSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-tests/common/src/AbstractContextualSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-tests/common/src/AbstractSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-tests/common/src/AbstractSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-tests/jvm/src/AbstractServerSerializationKotlinxTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-tests/jvm/src/AbstractServerSerializationKotlinxTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/jvm/src/io/ktor/serialization/kotlinx/xml/XmlSupport.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/jvm/src/io/ktor/serialization/kotlinx/xml/XmlSupport.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/jvm/test/XmlClientKotlinxSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/jvm/test/XmlClientKotlinxSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/jvm/test/XmlSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/jvm/test/XmlSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/jvm/test/XmlServerKotlinxSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-xml/jvm/test/XmlServerKotlinxSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/posix/src/io/ktor/serialization/kotlinx/ExtensionsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/posix/src/io/ktor/serialization/kotlinx/ExtensionsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-tests/jvm/src/AbstractServerSerializationTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-tests/jvm/src/AbstractServerSerializationTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websocket-serialization/common/src/io/ktor/websocket/serialization/WebsocketChannelSerialization.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websocket-serialization/common/src/io/ktor/websocket/serialization/WebsocketChannelSerialization.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/CloseReason.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/CloseReason.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/FrameCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/FrameCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/FrameTooBigException.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/FrameTooBigException.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/FrameType.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/FrameType.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/ProtocolViolationException.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/ProtocolViolationException.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/Utils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/Utils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketExtension.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketExtension.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketExtensionHeader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketExtensionHeader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketSession.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketSession.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/test/io/ktor/tests/http/cio/websocket/FrameCloseTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/test/io/ktor/tests/http/cio/websocket/FrameCloseTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/test/io/ktor/tests/http/cio/websocket/WebSocketExtensionHeaderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/test/io/ktor/tests/http/cio/websocket/WebSocketExtensionHeaderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/js/src/io/ktor/websocket/FrameJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/js/src/io/ktor/websocket/FrameJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/js/src/io/ktor/websocket/RawWebSocket.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/js/src/io/ktor/websocket/RawWebSocket.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/Frame.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/Frame.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/RawWebSocketJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/RawWebSocketJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/Serializer.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/Serializer.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/SimpleFrameCollector.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/SimpleFrameCollector.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/UtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/UtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketDeflateExtension.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketDeflateExtension.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketReader.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketReader.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketWriter.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketWriter.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/internals/BytePacketUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/internals/BytePacketUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/internals/DeflaterUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/internals/DeflaterUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/test/WebSocketDeflateTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/test/WebSocketDeflateTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/test/WebSocketReaderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/test/WebSocketReaderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/posix/src/io/ktor/websocket/FrameNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/posix/src/io/ktor/websocket/FrameNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/posix/src/io/ktor/websocket/RawWebSocket.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/posix/src/io/ktor/websocket/RawWebSocket.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/common/src/TestCommon.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/common/src/TestCommon.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/darwin/src/TestDarwin.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/darwin/src/TestDarwin.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/js/src/TestJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/js/src/TestJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/jvm/src/TestJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/jvm/src/TestJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/linuxX64/src/TestLinuxX64.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/linuxX64/src/TestLinuxX64.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/mingwX64/src/TestMingwX64.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/mingwX64/src/TestMingwX64.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/posix/src/TestWorker.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-test-dispatcher/posix/src/TestWorker.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Annotations.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Annotations.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Attributes.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Attributes.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Base64.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Base64.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/ByteChannels.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/ByteChannels.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Bytes.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Bytes.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/CaseInsensitiveMap.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/CaseInsensitiveMap.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/CaseInsensitiveSet.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/CaseInsensitiveSet.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Charset.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Charset.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Collections.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Collections.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/CoroutinesUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/CoroutinesUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Crypto.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Crypto.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/DelegatingMutableSet.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/DelegatingMutableSet.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Encoders.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Encoders.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Hash.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Hash.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/HashFunction.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/HashFunction.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/NonceManager.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/NonceManager.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/PlatformUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/PlatformUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Ranges.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Ranges.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/StackFrames.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/StackFrames.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/StringValues.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/StringValues.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Text.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Text.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Throwable.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Throwable.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/cio/Channels.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/cio/Channels.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/cio/Readers.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/cio/Readers.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/collections/CollectionUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/collections/CollectionUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/collections/ConcurrentMap.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/collections/ConcurrentMap.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/collections/ConcurrentSet.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/collections/ConcurrentSet.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/collections/CopyOnWriteHashMap.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/collections/CopyOnWriteHashMap.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/converters/ConversionService.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/converters/ConversionService.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/converters/DataConversion.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/converters/DataConversion.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/date/Date.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/date/Date.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/date/GMTDateParser.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/date/GMTDateParser.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/debug/ContextUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/debug/ContextUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/debug/IntellijIdeaDebugDetector.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/debug/IntellijIdeaDebugDetector.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/debug/plugins/PluginName.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/debug/plugins/PluginName.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/debug/plugins/PluginsTrace.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/debug/plugins/PluginsTrace.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/internal/ExceptionUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/internal/ExceptionUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/internal/LockFreeLinkedList.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/internal/LockFreeLinkedList.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/logging/KtorSimpleLogger.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/logging/KtorSimpleLogger.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/logging/Logger.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/logging/Logger.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/network/NetworkAddress.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/network/NetworkAddress.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/DebugPipelineContext.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/DebugPipelineContext.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/PhaseContent.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/PhaseContent.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/Pipeline.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/Pipeline.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/PipelineContext.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/PipelineContext.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/PipelinePhase.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/PipelinePhase.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/PipelinePhaseRelation.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/PipelinePhaseRelation.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/StackTraceRecover.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/StackTraceRecover.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/StackWalkingFailed.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/StackWalkingFailed.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/StackWalkingFailedFrame.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/StackWalkingFailedFrame.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/SuspendFunctionGun.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/SuspendFunctionGun.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/reflect/Type.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/reflect/Type.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/Base64Test.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/Base64Test.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/CaseInsensitiveMapTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/CaseInsensitiveMapTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/ChannelTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/ChannelTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/GMTDateParserTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/GMTDateParserTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/GMTDateTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/GMTDateTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/HashFunctionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/HashFunctionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/NonceTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/NonceTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/PipelineContractsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/PipelineContractsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/PipelinePhasesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/PipelinePhasesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/StringValuesBuilderTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/StringValuesBuilderTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/StringValuesTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/StringValuesTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/converters/DataConversionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/converters/DataConversionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/darwin/src/io/ktor/util/ThreadInfoDarwin.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/darwin/src/io/ktor/util/ThreadInfoDarwin.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/AttributesJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/AttributesJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/CollectionsJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/CollectionsJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/CryptoJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/CryptoJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/PlatformUtilsJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/PlatformUtilsJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/StackFramesJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/StackFramesJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/collections/ConcurrentMapJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/collections/ConcurrentMapJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/converters/ConversionServiceJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/converters/ConversionServiceJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/date/DateJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/date/DateJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/debug/IntellijIdeaDebugDetectorJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/debug/IntellijIdeaDebugDetectorJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/internal/ExceptionUtilsJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/internal/ExceptionUtilsJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/logging/KtorSimpleLoggerJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/logging/KtorSimpleLoggerJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/logging/LoggerJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/logging/LoggerJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/network/NetworkAddressJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/network/NetworkAddressJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/pipeline/PipelineContext.js.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/pipeline/PipelineContext.js.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/pipeline/StackTraceRecoverJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/pipeline/StackTraceRecoverJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/reflect/TypeInfoJs.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/reflect/TypeInfoJs.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/test/io.ktor.util/CryptoTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/test/io.ktor.util/CryptoTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/AttributesJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/AttributesJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/BufferViewJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/BufferViewJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Cache.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Cache.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/CollectionsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/CollectionsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Deflater.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Deflater.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/InputJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/InputJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/NIO.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/NIO.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/NioPath.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/NioPath.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Nonce.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Nonce.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Path.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Path.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/PlatformUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/PlatformUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/StackFramesJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/StackFramesJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/StatelessHmacNonceManager.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/StatelessHmacNonceManager.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/ByteBufferPool.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/ByteBufferPool.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/FileChannels.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/FileChannels.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/FileChannelsAtNioPath.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/FileChannelsAtNioPath.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/InputStreamAdapters.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/InputStreamAdapters.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/OutputStreamAdapters.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/OutputStreamAdapters.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/ReadersJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/ReadersJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/Semaphore.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/Semaphore.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/collections/ConcurrentMapJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/collections/ConcurrentMapJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/converters/ConversionServiceJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/converters/ConversionServiceJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/date/DateJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/date/DateJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/debug/IntellijIdeaDebugDetectorJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/debug/IntellijIdeaDebugDetectorJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/internal/ExceptionUtilsJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/internal/ExceptionUtilsJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/logging/KtorSimpleLoggerJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/logging/KtorSimpleLoggerJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/logging/LoggerJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/logging/LoggerJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/network/NetworkAddressJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/network/NetworkAddressJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/pipeline/PipelineContext.jvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/pipeline/PipelineContext.jvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/pipeline/StackTraceRecoverJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/pipeline/StackTraceRecoverJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/reflect/TypeInfoJvm.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/reflect/TypeInfoJvm.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/CacheTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/CacheTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/DeflaterReadChannelTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/DeflaterReadChannelTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/DropLeadingTopDirsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/DropLeadingTopDirsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/FileChannelTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/FileChannelTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/HexFunctionsTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/HexFunctionsTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/InputJvmTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/InputJvmTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/NonceSmokeTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/NonceSmokeTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/PipelineTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/PipelineTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/StackWalkingFailedTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/StackWalkingFailedTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/StatelessHmacNonceManagerTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/StatelessHmacNonceManagerTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/converters/DataConversionTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/converters/DataConversionTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/util/HashFunctionConsistencyTest.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/util/HashFunctionConsistencyTest.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/linuxX64/src/io/ktor/util/ThreadInfoLinux.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/linuxX64/src/io/ktor/util/ThreadInfoLinux.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/mingwX64/src/io/ktor/util/CryptoMingw.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/mingwX64/src/io/ktor/util/CryptoMingw.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/mingwX64/src/io/ktor/util/ThreadInfoMingw.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/mingwX64/src/io/ktor/util/ThreadInfoMingw.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/mingwX64/src/io/ktor/util/date/DateMingw.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/mingwX64/src/io/ktor/util/date/DateMingw.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/nix/src/io/ktor/util/CryptoPosix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/nix/src/io/ktor/util/CryptoPosix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/nix/src/io/ktor/util/date/DateNix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/nix/src/io/ktor/util/date/DateNix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/AttributesNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/AttributesNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/CollectionsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/CollectionsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/CoroutineUtils.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/CoroutineUtils.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/CryptoNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/CryptoNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/PlatformUtilsNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/PlatformUtilsNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/StackFramesNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/StackFramesNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/ThreadInfo.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/ThreadInfo.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/collections/LockFreeMPSCQueueNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/collections/LockFreeMPSCQueueNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/converters/ConversionServiceNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/converters/ConversionServiceNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/date/DateNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/date/DateNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/debug/IntellijIdeaDebugDetectorNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/debug/IntellijIdeaDebugDetectorNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/internal/ExceptionUtilsPosix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/internal/ExceptionUtilsPosix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/logging/KtorSimpleLoggerNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/logging/KtorSimpleLoggerNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/logging/LogLevelNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/logging/LogLevelNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/logging/LoggerNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/logging/LoggerNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/network/NetworkAddressNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/network/NetworkAddressNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/pipeline/PipelineContext.posix.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/pipeline/PipelineContext.posix.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/pipeline/StackTraceRecoverNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/pipeline/StackTraceRecoverNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/reflect/TypeInfoNative.kt':[
-0,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/reflect/TypeInfoNative.kt": [
+0
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/test/io/ktor/util/MultiWorkerDispatcherTest.kt':[
-0,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/test/io/ktor/util/MultiWorkerDispatcherTest.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1451.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1451.json
@@ -4013,6 +4013,9 @@
 "kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-http-redirect/jvmAndNix/src/io/ktor/server/plugins/httpsredirect/HttpsRedirect.kt": [
 0
 ],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jte-classes/gg/jte/generated/ondemand/JtetestGenerated.kt": [
+0
+],
 "kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/src/io/ktor/server/jte/Jte.kt": [
 0
 ],

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1451.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1451.json
@@ -4013,9 +4013,6 @@
 "kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-http-redirect/jvmAndNix/src/io/ktor/server/plugins/httpsredirect/HttpsRedirect.kt": [
 0
 ],
-"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jte-classes/gg/jte/generated/ondemand/JtetestGenerated.kt": [
-0
-],
 "kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/src/io/ktor/server/jte/Jte.kt": [
 0
 ],

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1481.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1481.json
@@ -1,103 +1,103 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/CommonConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/CommonConfig.kt": [
 12,
-18,
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Publication.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Publication.kt": [
 80,
-165,
+165
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngineConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheEngineConfig.kt": [
 66,
-74,
+74
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5EngineConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5EngineConfig.kt": [
 58,
-66,
+66
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt':[
-57,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCacheEntry.kt": [
+57
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt':[
-75,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt": [
+75
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngineConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/DarwinLegacyClientEngineConfig.kt": [
 72,
-85,
+85
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyCertificatePinner.kt':[
-345,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyCertificatePinner.kt": [
+345
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/DarwinClientEngineConfig.kt": [
 73,
-86,
+86
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt':[
-345,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt": [
+345
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt':[
-59,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt": [
+59
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpConfig.kt':[
-43,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpConfig.kt": [
+43
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Ranges.kt':[
-100,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Ranges.kt": [
+100
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/PrimitiveArraysJs.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/bits/PrimitiveArraysJs.kt": [
 298,
-305,
+305
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt':[
-479,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt": [
+479
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt':[
-116,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt": [
+116
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt':[
-53,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt": [
+53
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt": [
 322,
 323,
 377,
-378,
+378
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt':[
-210,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt": [
+210
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt':[
-32,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt": [
+32
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Authentication.kt':[
-24,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Authentication.kt": [
+24
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BasicAuth.kt':[
-121,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BasicAuth.kt": [
+121
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-id/jvmAndNix/src/io/ktor/server/plugins/callid/CallId.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-id/jvmAndNix/src/io/ktor/server/plugins/callid/CallId.kt": [
 186,
 187,
-265,
+265
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/PartialContentUtils.kt':[
-24,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/PartialContentUtils.kt": [
+24
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/Webjars.kt':[
-46,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/Webjars.kt": [
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/WebResources.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/WebResources.kt": [
 74,
-76,
+76
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/WebResources.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/WebResources.kt": [
 73,
-75,
+75
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt':[
-117,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplication.kt": [
+117
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/ThreadInfo.kt':[
-25,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/ThreadInfo.kt": [
+25
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1481.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1481.json
@@ -1,8 +1,4 @@
 {
-"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/CommonConfig.kt": [
-12,
-18
-],
 "kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Publication.kt": [
 80,
 165

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1656.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1656.json
@@ -1,5 +1,5 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt':[
-150,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt": [
+150
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1764.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1764.json
@@ -1,5 +1,5 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/GMTDateTest.kt':[
-45,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/test/io/ktor/util/GMTDateTest.kt": [
+45
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1821.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1821.json
@@ -1,71 +1,71 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt':[
-120,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt": [
+120
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ContentTypes.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ContentTypes.kt": [
 70,
-78,
+78
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Cookie.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Cookie.kt": [
 169,
 177,
-193,
+193
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Parameters.kt':[
-93,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Parameters.kt": [
+93
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/regex/RegexParserGenerator.kt':[
-53,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/parsing/regex/RegexParserGenerator.kt": [
+53
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ConnectionOptions.kt':[
-114,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ConnectionOptions.kt": [
+114
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt": [
 417,
-488,
+488
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ExceptionUtilsJvm.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ExceptionUtilsJvm.kt": [
 72,
-77,
+77
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/PosixIoTest.kt':[
-48,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/PosixIoTest.kt": [
+48
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt':[
-246,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt": [
+246
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/DefaultTransformJvm.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/DefaultTransformJvm.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/MapApplicationConfig.kt':[
-106,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/MapApplicationConfig.kt": [
+106
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/Route.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/Route.kt": [
 125,
-129,
+129
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt':[
-86,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt": [
+86
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultTransform.kt':[
-45,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultTransform.kt": [
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/ServerInitializer.kt':[
-56,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/ServerInitializer.kt": [
+56
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt':[
-56,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt": [
+56
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestAuth.kt':[
-66,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/DigestAuth.kt": [
+66
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt':[
-287,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt": [
+287
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt':[
-146,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt": [
+146
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt": [
 156,
 167,
 178,
@@ -77,9 +77,9 @@
 335,
 344,
 350,
-372,
+372
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/converters/ConversionService.kt':[
-40,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/converters/ConversionService.kt": [
+40
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1871.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1871.json
@@ -1,21 +1,21 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/FormDataContent.kt':[
-66,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/FormDataContent.kt": [
+66
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/test/ContentNegotiationJvmTest.kt':[
-132,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/test/ContentNegotiationJvmTest.kt": [
+132
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt':[
-172,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt": [
+172
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationRequest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationRequest.kt": [
 162,
-207,
+207
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/testing/TestApplicationEngineTest.kt':[
-308,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/testing/TestApplicationEngineTest.kt": [
+308
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt':[
-188,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt": [
+188
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1874.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S1874.json
@@ -1,11 +1,11 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Multithreaded.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Multithreaded.kt": [
 19,
-20,
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/pool/DefaultPool.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/pool/DefaultPool.kt": [
 24,
 36,
-47,
-],
+47
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S2068.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S2068.json
@@ -1,46 +1,46 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Auth.kt':[
-27,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Auth.kt": [
+27
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/AndroidHttpsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/AndroidHttpsTest.kt": [
 61,
 67,
 73,
-79,
+79
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt": [
 66,
 72,
 78,
-84,
+84
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt": [
 89,
-156,
+156
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/URLBuilderTest.kt": [
 320,
-323,
+323
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/test/io/ktor/tests/http/UrlTest.kt": [
 41,
 271,
-300,
+300
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/KeyStoreBuilderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/KeyStoreBuilderTest.kt": [
 26,
 49,
 62,
 80,
 96,
-111,
+111
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt": [
 113,
 114,
-115,
+115
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthBuildersTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthBuildersTest.kt": [
 82,
 89,
 110,
@@ -67,12 +67,12 @@
 547,
 860,
 866,
-872,
+872
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ServerURLBuilderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ServerURLBuilderTest.kt": [
 112,
 112,
 113,
-113,
-],
+113
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S2097.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S2097.json
@@ -1,17 +1,17 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/DelegatingMutableSet.kt':[
-50,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/DelegatingMutableSet.kt": [
+50
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/StringValues.kt':[
-118,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/StringValues.kt": [
+118
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/collections/ConcurrentMapJs.kt':[
-64,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/collections/ConcurrentMapJs.kt": [
+64
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/collections/ConcurrentMapJvm.kt':[
-59,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/collections/ConcurrentMapJvm.kt": [
+59
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt':[
-73,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/collections/ConcurrentMapNative.kt": [
+73
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S2245.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S2245.json
@@ -1,30 +1,30 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/BytePacketReaderWriterTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/BytePacketReaderWriterTest.kt": [
 216,
 228,
 240,
-254,
+254
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/StreamTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/StreamTest.kt": [
+35
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ToByteReadChannelTest.kt": [
 35,
+65
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ToByteReadChannelTest.kt':[
-35,
-65,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt": [
+333
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt':[
-333,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt": [
+308
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt':[
-308,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt": [
 48,
 350,
 391,
-420,
+420
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/CacheTest.kt':[
-54,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/CacheTest.kt": [
+54
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S3776.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S3776.json
@@ -1,242 +1,242 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Publication.kt':[
-56,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Publication.kt": [
+56
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/TargetsConfig.kt':[
-24,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/TargetsConfig.kt": [
+24
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Auth.kt':[
-17,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Auth.kt": [
+17
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Content.kt':[
-18,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Content.kt": [
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Timeout.kt':[
-15,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Timeout.kt": [
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/WebSockets.kt':[
-11,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/WebSockets.kt": [
+11
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt':[
-98,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt": [
+98
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt':[
-144,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt": [
+144
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt':[
-26,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt": [
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt':[
-27,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt": [
+27
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt':[
-136,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt": [
+136
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt':[
-86,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt": [
+86
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt':[
-174,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt": [
+174
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Codecs.kt':[
-187,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Codecs.kt": [
+187
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt':[
-117,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt": [
+117
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLParser.kt':[
-33,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLParser.kt": [
+33
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt':[
-148,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/auth/HttpAuthHeader.kt": [
+148
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ChunkedTransferEncoding.kt':[
-69,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ChunkedTransferEncoding.kt": [
+69
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ConnectionOptions.kt':[
-54,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/ConnectionOptions.kt": [
+54
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt':[
-67,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt": [
+67
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt": [
 277,
 386,
-461,
+461
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt": [
 49,
-186,
+186
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/UTF8.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/UTF8.kt": [
 24,
-120,
+120
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt':[
-353,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt": [
+353
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/TakeWhileTest.kt':[
-119,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/TakeWhileTest.kt": [
+119
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
 1168,
-1940,
+1940
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/Delimited.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/Delimited.kt": [
 66,
-116,
+116
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt": [
 55,
 179,
-268,
+268
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/UTF.kt": [
 122,
 215,
 299,
-420,
+420
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Channels.kt':[
-67,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/nio/Channels.kt": [
+67
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt": [
 126,
-331,
+331
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt':[
-64,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt": [
+64
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/LockFreeMPSCQueue.kt':[
-86,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/LockFreeMPSCQueue.kt": [
+86
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt": [
 16,
-76,
+76
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt": [
 16,
-76,
+76
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketOptions.kt':[
-24,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/JavaSocketOptions.kt": [
+24
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt':[
-104,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt": [
+104
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/CipherUtils.kt':[
-15,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/CipherUtils.kt": [
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/CIOReader.kt':[
-15,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/CIOReader.kt": [
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/CIOWriter.kt':[
-16,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/CIOWriter.kt": [
+16
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt':[
-97,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt": [
+97
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt':[
-33,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt": [
+33
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt':[
-431,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/src/io/ktor/server/http/content/StaticContent.kt": [
+431
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingResolveContext.kt':[
-92,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingResolveContext.kt": [
+92
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLineJvm.kt':[
-20,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLineJvm.kt": [
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt':[
-53,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt": [
+53
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultTransform.kt':[
-36,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultTransform.kt": [
+36
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/ServerInitializer.kt':[
-15,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/ServerInitializer.kt": [
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt':[
-15,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt": [
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/src/io/ktor/server/auth/ldap/Ldap.kt':[
-92,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/src/io/ktor/server/auth/ldap/Ldap.kt": [
+92
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth.kt':[
-136,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth.kt": [
+136
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt": [
 89,
-429,
+429
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2JvmTest.kt':[
-73,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2JvmTest.kt": [
+73
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt':[
-157,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt": [
+157
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt": [
 83,
-596,
+596
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/ResponseConverter.kt':[
-18,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/ResponseConverter.kt": [
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt':[
-40,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt": [
+40
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSUtils.kt':[
-80,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORSUtils.kt": [
+80
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt':[
-178,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt": [
+178
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt':[
-327,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt": [
+327
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt": [
 565,
-600,
+600
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt": [
 293,
-415,
+415
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt':[
-97,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt": [
+97
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt':[
-323,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt": [
+323
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt": [
 356,
-482,
+482
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt':[
-159,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt": [
+159
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt':[
-45,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt": [
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketWriter.kt':[
-90,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketWriter.kt": [
+90
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/internal/LockFreeLinkedList.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/internal/LockFreeLinkedList.kt": [
 555,
 679,
-719,
+719
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt':[
-58,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt": [
+58
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Path.kt':[
-49,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Path.kt": [
+49
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/FileChannels.kt':[
-25,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/FileChannels.kt": [
+25
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/collections/LockFreeMPSCQueueNative.kt':[
-97,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/collections/LockFreeMPSCQueueNative.kt": [
+97
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S4144.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S4144.json
@@ -1,22 +1,22 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadTextCommonTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadTextCommonTest.kt": [
 54,
-71,
+71
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/BytePacketReaderWriterTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/BytePacketReaderWriterTest.kt": [
 323,
-340,
+340
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/SocketUtils.kt':[
-91,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/util/SocketUtils.kt": [
+91
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ServerURLBuilderTest.kt':[
-36,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/ServerURLBuilderTest.kt": [
+36
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/ParserServerSetCookieTest.kt':[
-37,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/ParserServerSetCookieTest.kt": [
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/PipelineTest.kt':[
-169,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/PipelineTest.kt": [
+169
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S4423.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S4423.json
@@ -1,15 +1,15 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/AndroidHttpsTest.kt':[
-86,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/AndroidHttpsTest.kt": [
+86
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt':[
-91,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt": [
+91
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/SslOverProxyTest.kt':[
-32,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/SslOverProxyTest.kt": [
+32
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBaseJvm.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBaseJvm.kt": [
 304,
-329,
-],
+329
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S4790.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S4790.json
@@ -1,17 +1,17 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt':[
-82,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/jvm/src/io/ktor/client/plugins/cache/storage/FileCacheStorage.kt": [
+82
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth1a.kt':[
-330,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/src/io/ktor/server/auth/OAuth1a.kt": [
+330
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt": [
 136,
 191,
 360,
-364,
+364
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt':[
-33,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/CryptoJvm.kt": [
+33
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S4830.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S4830.json
@@ -1,10 +1,10 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/SslOverProxyTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/SslOverProxyTest.kt": [
 27,
-28,
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBaseJvm.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBaseJvm.kt": [
 350,
-351,
-],
+351
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S5542.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S5542.json
@@ -1,5 +1,5 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Render.kt':[
-93,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/Render.kt": [
+93
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S5612.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S5612.json
@@ -1,258 +1,258 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/JsConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/JsConfig.kt": [
 27,
-28,
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/JvmConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/JvmConfig.kt": [
 25,
-28,
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Publication.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/Publication.kt": [
 84,
 103,
-105,
+105
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/TargetsConfig.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/TargetsConfig.kt": [
 30,
-42,
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/ClientTestServer.kt':[
-48,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/ClientTestServer.kt": [
+48
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Auth.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Auth.kt": [
 18,
 55,
 56,
 101,
-156,
+156
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Cache.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Cache.kt": [
 20,
-21,
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Content.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Content.kt": [
 19,
-20,
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Cookies.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Cookies.kt": [
 14,
-15,
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Download.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Download.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Encoding.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Encoding.kt": [
 16,
-17,
+17
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Headers.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Headers.kt": [
 14,
-15,
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Logging.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Logging.kt": [
 14,
-15,
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Redirect.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Redirect.kt": [
 14,
-15,
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Timeout.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/Timeout.kt": [
 16,
-17,
+17
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/WebSockets.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/buildSrc/src/main/kotlin/test/server/tests/WebSockets.kt": [
 12,
-13,
+13
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt':[
-52,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt": [
+52
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/AndroidHttpsTest.kt':[
-56,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-android/jvm/test/io/ktor/client/engine/android/AndroidHttpsTest.kt": [
+56
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt':[
-115,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheRequestProducer.kt": [
+115
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/RequestProducerTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/test/io/ktor/client/engine/apache/RequestProducerTest.kt": [
 89,
 128,
 166,
-167,
+167
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5Engine.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/Apache5Engine.kt": [
 61,
-62,
+62
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/src/io/ktor/client/engine/cio/ConnectionPipeline.kt": [
 40,
-70,
+70
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIOHttpsTest.kt": [
 61,
-99,
+99
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/CIORequestTest.kt": [
 34,
-141,
+141
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvm/test/io/ktor/client/engine/cio/ConnectErrorsTest.kt": [
 41,
 50,
 85,
 112,
 139,
-161,
+161
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt':[
-152,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/Endpoint.kt": [
+152
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/utils.kt": [
 32,
 97,
 130,
-134,
+134
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultResponseValidation.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultResponseValidation.kt": [
 25,
-29,
+29
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt": [
 28,
-61,
+61
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRequestRetry.kt':[
-274,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpRequestRetry.kt": [
+274
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpTimeout.kt':[
-144,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpTimeout.kt": [
+144
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cache/HttpCache.kt": [
 140,
-184,
+184
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/FormDataContent.kt':[
-52,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/FormDataContent.kt": [
+52
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt':[
-31,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt": [
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/ClientPluginsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/ClientPluginsTest.kt": [
 42,
-106,
+106
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/DefaultRequestTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/DefaultRequestTest.kt": [
 99,
-146,
+146
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/MultiPartFormDataContentTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/test/MultiPartFormDataContentTest.kt": [
 128,
-161,
+161
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/node/NodeFetch.kt':[
-14,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/node/NodeFetch.kt": [
+14
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/plugins/websocket/JsWebSocketSession.kt": [
 92,
-93,
+93
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-curl/desktop/src/io/ktor/client/engine/curl/internal/CurlMultiApiHandler.kt": [
 83,
-204,
+204
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyCertificatePinner.kt':[
-185,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin-legacy/darwin/src/io/ktor/client/engine/darwin/certificates/LegacyCertificatePinner.kt": [
+185
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt':[
-185,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/certificates/CertificatePinner.kt": [
+185
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt':[
-87,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/internal/DarwinWebsocketSession.kt": [
+87
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-darwin/darwin/test/DarwinEngineTest.kt": [
 163,
-205,
+205
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpWebSocket.kt": [
 89,
-91,
+91
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/JavaEngineTests.kt':[
-29,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/JavaEngineTests.kt": [
+29
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestTests.kt':[
-28,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/test/io/ktor/client/engine/java/RequestTests.kt": [
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/test/io/ktor/client/engine/jetty/jakarta/JettyHttp2EngineTest.kt':[
-28,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty-jakarta/jvm/test/io/ktor/client/engine/jetty/jakarta/JettyHttp2EngineTest.kt": [
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/test/io/ktor/client/engine/jetty/JettyHttp2EngineTest.kt':[
-28,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-jetty/jvm/test/io/ktor/client/engine/jetty/JettyHttp2EngineTest.kt": [
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineTests.kt':[
-45,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/jvm/test/io/ktor/client/tests/mock/MockEngineTests.kt": [
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt':[
-61,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttpWebsocketSession.kt": [
+61
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/Auth.kt':[
-51,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/Auth.kt": [
+51
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt':[
-475,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTest.kt": [
+475
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTokenHolderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-auth/common/test/io/ktor/client/plugins/auth/AuthTokenHolderTest.kt": [
 16,
-101,
+101
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/ContentNegotiationTests.kt": [
 111,
 164,
 196,
 228,
 259,
 348,
-375,
+375
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/IgnoreTypesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/common/test/io/ktor/client/plugins/IgnoreTypesTest.kt": [
 46,
-79,
+79
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/AbstractClientContentNegotiationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-content-negotiation/ktor-client-content-negotiation-tests/jvm/src/io/ktor/client/plugins/contentnegotiation/tests/AbstractClientContentNegotiationTest.kt": [
 83,
 123,
 193,
-251,
+251
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/test/KotlinxSerializerTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/common/test/KotlinxSerializerTest.kt": [
 48,
-82,
+82
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-json-tests/jvm/src/io/ktor/client/plugins/json/tests/JsonTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-json/ktor-client-json-tests/jvm/src/io/ktor/client/plugins/json/tests/JsonTest.kt": [
 97,
 151,
-209,
+209
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt':[
-104,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logging.kt": [
+104
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/test/io/ktor/client/plugins/logging/LoggingJsonTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/jvm/test/io/ktor/client/plugins/logging/LoggingJsonTest.kt": [
 19,
-49,
+49
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-resources/common/test/ResourcesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-resources/common/test/ResourcesTest.kt": [
 25,
-39,
+39
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/jvm/test/TracingWrapperTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-tracing/jvm/test/TracingWrapperTest.kt": [
 23,
 98,
-224,
+224
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/CommonClientTestUtils.kt':[
-69,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/src/io/ktor/client/tests/utils/CommonClientTestUtils.kt": [
+69
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CallValidatorTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CallValidatorTest.kt": [
 24,
 68,
 145,
@@ -261,9 +261,9 @@
 336,
 364,
 391,
-441,
+441
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CharsetTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/CharsetTest.kt": [
 22,
 59,
 60,
@@ -272,21 +272,21 @@
 143,
 144,
 185,
-213,
+213
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ClientPipelinesTest.kt':[
-22,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ClientPipelinesTest.kt": [
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt':[
-169,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTest.kt": [
+169
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTypeTest.kt':[
-20,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ContentTypeTest.kt": [
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt':[
-104,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/ExceptionsTest.kt": [
+104
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRequestRetryTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/HttpRequestRetryTest.kt": [
 21,
 69,
 70,
@@ -294,17 +294,17 @@
 181,
 303,
 333,
-390,
+390
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingMockedTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingMockedTests.kt": [
 21,
 66,
 131,
 187,
 256,
-301,
+301
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/LoggingTest.kt": [
 71,
 141,
 197,
@@ -312,23 +312,23 @@
 303,
 355,
 431,
-500,
+500
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MockedTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MockedTests.kt": [
 20,
 46,
-76,
+76
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MultiPartFormDataTest.kt':[
-19,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/MultiPartFormDataTest.kt": [
+19
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt':[
-34,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/PostTest.kt": [
+34
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt':[
-84,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/WebSocketTest.kt": [
+84
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheLegacyStorageTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheLegacyStorageTest.kt": [
 125,
 135,
 182,
@@ -344,9 +344,9 @@
 510,
 520,
 571,
-581,
+581
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CacheTest.kt": [
 123,
 133,
 180,
@@ -362,98 +362,98 @@
 510,
 520,
 571,
-581,
+581
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CookiesTest.kt':[
-177,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/common/test/io/ktor/client/tests/plugins/CookiesTest.kt": [
+177
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/CookiesAndRedirectMockedTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/CookiesAndRedirectMockedTest.kt": [
 46,
 102,
-129,
+129
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/ExceptionsJvmTest.kt':[
-42,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/ExceptionsJvmTest.kt": [
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/FileCacheTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/FileCacheTest.kt": [
 21,
-29,
+29
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/FormsTest.kt':[
-20,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/FormsTest.kt": [
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/HttpRedirectMockedTest.kt':[
-137,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/HttpRedirectMockedTest.kt": [
+137
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/LoggingTestJvm.kt':[
-33,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/LoggingTestJvm.kt": [
+33
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/WebSocketJvmTest.kt':[
-41,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/test/io/ktor/client/tests/WebSocketJvmTest.kt": [
+41
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Codecs.kt':[
-73,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/Codecs.kt": [
+73
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/RequestParserTest.kt':[
-16,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/RequestParserTest.kt": [
+16
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt':[
-281,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt": [
+281
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/ChunkedTest.kt':[
-161,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/ChunkedTest.kt": [
+161
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/test/io/ktor/tests/http/cio/MultipartTest.kt": [
 16,
 87,
 155,
-218,
+218
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Strings.kt": [
 55,
-57,
+57
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/UTF8.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/UTF8.kt": [
 39,
 41,
-125,
+125
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSessionsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSessionsTest.kt": [
 13,
 64,
 83,
-127,
+127
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ByteChannelSmokeTest.kt": [
 215,
 355,
 540,
-575,
+575
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/charsets/CharsetJS.kt": [
 140,
-239,
+239
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
 222,
 396,
 1190,
-1954,
+1954
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/Delimited.kt':[
-75,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/Delimited.kt": [
+75
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt':[
-65,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/charsets/CharsetJVM.kt": [
+65
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ByteBufferChannelTest.kt": [
 149,
-181,
+181
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ConsumeEachBufferRangeTest.kt':[
-25,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/test/io/ktor/utils/io/ConsumeEachBufferRangeTest.kt": [
+25
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt": [
 141,
 144,
 220,
@@ -462,73 +462,73 @@
 293,
 345,
 346,
-352,
+352
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/errors/PosixErrors.kt':[
-78,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/errors/PosixErrors.kt": [
+78
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/ByteChannelNativeConcurrentTest.kt':[
-63,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/test/io/ktor/utils/io/ByteChannelNativeConcurrentTest.kt": [
+63
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt':[
-38,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt": [
+38
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOReader.kt": [
 25,
-82,
+82
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/CIOWriter.kt": [
 26,
 82,
-86,
+86
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt':[
-107,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/sockets/tests/ServerSocketTest.kt": [
+107
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/util/StartTimeoutTest.kt':[
-72,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/test/io/ktor/network/util/StartTimeoutTest.kt": [
+72
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/TcpSocketTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/TcpSocketTest.kt": [
 17,
-60,
+60
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/test/io/ktor/network/sockets/tests/UDPSocketTest.kt": [
 21,
 55,
-192,
+192
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientHandshake.kt": [
 56,
-101,
+101
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/CipherUtils.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/cipher/CipherUtils.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt':[
-208,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/src/io/ktor/network/tls/certificates/Certificates.kt": [
+208
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SelectUtils.kt':[
-73,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/selector/SelectUtils.kt": [
+73
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/CIOReader.kt':[
-20,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/CIOReader.kt": [
+20
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/CIOWriter.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/CIOWriter.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/DatagramSendChannel.kt':[
-108,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/DatagramSendChannel.kt": [
+108
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/DatagramSocketNative.kt':[
-86,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/DatagramSocketNative.kt": [
+86
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/TCPServerSocketNative.kt':[
-34,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/nix/src/io/ktor/network/sockets/TCPServerSocketNative.kt": [
+34
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/internal/WeakTimeoutQueueJvm.kt':[
-69,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/src/io/ktor/server/cio/internal/WeakTimeoutQueueJvm.kt": [
+69
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/CIOHttpClientTest.kt": [
 25,
 30,
 31,
@@ -536,41 +536,41 @@
 97,
 102,
 103,
-106,
+106
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ClassCastExceptionTest.kt':[
-32,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ClassCastExceptionTest.kt": [
+32
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ServerPipelineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvm/test/io/ktor/tests/server/cio/ServerPipelineTest.kt": [
 63,
 98,
 134,
 179,
 214,
-223,
+223
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationEngine.kt':[
-149,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/CIOApplicationEngine.kt": [
+149
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/HttpServer.kt": [
 47,
-48,
+48
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt':[
-37,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt": [
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/Route.kt':[
-96,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/Route.kt": [
+96
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/ApplicationPluginTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/ApplicationPluginTest.kt": [
 196,
 243,
-308,
+308
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/HooksTest.kt':[
-154,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/HooksTest.kt": [
+154
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/RouteScopedPluginTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/application/RouteScopedPluginTest.kt": [
 31,
 34,
 35,
@@ -582,120 +582,120 @@
 265,
 266,
 267,
-398,
+398
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/routing/RegexRoutingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/routing/RegexRoutingTest.kt": [
 18,
-19,
+19
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/routing/RouteTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/test/io/ktor/server/routing/RouteTest.kt": [
 46,
 47,
-48,
+48
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineEnvironmentReloading.kt':[
-104,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ApplicationEngineEnvironmentReloading.kt": [
+104
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLineJvm.kt':[
-64,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLineJvm.kt": [
+64
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/CommandLine.kt':[
-39,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/CommandLine.kt": [
+39
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultTransform.kt':[
-37,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/DefaultTransform.kt": [
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt':[
-83,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/JettyKtorHandler.kt": [
+83
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/ServerInitializer.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/ServerInitializer.kt": [
 16,
-46,
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/internal/JettyUpgradeImpl.kt':[
-37,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/src/io/ktor/server/jetty/jakarta/internal/JettyUpgradeImpl.kt": [
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyServletApplicationEngine.kt':[
-31,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/JettyServletApplicationEngine.kt": [
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/WebResourcesTest.kt':[
-48,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/WebResourcesTest.kt": [
+48
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletContainer.kt':[
-32,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/JettyHttp2ServletContainer.kt": [
+32
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt':[
-83,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/JettyKtorHandler.kt": [
+83
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/ServerInitializer.kt": [
 16,
-46,
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/internal/JettyUpgradeImpl.kt':[
-37,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/src/io/ktor/server/jetty/internal/JettyUpgradeImpl.kt": [
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyServletApplicationEngine.kt':[
-31,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/JettyServletApplicationEngine.kt": [
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/WebResourcesTest.kt':[
-48,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/WebResourcesTest.kt": [
+48
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletContainer.kt':[
-32,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/JettyHttp2ServletContainer.kt": [
+32
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt':[
-172,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/NettyApplicationEngine.kt": [
+172
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt':[
-324,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/NettyHttpResponsePipeline.kt": [
+324
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt':[
-30,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt": [
+30
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTAuthTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/jvm/test/io/ktor/server/auth/jwt/JWTAuthTest.kt": [
 81,
 481,
-482,
+482
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/src/io/ktor/server/auth/ldap/Ldap.kt':[
-92,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/src/io/ktor/server/auth/ldap/Ldap.kt": [
+92
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LdapAuthTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/jvm/test/io/ktor/tests/auth/ldap/LdapAuthTest.kt": [
 43,
 114,
-115,
+115
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/AuthWithPlugins.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/AuthWithPlugins.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/DigestTest.kt": [
 25,
 55,
 129,
-325,
+325
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt": [
 314,
 430,
 431,
 432,
 433,
-479,
+479
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2JvmTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2JvmTest.kt": [
 214,
 248,
 305,
 339,
 372,
 404,
-435,
+435
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationInterceptors.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/AuthenticationInterceptors.kt": [
 53,
-67,
+67
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthBuildersTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/AuthBuildersTest.kt": [
 52,
 118,
 179,
@@ -717,12 +717,12 @@
 879,
 915,
 936,
-937,
+937
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BasicAuthTest.kt':[
-41,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BasicAuthTest.kt": [
+41
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt": [
 353,
 354,
 397,
@@ -734,56 +734,56 @@
 598,
 599,
 600,
-601,
+601
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/SessionAuthTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/SessionAuthTest.kt": [
 26,
 63,
-96,
+96
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/UserHashedTableAuthTest.kt':[
-42,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/UserHashedTableAuthTest.kt": [
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-caching-headers/jvmAndNix/src/io/ktor/server/plugins/cachingheaders/CacheControlMerge.kt':[
-49,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-caching-headers/jvmAndNix/src/io/ktor/server/plugins/cachingheaders/CacheControlMerge.kt": [
+49
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-caching-headers/jvmAndNix/src/io/ktor/server/plugins/cachingheaders/CachingHeaders.kt':[
-55,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-caching-headers/jvmAndNix/src/io/ktor/server/plugins/cachingheaders/CachingHeaders.kt": [
+55
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-id/jvmAndNix/src/io/ktor/server/plugins/callid/CallId.kt':[
-184,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-id/jvmAndNix/src/io/ktor/server/plugins/callid/CallId.kt": [
+184
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLogging.kt':[
-35,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/src/io/ktor/server/plugins/callloging/CallLogging.kt": [
+35
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-call-logging/jvm/test/io/ktor/server/plugins/callloging/CallLoggingTest.kt": [
 231,
 261,
 300,
-338,
+338
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Compression.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Compression.kt": [
 69,
 79,
-107,
+107
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-conditional-headers/jvmAndNix/src/io/ktor/server/plugins/conditionalheaders/ConditionalHeaders.kt':[
-78,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-conditional-headers/jvmAndNix/src/io/ktor/server/plugins/conditionalheaders/ConditionalHeaders.kt": [
+78
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/test/ContentNegotiationJvmTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvm/test/ContentNegotiationJvmTest.kt": [
 43,
 64,
 115,
-120,
+120
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/RequestConverter.kt':[
-17,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/RequestConverter.kt": [
+17
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/ResponseConverter.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/src/io/ktor/server/plugins/contentnegotiation/ResponseConverter.kt": [
 18,
-39,
+39
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/ContentNegotiationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/ContentNegotiationTest.kt": [
 63,
 69,
 70,
@@ -795,92 +795,92 @@
 482,
 571,
 664,
-723,
+723
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/RequestConverterTest.kt':[
-25,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/RequestConverterTest.kt": [
+25
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt':[
-84,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-cors/jvmAndNix/src/io/ktor/server/plugins/cors/CORS.kt": [
+84
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-default-headers/jvm/src/io/ktor/server/plugins/defaultheaders/DefaultHeaders.kt':[
-66,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-default-headers/jvm/src/io/ktor/server/plugins/defaultheaders/DefaultHeaders.kt": [
+66
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/DoubleReceive.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-double-receive/jvmAndNix/src/io/ktor/server/plugins/doublereceive/DoubleReceive.kt": [
 31,
-35,
+35
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-forwarded-header/jvmAndNix/src/io/ktor/server/plugins/forwardedheaders/ForwardedHeaders.kt':[
-156,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-forwarded-header/jvmAndNix/src/io/ktor/server/plugins/forwardedheaders/ForwardedHeaders.kt": [
+156
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-freemarker/jvm/test/io/ktor/tests/freemarker/FreeMarkerTest.kt':[
-75,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-freemarker/jvm/test/io/ktor/tests/freemarker/FreeMarkerTest.kt": [
+75
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-hsts/jvmAndNix/src/io/ktor/server/plugins/hsts/HSTS.kt':[
-77,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-hsts/jvmAndNix/src/io/ktor/server/plugins/hsts/HSTS.kt": [
+77
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/tests/html/HtmlBuilderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/tests/html/HtmlBuilderTest.kt": [
 23,
 56,
-95,
+95
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/tests/html/HtmlContentTest.kt':[
-19,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/tests/html/HtmlContentTest.kt": [
+19
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/tests/html/HtmlTemplateTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/test/io/ktor/tests/html/HtmlTemplateTest.kt": [
 75,
-91,
+91
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/test/io/ktor/tests/jte/JteTest.kt':[
-78,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-jte/jvm/test/io/ktor/tests/jte/JteTest.kt": [
+78
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt':[
-182,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt": [
+182
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/CustomLocationsTest.kt':[
-78,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/CustomLocationsTest.kt": [
+78
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/OAuthLocationsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/OAuthLocationsTest.kt": [
 20,
-55,
+55
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt':[
-107,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt": [
+107
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/test/io/ktor/server/metrics/micrometer/MicrometerMetricsTests.kt": [
 40,
 72,
 107,
 137,
 172,
 239,
-355,
+355
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetrics.kt':[
-49,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics/jvm/src/io/ktor/server/metrics/dropwizard/DropwizardMetrics.kt": [
+49
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/test/io/ktor/server/mustache/MustacheTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-mustache/jvm/test/io/ktor/server/mustache/MustacheTest.kt": [
 155,
-156,
+156
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/PartialContent.kt':[
-43,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-partial-content/jvmAndNix/src/io/ktor/server/plugins/partialcontent/PartialContent.kt": [
+43
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/test/io/ktor/server/plugins/requestvalidation/RequestValidationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-request-validation/jvmAndNix/test/io/ktor/server/plugins/requestvalidation/RequestValidationTest.kt": [
 23,
-90,
+90
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt':[
-446,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-resources/jvmAndNix/test/io/ktor/tests/resources/ResourcesTest.kt": [
+446
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/Sessions.kt':[
-28,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/Sessions.kt": [
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/src/io/ktor/server/plugins/statuspages/StatusPages.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/src/io/ktor/server/plugins/statuspages/StatusPages.kt": [
 32,
-51,
+51
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt": [
 29,
 120,
 149,
@@ -893,31 +893,31 @@
 422,
 451,
 483,
-515,
+515
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/src/io/ktor/server/plugins/swagger/Swagger.kt": [
 59,
 63,
 65,
-76,
+76
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/test/io/ktor/server/plugins/swagger/SwaggerTest.kt':[
-15,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-swagger/jvm/test/io/ktor/server/plugins/swagger/SwaggerTest.kt": [
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/test/io/ktor/server/thymeleaf/ThymeleafTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-thymeleaf/jvm/test/io/ktor/server/thymeleaf/ThymeleafTest.kt": [
 57,
-173,
+173
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/src/io/ktor/server/velocity/VelocityTools.kt':[
-27,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/src/io/ktor/server/velocity/VelocityTools.kt": [
+27
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt':[
-58,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-velocity/jvm/test/io/ktor/tests/velocity/VelocityTest.kt": [
+58
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/Webjars.kt':[
-39,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/Webjars.kt": [
+39
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt": [
 116,
 157,
 195,
@@ -928,54 +928,54 @@
 533,
 566,
 601,
-641,
+641
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketWithContentNegotiationTest.kt':[
-26,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketWithContentNegotiationTest.kt": [
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServlet.kt':[
-106,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/KtorServlet.kt": [
+106
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt':[
-22,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt": [
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt':[
-107,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/KtorServlet.kt": [
+107
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt':[
-22,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt": [
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBaseJvm.kt':[
-115,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/EngineTestBaseJvm.kt": [
+115
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt':[
-419,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt": [
+419
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/test/TestApplicationTestJvm.kt':[
-143,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/test/TestApplicationTestJvm.kt": [
+143
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationRequest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/src/io/ktor/server/testing/TestApplicationRequest.kt": [
 145,
 150,
 190,
-195,
+195
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvmAndNix/test/TestApplicationTest.kt": [
 129,
 172,
 225,
 273,
 281,
-339,
+339
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ConnectionTestSuite.kt':[
-50,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/ConnectionTestSuite.kt": [
+50
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/EngineStressSuite.kt": [
 111,
-215,
+215
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt": [
 184,
 215,
 216,
@@ -984,18 +984,18 @@
 326,
 327,
 364,
-379,
+379
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt": [
 95,
 102,
 107,
 154,
 611,
 694,
-734,
+734
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvmAndNix/src/io/ktor/server/testing/suites/WebSocketEngineSuite.kt": [
 42,
 85,
 131,
@@ -1008,35 +1008,35 @@
 407,
 441,
 482,
-544,
+544
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/SinglePageApplicationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/http/spa/SinglePageApplicationTest.kt": [
 17,
 99,
 131,
-159,
+159
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CompressionTest.kt": [
 170,
 411,
 575,
-604,
+604
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/ConditionalHeadersJvmTests.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/ConditionalHeadersJvmTests.kt": [
 68,
 96,
 224,
 279,
 320,
-361,
+361
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CookiesTest.kt':[
-78,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/CookiesTest.kt": [
+78
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/PartialContentTest.kt':[
-33,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/PartialContentTest.kt": [
+33
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/StaticContentTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/StaticContentTest.kt": [
 34,
 94,
 137,
@@ -1052,19 +1052,19 @@
 790,
 847,
 875,
-929,
+929
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/SessionTestJvm.kt':[
-40,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/sessions/SessionTestJvm.kt": [
+40
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/testing/TestApplicationEngineTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/testing/TestApplicationEngineTest.kt": [
 99,
 195,
 252,
 291,
-296,
+296
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/ApplicationRequestHeaderTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/application/ApplicationRequestHeaderTest.kt": [
 19,
 20,
 49,
@@ -1072,21 +1072,21 @@
 51,
 52,
 111,
-112,
+112
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/RespondFunctionsTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/RespondFunctionsTest.kt": [
 19,
-47,
+47
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/http/TestEngineMultipartTest.kt": [
 171,
-176,
+176
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/AutoHeadResponseTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/AutoHeadResponseTest.kt": [
 72,
-106,
+106
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CORSTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CORSTest.kt": [
 89,
 118,
 168,
@@ -1107,22 +1107,22 @@
 1049,
 1091,
 1192,
-1229,
+1229
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CachingHeadersTest.kt':[
-116,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CachingHeadersTest.kt": [
+116
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CallIdTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/CallIdTest.kt": [
 84,
 114,
-213,
+213
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/HSTSTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/HSTSTest.kt": [
 55,
 56,
-164,
+164
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/OriginConnectionPointTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/OriginConnectionPointTest.kt": [
 20,
 22,
 23,
@@ -1138,14 +1138,14 @@
 720,
 749,
 803,
-804,
+804
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/PartialContentTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/PartialContentTest.kt": [
 32,
 69,
-293,
+293
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/RateLimitTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/plugins/RateLimitTest.kt": [
 69,
 128,
 175,
@@ -1156,9 +1156,9 @@
 346,
 380,
 416,
-458,
+458
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingProcessingTest.kt": [
 24,
 53,
 97,
@@ -1180,9 +1180,9 @@
 820,
 872,
 873,
-992,
+992
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingResolveTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/routing/RoutingResolveTest.kt": [
 744,
 794,
 845,
@@ -1197,9 +1197,9 @@
 1197,
 1233,
 1260,
-1287,
+1287
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/sessions/SessionTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvmAndNix/test/io/ktor/tests/server/sessions/SessionTest.kt": [
 52,
 116,
 161,
@@ -1210,73 +1210,73 @@
 371,
 413,
 463,
-498,
+498
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/TomcatApplicationEngine.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/TomcatApplicationEngine.kt": [
 65,
 67,
 72,
 74,
-96,
+96
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt": [
 65,
 67,
 72,
-74,
+74
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/UrlBuilder.kt':[
-55,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-resources/common/src/io/ktor/resources/UrlBuilder.kt": [
+55
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ServerGsonBlockingTest.kt':[
-35,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ServerGsonBlockingTest.kt": [
+35
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ServerGsonTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-gson/jvm/test/ServerGsonTest.kt": [
 44,
-75,
+75
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonBlockingTest.kt':[
-36,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonBlockingTest.kt": [
+36
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt':[
-42,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-jackson/jvm/test/ServerJacksonTest.kt": [
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/test/JsonSerializationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-json/common/test/JsonSerializationTest.kt": [
 34,
-68,
+68
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-tests/common/src/AbstractSerializationTest.kt':[
-43,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/ktor-serialization-kotlinx-tests/common/src/AbstractSerializationTest.kt": [
+43
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-tests/jvm/src/AbstractServerSerializationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-tests/jvm/src/AbstractServerSerializationTest.kt": [
 33,
-38,
+38
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt": [
 161,
-166,
+166
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt':[
-55,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/PingPong.kt": [
+55
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt": [
 56,
-85,
+85
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/ByteChannels.kt':[
-55,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/ByteChannels.kt": [
+55
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt':[
-61,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/EncodersJvm.kt": [
+61
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Nonce.kt':[
-34,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Nonce.kt": [
+34
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/FileChannels.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/cio/FileChannels.kt": [
 31,
-38,
+38
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/PipelineTest.kt':[
-89,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/test/io/ktor/tests/utils/PipelineTest.kt": [
+89
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6307.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6307.json
@@ -1,20 +1,20 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/MultipleDispatchOnTimeout.kt':[
-42,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/jvm/test/io/ktor/tests/server/jetty/jakarta/MultipleDispatchOnTimeout.kt": [
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/MultipleDispatchOnTimeout.kt':[
-42,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty-jakarta/ktor-server-jetty-test-http2-jakarta/jvm/test/io/ktor/tests/server/jetty/http2/jakarta/MultipleDispatchOnTimeout.kt": [
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/MultipleDispatchOnTimeout.kt':[
-42,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/jvm/test/io/ktor/tests/server/jetty/MultipleDispatchOnTimeout.kt": [
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/MultipleDispatchOnTimeout.kt':[
-42,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-jetty/ktor-server-jetty-test-http2/jvm/test/io/ktor/tests/server/jetty/http2/MultipleDispatchOnTimeout.kt": [
+42
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/test/TestApplicationTestJvm.kt':[
-174,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/test/TestApplicationTestJvm.kt": [
+174
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt':[
-361,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/SustainabilityTestSuite.kt": [
+361
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6314.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6314.json
@@ -1,28 +1,28 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BasicAuthTest.kt':[
-43,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/BasicAuthTest.kt": [
+43
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt": [
 355,
 399,
-443,
+443
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/ContentNegotiationTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-content-negotiation/jvmAndNix/test/ContentNegotiationTest.kt": [
 573,
 642,
 666,
 701,
-725,
+725
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt':[
-419,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt": [
+419
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-suites/jvm/src/io/ktor/server/testing/suites/HttpServerJvmTestSuite.kt": [
 56,
 130,
-184,
+184
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/PartialContentTest.kt':[
-181,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tests/jvm/test/io/ktor/server/plugins/PartialContentTest.kt": [
+181
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6510.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6510.json
@@ -1,14 +1,14 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RouteSelector.kt':[
-494,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RouteSelector.kt": [
+494
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt':[
-137,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/test/io/ktor/tests/hosts/CommandLineTest.kt": [
+137
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BasicAuth.kt':[
-109,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BasicAuth.kt": [
+109
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt':[
-233,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-test-host/jvm/src/io/ktor/server/testing/HighLoadHttpGenerator.kt": [
+233
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6511.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6511.json
@@ -1,18 +1,18 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/Multipart.kt": [
 401,
-515,
+515
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Output.kt':[
-248,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Output.kt": [
+248
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt':[
-89,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt": [
+89
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/SessionsBackwardCompatibleEncoder.kt':[
-48,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/SessionsBackwardCompatibleEncoder.kt": [
+48
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt':[
-93,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt": [
+93
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6514.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6514.json
@@ -1,16 +1,16 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/HttpCookies.kt':[
-82,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/cookies/HttpCookies.kt": [
+82
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/UrlDecodedParametersBuilder.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/UrlDecodedParametersBuilder.kt": [
 28,
 58,
-60,
+60
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt':[
-87,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls/TLSClientSessionJvm.kt": [
+87
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt':[
-144,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/DefaultWebSocketSession.kt": [
+144
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6517.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6517.json
@@ -1,72 +1,72 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt':[
-113,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/engine/HttpClientEngine.kt": [
+113
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpSend.kt':[
-25,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/HttpSend.kt": [
+25
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/ClientHook.kt':[
-14,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/ClientHook.kt": [
+14
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/fetch/LibDom.kt':[
-361,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/js/src/io/ktor/client/fetch/LibDom.kt": [
+361
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logger.kt':[
-10,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-plugins/ktor-client-logging/common/src/io/ktor/client/plugins/logging/Logger.kt": [
+10
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ContentTypeMatcher.kt':[
-10,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/ContentTypeMatcher.kt": [
+10
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/Multipart.kt':[
-104,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/content/Multipart.kt": [
+104
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Closeable.kt':[
-3,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Closeable.kt": [
+3
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/CloseableJS.kt':[
-3,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/CloseableJS.kt": [
+3
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/CloseableNative.kt':[
-3,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/core/CloseableNative.kt": [
+3
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/Sockets.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvmAndNix/src/io/ktor/network/sockets/Sockets.kt": [
 78,
-90,
+90
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/Hook.kt':[
-13,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/application/Hook.kt": [
+13
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/ConfigLoaders.kt':[
-14,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/ConfigLoaders.kt": [
+14
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/logging/Logging.kt':[
-19,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/logging/Logging.kt": [
+19
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/EmbeddedServer.kt':[
-15,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/EmbeddedServer.kt": [
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt':[
-583,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/test/io/ktor/tests/auth/OAuth2Test.kt": [
+583
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/src/io/ktor/server/html/Template.kt':[
-11,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-html-builder/jvmAndNix/src/io/ktor/server/html/Template.kt": [
+11
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/Locations.kt':[
-140,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/Locations.kt": [
+140
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimiter.kt':[
-14,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimiter.kt": [
+14
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletUpgrade.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletUpgrade.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt':[
-21,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt": [
+21
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/common/src/ContentConverter.kt':[
-101,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/common/src/ContentConverter.kt": [
+101
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/Extensions.kt':[
-22,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-serialization/ktor-serialization-kotlinx/common/src/io/ktor/serialization/kotlinx/Extensions.kt": [
+22
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6518.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6518.json
@@ -1,45 +1,45 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/HttpMessageProperties.kt": [
 15,
 23,
 38,
-43,
+43
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/UrlDecodedParametersBuilder.kt':[
-33,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/UrlDecodedParametersBuilder.kt": [
+33
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/HttpMessagePropertiesJvm.kt':[
-23,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/jvm/src/io/ktor/http/HttpMessagePropertiesJvm.kt": [
+23
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/CharArrayBuilder.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/CharArrayBuilder.kt": [
 30,
-121,
+121
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Chars.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/Chars.kt": [
 15,
+26
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
+548
+],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryJvm.kt": [
 26,
+31
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
-548,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/bits/MemoryJvm.kt':[
-26,
-31,
-],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/LockFreeMPSCQueue.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/LockFreeMPSCQueue.kt": [
 110,
-122,
+122
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/AutoReloadUtils.kt':[
-74,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/AutoReloadUtils.kt": [
+74
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt':[
-363,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/OAuth2.kt": [
+363
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt':[
-322,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvm/test/io/ktor/tests/websocket/WebSocketTest.kt": [
+322
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Attributes.kt':[
-87,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Attributes.kt": [
+87
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6529.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6529.json
@@ -1,8 +1,8 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt':[
-40,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-mock/common/src/io/ktor/client/engine/mock/MockEngine.kt": [
+40
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt':[
-77,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/test/io/ktor/tests/locations/LocationsTest.kt": [
+77
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6530.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6530.json
@@ -1,8 +1,8 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/network/NetworkAddressJvm.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/network/NetworkAddressJvm.kt": [
 19,
 19,
 22,
-25,
-],
+25
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6531.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6531.json
@@ -1,68 +1,68 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheResponseConsumer.kt':[
-91,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache/jvm/src/io/ktor/client/engine/apache/ApacheResponseConsumer.kt": [
+91
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt':[
-224,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/HttpClient.kt": [
+224
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ExceptionUtilsJvm.kt':[
-45,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ExceptionUtilsJvm.kt": [
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/CancellableReusableContinuation.kt':[
-46,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/CancellableReusableContinuation.kt": [
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/LockFreeMPSCQueue.kt':[
-50,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/LockFreeMPSCQueue.kt": [
+50
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/ConnectUtilsJvm.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/ConnectUtilsJvm.kt": [
 49,
-61,
+61
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt':[
-210,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/backend/ServerPipeline.kt": [
+210
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/jvmAndNix/src/io/ktor/server/config/yaml/YamlConfig.kt':[
-73,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-config-yaml/jvmAndNix/src/io/ktor/server/config/yaml/YamlConfig.kt": [
+73
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/cio/RequestBodyHandler.kt": [
 56,
 60,
-157,
+157
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt": [
 438,
-483,
+483
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2JvmTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2JvmTest.kt": [
 416,
-447,
+447
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Principal.kt':[
-28,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Principal.kt": [
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/Locations.kt':[
-154,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/Locations.kt": [
+154
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt": [
 143,
-465,
+465
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/RawWebSocketTest.kt':[
-80,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-websockets/jvmAndNix/test/io/ktor/tests/websocket/RawWebSocketTest.kt": [
+80
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt':[
-122,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletApplicationEngine.kt": [
+122
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt':[
-122,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletApplicationEngine.kt": [
+122
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-events/common/src/io/ktor/events/Events.kt':[
-49,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-events/common/src/io/ktor/events/Events.kt": [
+49
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt':[
-80,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/RawWebSocketCommon.kt": [
+80
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketWriter.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/WebSocketWriter.kt": [
 76,
 78,
 78,
@@ -71,23 +71,23 @@
 81,
 100,
 101,
-105,
+105
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/internal/LockFreeLinkedList.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/internal/LockFreeLinkedList.kt": [
 195,
 641,
-747,
+747
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/Pipeline.kt':[
-220,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/Pipeline.kt": [
+220
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/SuspendFunctionGun.kt':[
-22,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/SuspendFunctionGun.kt": [
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/AttributesJs.kt':[
-18,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/js/src/io/ktor/util/AttributesJs.kt": [
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/collections/LockFreeMPSCQueueNative.kt':[
-57,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/posix/src/io/ktor/util/collections/LockFreeMPSCQueueNative.kt": [
+57
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6532.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6532.json
@@ -1,146 +1,146 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt':[
-126,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-apache5/jvm/src/io/ktor/client/engine/apache5/ApacheResponseConsumer.kt": [
+126
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt':[
-50,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngine.kt": [
+50
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/KtorCallContexts.kt':[
-106,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/api/KtorCallContexts.kt": [
+106
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpEngine.kt':[
-107,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpEngine.kt": [
+107
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpResponseBodyHandler.kt':[
-48,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-java/jvm/src/io/ktor/client/engine/java/JavaHttpResponseBodyHandler.kt": [
+48
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientLoaderJvm.kt':[
-45,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-client/ktor-client-tests/jvm/src/io/ktor/client/tests/utils/ClientLoaderJvm.kt": [
+45
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLParser.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/common/src/io/ktor/http/URLParser.kt": [
 147,
-211,
+211
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpBody.kt':[
-159,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/HttpBody.kt": [
+159
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/AsciiCharTree.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/AsciiCharTree.kt": [
 19,
-47,
+47
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/CharArrayBuilder.kt':[
-178,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/internals/CharArrayBuilder.kt": [
+178
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/CharArrayBuilderTest.kt':[
-158,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/common/test/io/ktor/tests/http/cio/CharArrayBuilderTest.kt": [
+158
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt':[
-124,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt": [
+124
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Buffer.kt':[
-404,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Buffer.kt": [
+404
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferAppend.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/BufferAppend.kt": [
 33,
-46,
+46
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Buffers.kt':[
-89,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Buffers.kt": [
+89
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Input.kt':[
-793,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Input.kt": [
+793
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Output.kt':[
-263,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/Output.kt": [
+263
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/PacketDirect.kt':[
-18,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/PacketDirect.kt": [
+18
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/ChunkBuffer.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/core/internal/ChunkBuffer.kt": [
 45,
 75,
 88,
 98,
 101,
-115,
+115
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/pool/Pool.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/src/io/ktor/utils/io/pool/Pool.kt": [
 73,
 85,
-94,
+94
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/DummyCoroutines.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/DummyCoroutines.kt": [
 43,
-48,
+48
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadUntilDelimiterTest.kt':[
-280,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/common/test/io/ktor/utils/io/ReadUntilDelimiterTest.kt": [
+280
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/InputArraysJS.kt':[
-11,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/js/src/io/ktor/utils/io/core/InputArraysJS.kt": [
+11
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/ByteBufferChannel.kt": [
 1471,
 1839,
 1921,
 2159,
-2179,
+2179
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/ByteBufferChannelInternals.kt':[
-44,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/ByteBufferChannelInternals.kt": [
+44
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/WriteSessionImpl.kt':[
-54,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/internal/WriteSessionImpl.kt": [
+54
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt':[
-293,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/javaio/Blocking.kt": [
+293
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/nio/Reading.kt':[
-15,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/nio/Reading.kt": [
+15
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/nio/Writing.kt':[
-16,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/jvm/src/io/ktor/utils/io/jvm/nio/Writing.kt": [
+16
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/bits/MemoryNative.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/bits/MemoryNative.kt": [
 234,
-250,
+250
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt':[
-77,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-io/posix/src/io/ktor/utils/io/charsets/CharsetNative.kt": [
+77
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt':[
-193,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/ActorSelectorManager.kt": [
+193
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/InterestSuspensionsMap.kt':[
-30,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/selector/InterestSuspensionsMap.kt": [
+30
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketImpl.kt':[
-89,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/jvm/src/io/ktor/network/sockets/SocketImpl.kt": [
+89
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseCookies.kt':[
-30,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/response/ResponseCookies.kt": [
+30
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingBuilder.kt':[
-353,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/routing/RoutingBuilder.kt": [
+353
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLineJvm.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/CommandLineJvm.kt": [
 105,
 110,
 113,
-144,
+144
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EnvironmentUtilsJvm.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/EnvironmentUtilsJvm.kt": [
 22,
 27,
-32,
+32
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt':[
-308,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/BaseApplicationResponse.kt": [
+308
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/CommandLine.kt':[
-77,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/CommandLine.kt": [
+77
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt": [
 101,
 104,
 108,
@@ -149,106 +149,106 @@
 146,
 153,
 156,
-483,
+483
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Authentication.kt':[
-38,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/Authentication.kt": [
+38
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BasicAuth.kt':[
-74,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvmAndNix/src/io/ktor/server/auth/BasicAuth.kt": [
+74
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Config.kt':[
-69,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-compression/jvm/src/io/ktor/server/plugins/compression/Config.kt": [
+69
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt':[
-87,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-locations/jvm/src/io/ktor/server/locations/BackwardCompatibleImpl.kt": [
+87
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt':[
-109,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-metrics-micrometer/jvm/src/io/ktor/server/metrics/micrometer/MicrometerMetrics.kt": [
+109
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimitConfig.kt':[
-28,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-rate-limit/jvmAndNix/src/io/ktor/server/plugins/ratelimit/RateLimitConfig.kt": [
+28
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/CacheJvm.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/CacheJvm.kt": [
 61,
-151,
+151
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/DirectoryStorage.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/DirectoryStorage.kt": [
 63,
-66,
+66
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/SessionSerializerReflection.kt": [
 165,
 176,
 187,
-328,
+328
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTrackerById.kt':[
-104,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTrackerById.kt": [
+104
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTrackerByValue.kt':[
-37,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionTrackerByValue.kt": [
+37
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/ListLikeDecoder.kt':[
-67,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/ListLikeDecoder.kt": [
+67
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/MapDecoder.kt':[
-89,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/MapDecoder.kt": [
+89
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/SessionsBackwardCompatibleDecoder.kt':[
-91,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/serialization/SessionsBackwardCompatibleDecoder.kt": [
+91
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt':[
-186,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-status-pages/jvmAndNix/test/io/ktor/server/plugins/statuspages/StatusPagesTest.kt": [
+186
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/WebjarsUtils.kt':[
-29,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-webjars/jvm/src/io/ktor/server/webjars/WebjarsUtils.kt": [
+29
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletUpgrade.kt':[
-86,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletUpgrade.kt": [
+86
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletWriter.kt':[
-26,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet-jakarta/jvm/src/io/ktor/server/servlet/jakarta/ServletWriter.kt": [
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt':[
-86,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletUpgrade.kt": [
+86
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletWriter.kt':[
-26,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-servlet/jvm/src/io/ktor/server/servlet/ServletWriter.kt": [
+26
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/TomcatApplicationEngine.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat-jakarta/jvm/src/io/ktor/server/tomcat/jakarta/TomcatApplicationEngine.kt": [
 81,
-88,
+88
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-tomcat/jvm/src/io/ktor/server/tomcat/TomcatApplicationEngine.kt": [
 81,
-88,
+88
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/FrameParser.kt": [
 54,
-137,
+137
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/Serializer.kt':[
-70,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/jvm/src/io/ktor/websocket/Serializer.kt": [
+70
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Attributes.kt':[
-14,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/Attributes.kt": [
+14
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/converters/DataConversion.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/converters/DataConversion.kt": [
 103,
-112,
+112
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/SuspendFunctionGun.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/common/src/io/ktor/util/pipeline/SuspendFunctionGun.kt": [
 96,
-143,
+143
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/darwin/src/io/ktor/util/ThreadInfoDarwin.kt':[
-14,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/darwin/src/io/ktor/util/ThreadInfoDarwin.kt": [
+14
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Path.kt':[
-22,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/jvm/src/io/ktor/util/Path.kt": [
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/linuxX64/src/io/ktor/util/ThreadInfoLinux.kt':[
-14,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-utils/linuxX64/src/io/ktor/util/ThreadInfoLinux.kt": [
+14
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6558.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6558.json
@@ -1,8 +1,8 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationResponse.kt':[
-54,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-netty/jvm/src/io/ktor/server/netty/http2/NettyHttp2ApplicationResponse.kt": [
+54
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketExtensionHeader.kt':[
-40,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-shared/ktor-websockets/common/src/io/ktor/websocket/WebSocketExtensionHeader.kt": [
+40
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6611.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S6611.json
@@ -1,8 +1,8 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/MapApplicationConfig.kt': [
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvmAndNix/src/io/ktor/server/config/MapApplicationConfig.kt": [
 124,
 124,
 128,
-128,
-],
+128
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S899.json
+++ b/its/ruling/src/test/resources/expected/kotlin/ktor/kotlin-S899.json
@@ -1,27 +1,27 @@
 {
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-http/ktor-http-cio/jvm/src/io/ktor/http/cio/CIOMultipartDataBase.kt": [
 118,
-134,
+134
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/CertificatesTest.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-network/ktor-network-tls/ktor-network-tls-certificates/jvm/test/io/ktor/network/tls/certificates/CertificatesTest.kt": [
 157,
 171,
-185,
+185
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/content/LocalFileContentTest.kt':[
-22,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-core/jvm/test/io/ktor/tests/http/content/LocalFileContentTest.kt": [
+22
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt':[
-397,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth1aTest.kt": [
+397
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2JvmTest.kt':[
-470,
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-auth/jvm/test/io/ktor/tests/auth/OAuth2JvmTest.kt": [
+470
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/CacheJvm.kt':[
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/CacheJvm.kt": [
 211,
-221,
+221
 ],
-'kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/DirectoryStorage.kt':[
-52,
-],
+"kotlin-ktor-project:sources/kotlin/ktor/ktor-server/ktor-server-plugins/ktor-server-sessions/jvm/src/io/ktor/server/sessions/DirectoryStorage.kt": [
+52
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S104.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S104.json
@@ -1,5 +1,5 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt':[
-0,
-],
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S1067.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S1067.json
@@ -1,15 +1,15 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt':[
-1517,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
+1517
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/RealBufferedSource.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/RealBufferedSource.kt": [
 220,
-300,
+300
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Base64.kt':[
-33,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Base64.kt": [
+33
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/common/ByteString.kt':[
-150,
-],
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/common/ByteString.kt": [
+150
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S108.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S108.json
@@ -1,22 +1,22 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/AsyncTimeout.kt':[
-240,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/AsyncTimeout.kt": [
+240
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/BufferKotlinTest.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/BufferKotlinTest.kt": [
 31,
-36,
+36
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/ByteStringKotlinTest.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/ByteStringKotlinTest.kt": [
 39,
-44,
+44
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/OptionsTest.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/OptionsTest.kt": [
 182,
 190,
-195,
+195
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/SegmentSharingTest.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/SegmentSharingTest.kt": [
 51,
-57,
-],
+57
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S1135.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S1135.json
@@ -1,43 +1,43 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/js/src/main/kotlin/okio/ByteString.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/js/src/main/kotlin/okio/ByteString.kt": [
 86,
 146,
 166,
-208,
+208
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/js/src/main/kotlin/okio/platform.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/js/src/main/kotlin/okio/platform.kt": [
 57,
 63,
-65,
+65
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt':[
-2133,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
+2133
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ByteString.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ByteString.kt": [
 142,
 217,
 237,
-318,
+318
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ForwardingSink.kt':[
-26,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ForwardingSink.kt": [
+26
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ForwardingSource.kt':[
-26,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ForwardingSource.kt": [
+26
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/InflaterSource.kt':[
-91,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/InflaterSource.kt": [
+91
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/platform.kt':[
-44,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/platform.kt": [
+44
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/SegmentPool.kt':[
-24,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/SegmentPool.kt": [
+24
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/common/ByteString.kt':[
-32,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/common/ByteString.kt": [
+32
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/platform.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/platform.kt": [
 25,
 26,
 30,
@@ -47,6 +47,6 @@
 40,
 41,
 61,
-64,
-],
+64
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S1186.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S1186.json
@@ -1,19 +1,19 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/AsyncTimeout.kt':[
-76,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/AsyncTimeout.kt": [
+76
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
 63,
 65,
 100,
 1564,
-1568,
+1568
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Okio.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Okio.kt": [
 126,
-128,
+128
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Timeout.kt':[
-207,
-],
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Timeout.kt": [
+207
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S1192.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S1192.json
@@ -1,12 +1,12 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
 256,
-1945,
+1945
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Pipe.kt':[
-55,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Pipe.kt": [
+55
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/ByteStringKotlinTest.kt':[
-50,
-],
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/ByteStringKotlinTest.kt": [
+50
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S126.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S126.json
@@ -1,8 +1,8 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt':[
-2061,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
+2061
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/DeflaterSink.kt':[
-98,
-],
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/DeflaterSink.kt": [
+98
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S134.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S134.json
@@ -1,5 +1,5 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
 409,
 420,
 470,
@@ -11,12 +11,12 @@
 605,
 911,
 1474,
-1494,
+1494
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/InflaterSource.kt':[
-68,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/InflaterSource.kt": [
+68
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Options.kt':[
-170,
-],
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Options.kt": [
+170
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S138.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S138.json
@@ -1,5 +1,5 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/OptionsTest.kt':[
-41,
-],
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/OptionsTest.kt": [
+41
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S1451.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S1451.json
@@ -1,143 +1,143 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/js/src/main/kotlin/okio/ByteString.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/js/src/main/kotlin/okio/ByteString.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/js/src/main/kotlin/okio/platform.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/js/src/main/kotlin/okio/platform.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/AsyncTimeout.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/AsyncTimeout.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/BufferedSink.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/BufferedSink.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/BufferedSource.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/BufferedSource.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ByteString.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ByteString.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/DeflaterSink.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/DeflaterSink.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ForwardingSink.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ForwardingSink.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ForwardingSource.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ForwardingSource.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ForwardingTimeout.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/ForwardingTimeout.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/GzipSink.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/GzipSink.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/GzipSource.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/GzipSource.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/HashingSink.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/HashingSink.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/HashingSource.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/HashingSource.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/InflaterSource.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/InflaterSource.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Okio.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Okio.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Options.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Options.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Pipe.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Pipe.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/RealBufferedSink.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/RealBufferedSink.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/RealBufferedSource.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/RealBufferedSource.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/SegmentedByteString.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/SegmentedByteString.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Sink.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Sink.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Source.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Source.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Timeout.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Timeout.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/platform.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/platform.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/BufferCursorKotlinTest.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/BufferCursorKotlinTest.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/BufferKotlinTest.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/BufferKotlinTest.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/ByteStringKotlinTest.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/ByteStringKotlinTest.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/DeflateKotlinTest.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/DeflateKotlinTest.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/ForwardingTimeoutKotlinTest.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/ForwardingTimeoutKotlinTest.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/GzipKotlinTest.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/GzipKotlinTest.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/OkioKotlinTest.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/OkioKotlinTest.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/OptionsTest.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/OptionsTest.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/PipeKotlinTest.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/PipeKotlinTest.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/SegmentSharingTest.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/SegmentSharingTest.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/TestUtil.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/TestUtil.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Base64.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Base64.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/ByteString.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/ByteString.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Segment.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Segment.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/SegmentPool.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/SegmentPool.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Utf8.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Utf8.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Util.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Util.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/common/ByteString.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/common/ByteString.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/platform.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/platform.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/test/kotlin/okio/ByteStringTest.kt':[
-0,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/test/kotlin/okio/ByteStringTest.kt": [
+0
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/test/kotlin/okio/Utf8KotlinTest.kt':[
-0,
-],
+"kotlin-okio-project:sources/kotlin/okio/okio/src/test/kotlin/okio/Utf8KotlinTest.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S1764.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S1764.json
@@ -1,6 +1,6 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/TestUtil.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/TestUtil.kt": [
 116,
-153,
-],
+153
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S3776.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S3776.json
@@ -1,9 +1,9 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/AsyncTimeout.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/AsyncTimeout.kt": [
 82,
-268,
+268
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
 384,
 445,
 531,
@@ -11,18 +11,18 @@
 1131,
 1242,
 1453,
-1944,
+1944
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/GzipSource.kt':[
-97,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/GzipSource.kt": [
+97
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Options.kt':[
-105,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Options.kt": [
+105
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/RealBufferedSource.kt':[
-414,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/RealBufferedSource.kt": [
+414
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Base64.kt':[
-28,
-],
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Base64.kt": [
+28
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S5612.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S5612.json
@@ -1,8 +1,8 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/AsyncTimeout.kt':[
-269,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/AsyncTimeout.kt": [
+269
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt':[
-1457,
-],
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
+1457
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S6510.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S6510.json
@@ -1,8 +1,8 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt':[
-1352,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
+1352
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/TestUtil.kt':[
-80,
-],
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/test/java/okio/TestUtil.kt": [
+80
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S6511.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S6511.json
@@ -1,16 +1,16 @@
 {
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/AsyncTimeout.kt':[
-277,
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/AsyncTimeout.kt": [
+277
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt':[
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
 463,
 1149,
-1150,
+1150
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Base64.kt':[
-49,
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Base64.kt": [
+49
 ],
-'kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Utf8.kt':[
-84,
-],
+"kotlin-okio-project:sources/kotlin/okio/okio/src/main/kotlin/okio/Utf8.kt": [
+84
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S1144.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S1144.json
@@ -1,6 +1,6 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S1144.kt':[
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S1144.kt": [
 5,
-32,
-],
+32
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S1451.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S1451.json
@@ -1,32 +1,32 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S1144.kt':[
-0,
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S1144.kt": [
+0
 ],
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S1763.kt':[
-0,
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S1763.kt": [
+0
 ],
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2068.kt':[
-0,
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2068.kt": [
+0
 ],
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2116.kt':[
-0,
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2116.kt": [
+0
 ],
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2122.kt':[
-0,
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2122.kt": [
+0
 ],
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2123.kt':[
-0,
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2123.kt": [
+0
 ],
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2757.kt':[
-0,
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2757.kt": [
+0
 ],
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S3958.kt':[
-0,
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S3958.kt": [
+0
 ],
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S6202.kt':[
-0,
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S6202.kt": [
+0
 ],
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S6512.kt':[
-0,
-],
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S6512.kt": [
+0
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S1481.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S1481.json
@@ -1,5 +1,5 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2068.kt':[
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2068.kt": [
 6,
 7,
 11,
@@ -18,6 +18,6 @@
 40,
 41,
 42,
-43,
-],
+43
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S1763.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S1763.json
@@ -1,5 +1,5 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S1763.kt':[
-2,
-],
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S1763.kt": [
+2
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S2068.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S2068.json
@@ -1,7 +1,7 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2068.kt':[
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2068.kt": [
 6,
 7,
-39,
-],
+39
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S2116.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S2116.json
@@ -1,5 +1,5 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2116.kt':[
-4,
-],
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2116.kt": [
+4
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S2122.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S2122.json
@@ -1,5 +1,5 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2122.kt':[
-5,
-],
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2122.kt": [
+5
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S2123.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S2123.json
@@ -1,5 +1,5 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2123.kt':[
-6,
-],
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2123.kt": [
+6
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S2757.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S2757.json
@@ -1,6 +1,6 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2757.kt':[
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2757.kt": [
 5,
-13,
-],
+13
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S3958.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S3958.json
@@ -1,5 +1,5 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S3958.kt':[
-5,
-],
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S3958.kt": [
+5
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S6202.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S6202.json
@@ -1,5 +1,5 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S6202.kt':[
-2,
-],
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S6202.kt": [
+2
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S6512.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S6512.json
@@ -1,5 +1,5 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S6512.kt':[
-5,
-],
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S6512.kt": [
+5
+]
 }

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S6615.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S6615.json
@@ -1,8 +1,8 @@
 {
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2123.kt':[
-6,
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2123.kt": [
+6
 ],
-'kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2757.kt':[
+"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2757.kt": [
 2,
 5,
 6,
@@ -10,6 +10,6 @@
 8,
 12,
 13,
-14,
-],
+14
+]
 }

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/ApiExtensions.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/ApiExtensions.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.descriptors.SyntheticPropertyDescriptor
 import org.jetbrains.kotlin.descriptors.ValueDescriptor
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.descriptors.impl.LocalVariableDescriptor
@@ -68,8 +69,6 @@ import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.isNull
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 import org.jetbrains.kotlin.psi2ir.deparenthesize
-import org.jetbrains.kotlin.psi2ir.unwrappedGetMethod
-import org.jetbrains.kotlin.psi2ir.unwrappedSetMethod
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 import org.jetbrains.kotlin.resolve.calls.model.ExpressionValueArgument
@@ -570,3 +569,9 @@ fun SensorContext.hasCacheEnabled(): Boolean {
 fun KtWhenExpression.isExhaustive(context: KotlinFileContext): Boolean {
     return entries.any { it.isElse } || context.bindingContext[BindingContext.EXHAUSTIVE_WHEN, this] == true
 }
+
+val PropertyDescriptor.unwrappedGetMethod: FunctionDescriptor?
+    get() = if (this is SyntheticPropertyDescriptor) this.getMethod else getter
+
+val PropertyDescriptor.unwrappedSetMethod: FunctionDescriptor?
+    get() = if (this is SyntheticPropertyDescriptor) this.setMethod else setter

--- a/sonar-kotlin-api/src/test/resources/ast/kotlin-1.9.kt
+++ b/sonar-kotlin-api/src/test/resources/ast/kotlin-1.9.kt
@@ -1,0 +1,11 @@
+package ast
+
+fun testBreakAndContinue(ints: List<Int>) {
+    for (i in ints) {
+        when (i) {
+            in 2..< 5 -> continue
+            39 -> break
+            else -> println(i)
+        }
+    }
+}

--- a/sonar-kotlin-api/src/test/resources/ast/kotlin-1.9.txt
+++ b/sonar-kotlin-api/src/test/resources/ast/kotlin-1.9.txt
@@ -1,0 +1,112 @@
+KtFile 1:0 … 11:1: [dummy.kt] package astfun testBreakAndC … > println(i)        }    }}
+  KtPackageDirective 1:0 … 1:11: [] package ast
+    LeafPsiElement 1:0 … 1:7: [package] package
+    PsiWhiteSpaceImpl 1:7 … 1:8: [WHITE_SPACE] 
+    KtNameReferenceExpression 1:8 … 1:11: [] ast
+      LeafPsiElement 1:8 … 1:11: [IDENTIFIER] ast
+  KtImportList 1:11 … 1:11: [] 
+  PsiWhiteSpaceImpl 1:11 … 3:0: [WHITE_SPACE] 
+  KtNamedFunction 3:0 … 11:1: [] fun testBreakAndContinue(ints: … > println(i)        }    }}
+    LeafPsiElement 3:0 … 3:3: [fun] fun
+    PsiWhiteSpaceImpl 3:3 … 3:4: [WHITE_SPACE] 
+    LeafPsiElement 3:4 … 3:24: [IDENTIFIER] testBreakAndContinue
+    KtParameterList 3:24 … 3:41: [] (ints: List<Int>)
+      LeafPsiElement 3:24 … 3:25: [LPAR] (
+      KtParameter 3:25 … 3:40: [] ints: List<Int>
+        LeafPsiElement 3:25 … 3:29: [IDENTIFIER] ints
+        LeafPsiElement 3:29 … 3:30: [COLON] :
+        PsiWhiteSpaceImpl 3:30 … 3:31: [WHITE_SPACE] 
+        KtTypeReference 3:31 … 3:40: [] List<Int>
+          KtUserType 3:31 … 3:40: [] List<Int>
+            KtNameReferenceExpression 3:31 … 3:35: [] List
+              LeafPsiElement 3:31 … 3:35: [IDENTIFIER] List
+            KtTypeArgumentList 3:35 … 3:40: [] <Int>
+              LeafPsiElement 3:35 … 3:36: [LT] <
+              KtTypeProjection 3:36 … 3:39: [] Int
+                KtTypeReference 3:36 … 3:39: [] Int
+                  KtUserType 3:36 … 3:39: [] Int
+                    KtNameReferenceExpression 3:36 … 3:39: [] Int
+                      LeafPsiElement 3:36 … 3:39: [IDENTIFIER] Int
+              LeafPsiElement 3:39 … 3:40: [GT] >
+      LeafPsiElement 3:40 … 3:41: [RPAR] )
+    PsiWhiteSpaceImpl 3:41 … 3:42: [WHITE_SPACE] 
+    KtBlockExpression 3:42 … 11:1: [] {    for (i in ints) {       … > println(i)        }    }}
+      LeafPsiElement 3:42 … 3:43: [LBRACE] {
+      PsiWhiteSpaceImpl 3:43 … 4:4: [WHITE_SPACE] 
+      KtForExpression 4:4 … 10:5: [] for (i in ints) {        when …  -> println(i)        }    }
+        LeafPsiElement 4:4 … 4:7: [for] for
+        PsiWhiteSpaceImpl 4:7 … 4:8: [WHITE_SPACE] 
+        LeafPsiElement 4:8 … 4:9: [LPAR] (
+        KtParameter 4:9 … 4:10: [] i
+          LeafPsiElement 4:9 … 4:10: [IDENTIFIER] i
+        PsiWhiteSpaceImpl 4:10 … 4:11: [WHITE_SPACE] 
+        LeafPsiElement 4:11 … 4:13: [in] in
+        PsiWhiteSpaceImpl 4:13 … 4:14: [WHITE_SPACE] 
+        KtContainerNode 4:14 … 4:18: [] ints
+          KtNameReferenceExpression 4:14 … 4:18: [] ints
+            LeafPsiElement 4:14 … 4:18: [IDENTIFIER] ints
+        LeafPsiElement 4:18 … 4:19: [RPAR] )
+        PsiWhiteSpaceImpl 4:19 … 4:20: [WHITE_SPACE] 
+        KtContainerNodeForControlStructureBody 4:20 … 10:5: [] {        when (i) {          …  -> println(i)        }    }
+          KtBlockExpression 4:20 … 10:5: [] {        when (i) {          …  -> println(i)        }    }
+            LeafPsiElement 4:20 … 4:21: [LBRACE] {
+            PsiWhiteSpaceImpl 4:21 … 5:8: [WHITE_SPACE] 
+            KtWhenExpression 5:8 … 9:9: [] when (i) {            in 2..< …   else -> println(i)        }
+              LeafPsiElement 5:8 … 5:12: [when] when
+              PsiWhiteSpaceImpl 5:12 … 5:13: [WHITE_SPACE] 
+              LeafPsiElement 5:13 … 5:14: [LPAR] (
+              KtNameReferenceExpression 5:14 … 5:15: [] i
+                LeafPsiElement 5:14 … 5:15: [IDENTIFIER] i
+              LeafPsiElement 5:15 … 5:16: [RPAR] )
+              PsiWhiteSpaceImpl 5:16 … 5:17: [WHITE_SPACE] 
+              LeafPsiElement 5:17 … 5:18: [LBRACE] {
+              PsiWhiteSpaceImpl 5:18 … 6:12: [WHITE_SPACE] 
+              KtWhenEntry 6:12 … 6:33: [] in 2..< 5 -> continue
+                KtWhenConditionInRange 6:12 … 6:21: [] in 2..< 5
+                  KtOperationReferenceExpression 6:12 … 6:14: [] in
+                    LeafPsiElement 6:12 … 6:14: [in] in
+                  PsiWhiteSpaceImpl 6:14 … 6:15: [WHITE_SPACE] 
+                  KtBinaryExpression 6:15 … 6:21: [] 2..< 5
+                    KtConstantExpression 6:15 … 6:16: [] 2
+                      LeafPsiElement 6:15 … 6:16: [INTEGER_LITERAL] 2
+                    KtOperationReferenceExpression 6:16 … 6:19: [] ..<
+                      LeafPsiElement 6:16 … 6:19: [RANGE_UNTIL] ..<
+                    PsiWhiteSpaceImpl 6:19 … 6:20: [WHITE_SPACE] 
+                    KtConstantExpression 6:20 … 6:21: [] 5
+                      LeafPsiElement 6:20 … 6:21: [INTEGER_LITERAL] 5
+                PsiWhiteSpaceImpl 6:21 … 6:22: [WHITE_SPACE] 
+                LeafPsiElement 6:22 … 6:24: [ARROW] ->
+                PsiWhiteSpaceImpl 6:24 … 6:25: [WHITE_SPACE] 
+                KtContinueExpression 6:25 … 6:33: [] continue
+                  LeafPsiElement 6:25 … 6:33: [continue] continue
+              PsiWhiteSpaceImpl 6:33 … 7:12: [WHITE_SPACE] 
+              KtWhenEntry 7:12 … 7:23: [] 39 -> break
+                KtWhenConditionWithExpression 7:12 … 7:14: [] 39
+                  KtConstantExpression 7:12 … 7:14: [] 39
+                    LeafPsiElement 7:12 … 7:14: [INTEGER_LITERAL] 39
+                PsiWhiteSpaceImpl 7:14 … 7:15: [WHITE_SPACE] 
+                LeafPsiElement 7:15 … 7:17: [ARROW] ->
+                PsiWhiteSpaceImpl 7:17 … 7:18: [WHITE_SPACE] 
+                KtBreakExpression 7:18 … 7:23: [] break
+                  LeafPsiElement 7:18 … 7:23: [break] break
+              PsiWhiteSpaceImpl 7:23 … 8:12: [WHITE_SPACE] 
+              KtWhenEntry 8:12 … 8:30: [] else -> println(i)
+                LeafPsiElement 8:12 … 8:16: [else] else
+                PsiWhiteSpaceImpl 8:16 … 8:17: [WHITE_SPACE] 
+                LeafPsiElement 8:17 … 8:19: [ARROW] ->
+                PsiWhiteSpaceImpl 8:19 … 8:20: [WHITE_SPACE] 
+                KtCallExpression 8:20 … 8:30: [] println(i)
+                  KtNameReferenceExpression 8:20 … 8:27: [] println
+                    LeafPsiElement 8:20 … 8:27: [IDENTIFIER] println
+                  KtValueArgumentList 8:27 … 8:30: [] (i)
+                    LeafPsiElement 8:27 … 8:28: [LPAR] (
+                    KtValueArgument 8:28 … 8:29: [] i
+                      KtNameReferenceExpression 8:28 … 8:29: [] i
+                        LeafPsiElement 8:28 … 8:29: [IDENTIFIER] i
+                    LeafPsiElement 8:29 … 8:30: [RPAR] )
+              PsiWhiteSpaceImpl 8:30 … 9:8: [WHITE_SPACE] 
+              LeafPsiElement 9:8 … 9:9: [RBRACE] }
+            PsiWhiteSpaceImpl 9:9 … 10:4: [WHITE_SPACE] 
+            LeafPsiElement 10:4 … 10:5: [RBRACE] }
+      PsiWhiteSpaceImpl 10:5 … 11:0: [WHITE_SPACE] 
+      LeafPsiElement 11:0 … 11:1: [RBRACE] }

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ExternalAndroidStorageAccessCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ExternalAndroidStorageAccessCheck.kt
@@ -23,12 +23,12 @@ import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtReferenceExpression
-import org.jetbrains.kotlin.psi2ir.unwrappedGetMethod
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.CallAbstractCheck
 import org.sonarsource.kotlin.api.checks.FunMatcher
+import org.sonarsource.kotlin.api.checks.unwrappedGetMethod
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
 
 private const val MESSAGE = "Make sure accessing the Android external storage is safe here."


### PR DESCRIPTION
Upgrading to Kotlin 1.9.0 requires few small changes:

1. it's not possible to import anymore`org.jetbrains.kotlin.psi2ir.unwrappedGetMethod` and `org.jetbrains.kotlin.psi2ir.unwrappedSetMethod` since these are internal; we need to define them in our codebase
2.  some few rules mismatch in its/ruling:
 2.1 [S105](https://sonarsource.github.io/rspec/#/rspec/S105) is correctly raised on `JtetestGenerated.kt`
 2.2 [S1451](https://sonarsource.github.io/rspec/#/rspec/S1451) is raised on `JtetestGenerated.kt` (to be checked)
 2.3 [S1481](https://sonarsource.github.io/rspec/#/rspec/S1481) is correctly NOT raised on `CommonConfig.kt`

Many json files in the `its/ruling/src/test/resources/expected/kotlin` have been changed to comply with the new sonar lints version that was updated in `SlangRulingTest` in this commit: https://github.com/SonarSource/sonar-kotlin/commit/31fb39b1474d708f2fb7177982ffce604d51328e
The following command was used to modify the files:
```
find . -type f -name "*.json"  -exec sed -z "s/,\n]/\n]/g;s/,\n\[/\n[/g;s/,\n}/\n}/g;s/:\[/: \[/g;s/'/\"/g" 
```