### PR TITLE
[NO-JIRA] Default to Maven central when not authenticated to repox

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,7 @@ allprojects {
                 }
             }
         }
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
To enable external, and unauthenticated-to-repox, users to build sonar-kotlin locally, we add maven central as the fallback repository.