### PR TITLE
Upgrade Shadow Gradle plugin to 8.3.1

### DIFF
--- a/sonar-kotlin-plugin/build.gradle.kts
+++ b/sonar-kotlin-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ import java.util.Date
 import java.util.jar.JarInputStream
 
 plugins {
-    id("com.github.johnrengelman.shadow") version "7.1.0"
+    id("com.gradleup.shadow") version "8.3.1"
     kotlin("jvm")
 }
 


### PR DESCRIPTION
Requires upgrade of Gradle to at least 8.3 - see #433 