### PR TITLE
SONARKT-380 Weak TLS protocol improvement

### DIFF
--- a/kotlin-checks-test-sources/src/main/kotlin/checks/WeakSSLContextCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/WeakSSLContextCheckSample.kt
@@ -64,12 +64,12 @@ class WeakSSLContextCheckSample {
         bar(SSLContext.getInstance("SSL")) // Noncompliant {{Change this code to use a stronger protocol.}}
         bar(SSLContext.getInstance("SSLv2")) // Noncompliant
         bar(SSLContext.getInstance("SSLv3")) // Noncompliant
-        bar(SSLContext.getInstance("TLS")) // Noncompliant
+        bar(SSLContext.getInstance("TLS"))
         bar(SSLContext.getInstance("TLSv1")) // Noncompliant
         bar(SSLContext.getInstance("TLSv1.1")) // Noncompliant
         bar(SSLContext.getInstance("TLSv1.2"))
         bar(SSLContext.getInstance("TLSv1.3"))
-        bar(SSLContext.getInstance("DTLS")) // Noncompliant
+        bar(SSLContext.getInstance("DTLS"))
         bar(SSLContext.getInstance("DTLSv1.0")) // Noncompliant
         bar(SSLContext.getInstance("DTLSv1.2"))
         bar(SSLContext.getInstance("DTLSv1.3"))

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/WeakSSLContextCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/WeakSSLContextCheck.kt
@@ -48,8 +48,6 @@ class WeakSSLContextCheck : AbstractCheck() {
 
     private val WEAK_FOR_SSL = setOf(
         "SSL",
-        "TLS",
-        "DTLS",
         "SSLv2",
         "SSLv3",
         "TLSv1",


### PR DESCRIPTION
According to [SONARKT-1](https://sonarsource.atlassian.net/browse/SONARKT-1) **TLS** and **DTLS** are not incorrect version. In Java, these two protocols are [STRONG_AFTER_JAVA_8 ]( https://github.com/SonarSource/sonar-java/blob/master/java-checks/src/main/java/org/sonar/java/checks/WeakSSLContextCheck.java). 

[SONARKT-1]: https://sonarsource.atlassian.net/browse/SONARKT-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ