### PR TITLE
Aggregate coverage report should include `sonar-kotlin-test-api`

### DIFF
--- a/sonar-kotlin-plugin/build.gradle.kts
+++ b/sonar-kotlin-plugin/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     testImplementation(testLibs.sonar.plugin.api.test.fixtures)
 
     testImplementation(project(":sonar-kotlin-test-api"))
+    jacocoAggregation(project(":sonar-kotlin-test-api"))
 }
 
 val test: Test by tasks


### PR DESCRIPTION
This was overlooked in c60ff8f09a8c2eaa8fa286be68ca7a784276960d.