### PR TITLE
SONARKT-379 Fix false positive in S6218

### DIFF
--- a/kotlin-checks-test-sources/src/main/kotlin/checks/EqualsOverriddenWithArrayFieldCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/EqualsOverriddenWithArrayFieldCheckSample.kt
@@ -95,7 +95,7 @@ class EqualsOverriddenWithArrayFieldCheckSample {
         }
     }
 
-    data class WithInBodyProperty(val age: Int) { // Noncompliant {{Override equals and hashCode to consider array content in the method.}}
+    data class WithInBodyProperty(val age: Int) { // compliant
         val names: Array<String> = arrayOf("Alice")
         override fun toString(): String {
             return "$names\n$age"
@@ -156,8 +156,13 @@ class EqualsOverriddenWithArrayFieldCheckSample {
     data class EmptyBody(val names: Array<String>) { // Noncompliant {{Override equals and hashCode to consider array content in the method.}}
     }
 
-    data class ArrayInBody(val age: Int) { // Noncompliant {{Override equals and hashCode to consider array content in the method.}}
+    data class ArrayInBody(val age: Int) { // Compliant
         val employers = arrayOf("SonarSource")
+    }
+
+    data class ArrayGetterInBody(val age: Int) { // Compliant
+        val employers
+            get() = arrayOf("SonarSource")
     }
 
     data class NoArray(val age: Int) { // Compliant

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsOverriddenWithArrayFieldCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsOverriddenWithArrayFieldCheck.kt
@@ -56,12 +56,8 @@ class EqualsOverriddenWithArrayFieldCheck : AbstractCheck() {
     private fun KtClass.hasAnArrayProperty(bindingContext: BindingContext): Boolean {
         // Because we only call this function on data classes, we can assume they have constructor
         val constructor = this.findDescendantOfType<KtPrimaryConstructor>()!!
-        val oneParameterIsAnArray = constructor.valueParameters.any { it.isAnArray(bindingContext) }
-        return if (oneParameterIsAnArray) {
-            true
-        } else {
-            this.body?.properties?.any { it.isAnArray(bindingContext) } ?: false
-        }
+        // For data classes, only arguments of the primary constructor are included in equals and hashCode
+        return constructor.valueParameters.any { it.isAnArray(bindingContext) }
     }
 
     private fun KtClass.buildIssueMessage(bindingContext: BindingContext): String? {


### PR DESCRIPTION
Overriding `equals` and `hashCode` is not necessary for data classes that have array fields in their body, because only arguments of the primary constructor are included in the generated `equals` and `hashCode` for data classes.

This should not be trigger the rule:
```kotlin
data class ArrayInBody(val age: Int) { // Compliant
    val employers = arrayOf("SonarSource")
}
```