### PR TITLE
`:sonar-kotlin-api:test` should depend on `:kotlin-checks-test-sources`

### DIFF
--- a/sonar-kotlin-api/build.gradle.kts
+++ b/sonar-kotlin-api/build.gradle.kts
@@ -26,6 +26,9 @@ dependencies {
     testImplementation(project(":sonar-kotlin-test-api"))
 }
 
+val test: Test by tasks
+test.dependsOn(project(":kotlin-checks-test-sources").tasks.named("build"))
+
 task<JavaExec>("printAst") {
     group = "Application"
     classpath = sourceSets.main.get().runtimeClasspath


### PR DESCRIPTION
Otherwise execution of

    ./gradlew clean
    ./gradlew :sonar-kotlin-api:test

shows failures of `FunMatcherTest` and `KotlinTreeTest`.