### PR TITLE
Fix Kotlin Gradle plugin warning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.sonarsource.kotlin.buildsrc.tasks.CreateKotlinGradleRuleStubsTask
 import org.sonarsource.kotlin.buildsrc.tasks.CreateKotlinRuleStubsTask
@@ -125,7 +126,7 @@ subprojects {
     }
 
     tasks.withType<KotlinCompile>().all {
-        kotlinOptions.jvmTarget = java.sourceCompatibility.toString()
+        compilerOptions.jvmTarget = JvmTarget.fromTarget(java.sourceCompatibility.toString())
     }
 
     jacoco {

--- a/kotlin-checks-test-sources/build.gradle.kts
+++ b/kotlin-checks-test-sources/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 sonarqube.isSkipProject = true
 
 val compileKotlin: KotlinCompile by tasks
-compileKotlin.kotlinOptions {
+compileKotlin.compilerOptions {
     suppressWarnings = true
 }
 


### PR DESCRIPTION
> 'kotlinOptions: KotlinJvmOptions' is deprecated.
> Please migrate to the compilerOptions DSL.
> More details are here: https://kotl.in/u1r8ln