### PR TITLE
SONARKT-414 Change license to SONAR Source-Available License v1.0 (SSALv1)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,165 +1,184 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+SONAR Source-Available License v1.0
+Last Updated November 13, 2024
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+1. DEFINITIONS
 
+"Agreement" means this Sonar Source-Available License v1.0
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+"Competing" means marketing a product or service as a substitute for the
+functionality or value of SonarQube. A product or service may compete regardless
+of how it is designed or deployed. For example, a product or service may compete
+even if it provides its functionality via any kind of interface (including
+services, libraries, or plug-ins), even if it is ported to a different platform
+or programming language, and even if it is provided free of charge.
 
-  0. Additional Definitions.
+"Contribution" means:
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
+  a) in the case of the initial Contributor, the initial content Distributed under
+this Agreement, and
 
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
+  b) in the case of each subsequent Contributor:
+    i) changes to the Program, and
+    ii) additions to the Program;
 
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
+where such changes and/or additions to the Program originate from and are
+Distributed by that particular Contributor. A Contribution "originates" from a
+Contributor if it was added to the Program by such Contributor itself or anyone
+acting on such Contributor's behalf. Contributions do not include changes or
+additions to the Program that are not Modified Works.
 
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
+"Contributor" means any person or entity that Distributes the Program.
 
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
+"Derivative Works" shall mean any work, whether in Source Code or other form,
+that is based on (or derived from) the Program and for which the editorial
+revisions, annotations, elaborations, or other modifications represent, as a
+whole, an original work of authorship.
 
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
+"Distribute" means the acts of a) distributing or b) making available in any
+manner that enables the transfer of a copy.
 
-  1. Exception to Section 3 of the GNU GPL.
+"Licensed Patents" mean patent claims licensable by a Contributor that are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
 
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
+"Modified Works" shall mean any work in Source Code or other form that results
+from an addition to, deletion from, or modification of the contents of the
+Program, including, for purposes of clarity, any new file in Source Code form
+that contains any contents of the Program. Modified Works shall not include
+works that contain only declarations, interfaces, types, classes, structures, or
+files of the Program solely in each case in order to link to, bind by name, or
+subclass the Program or Modified Works thereof.
 
-  2. Conveying Modified Versions.
+"Non-competitive Purpose" means any purpose except for (a) providing to others
+any product or service that includes or offers the same or substantially similar
+functionality as SonarQube, (b) Competing with SonarQube, and/or (c) employing,
+using, or engaging artificial intelligence technology that is not part of the
+Program to ingest, interpret, analyze, train on, or interact with the data
+provided by the Program, or to engage with the Program in any manner.
 
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
+"Notices" means any legal statements or attributions included with the Program,
+including, without limitation, statements concerning copyright, patent,
+trademark, disclaimers of warranty, or limitations of liability
 
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
+"Program" means the Contributions Distributed in accordance with this Agreement.
 
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
+"Recipient" means anyone who receives the Program under this Agreement,
+including Contributors.
 
-  3. Object Code Incorporating Material from Library Header Files.
+"SonarQube" means an open-source or commercial edition of software offered by
+SonarSource that is branded "SonarQube".
 
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
+"SonarSource" means SonarSource SA, a Swiss company registered in Switzerland
+under UID No. CHE-114.587.664.
 
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
+"Source Code" means the form of a Program preferred for making modifications,
+including but not limited to software source code, documentation source, and
+configuration files.
 
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
+2. GRANT OF RIGHTS
 
-  4. Combined Works.
+  a) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free copyright license, for any
+Non-competitive Purpose, to reproduce, prepare Derivative Works of, publicly
+display, publicly perform, Distribute and sublicense the Contribution of such
+Contributor, if any, and such Derivative Works.
 
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
+  b) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed
+Patents, for any Non-competitive Purpose, to make, use, sell, offer to sell,
+import, and otherwise transfer the Contribution of such Contributor, if any, in
+Source Code or other form. This patent license shall apply to the combination of
+the Contribution and the Program if, at the time the Contribution is added by
+the Contributor, such addition of the Contribution causes such combination to be
+covered by the Licensed Patents. The patent license shall not apply to any other
+combinations that include the Contribution.
 
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
+  c) Recipient understands that although each Contributor grants the licenses to
+its Contributions set forth herein, no assurances are provided by any
+Contributor that the Program does not infringe the patent or other intellectual
+property rights of any other entity. Each Contributor disclaims any liability to
+Recipient for claims brought by any other entity based on infringement of
+intellectual property rights or otherwise. As a condition to exercising the
+rights and licenses granted hereunder, each Recipient hereby assumes sole
+responsibility to secure any other intellectual property rights needed, if any.
+For example, if a third-party patent license is required to allow Recipient to
+Distribute the Program, it is Recipient's responsibility to acquire that license
+before distributing the Program.
 
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
+  d) Each Contributor represents that to its knowledge it has sufficient copyright
+rights in its Contribution, if any, to grant the copyright license set forth in
+this Agreement.
 
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
+3. REQUIREMENTS
 
-   d) Do one of the following:
+3.1 If a Contributor Distributes the Program in any form, then the Program must
+also be made available as Source Code, in accordance with section 3.2, and the
+Contributor must accompany the Program with a statement that the Source Code for
+the Program is available under this Agreement, and inform Recipients how to
+obtain it in a reasonable manner on or through a medium customarily used for
+software exchange; and
 
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
+3.2 When the Program is Distributed as Source Code:
 
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
+  a) it must be made available under this Agreement, and
 
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
+  b) a copy of this Agreement must be included with each copy of the Program.
 
-  5. Combined Libraries.
+3.3 Contributors may not remove or alter any Notices contained within the
+Program from any copy of the Program which they Distribute, provided that
+Contributors may add their own appropriate Notices.
 
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
+4. NO WARRANTY
 
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY
+APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT
+LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely
+responsible for determining the appropriateness of using and distributing the
+Program and assumes all risks associated with its exercise of rights under this
+Agreement, including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs or
+equipment, and unavailability or interruption of operations.
 
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
+5. DISCLAIMER OF LIABILITY
 
-  6. Revised Versions of the GNU Lesser General Public License.
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY
+APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF
+THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGES.
 
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
+6. GENERAL
 
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
+If any provision of this Agreement is invalid or unenforceable under applicable
+law, it shall not affect the validity or enforceability of the remainder of the
+terms of this Agreement, and without further action by the parties hereto, such
+provision shall be reformed to the minimum extent necessary to make such
+provision valid and enforceable.
 
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient’s patent(s), then such Recipient’s rights granted under
+Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient’s rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient’s rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient’s obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue and
+survive.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives
+no rights or licenses to the intellectual property of any Contributor under this
+Agreement, whether expressly, by implication, estoppel, or otherwise. All rights
+in the Program not expressly granted under this Agreement are reserved. Nothing
+in this Agreement is intended to be enforceable by any entity that is not a
+Contributor or Recipient. No third-party beneficiary rights are created under
+this Agreement.

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,19 +1,16 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-$YEAR SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */

--- a/README.md
+++ b/README.md
@@ -145,3 +145,5 @@ See [this README in the utils](utils-kotlin/README.md).
 
 If you want a graphical output of ASTs, see [this README in the utils](utils-kotlin/README.md) for more info on how to convert an AST into a
 DOT format.
+
+# License

--- a/README.md
+++ b/README.md
@@ -147,3 +147,11 @@ If you want a graphical output of ASTs, see [this README in the utils](utils-kot
 DOT format.
 
 # License
+
+Copyright 2018-2024 SonarSource.
+
+SonarQube analyzers released after November 29, 2024, including patch fixes for prior versions,
+are published under the [Sonar Source-Available License Version 1 (SSALv1)](LICENSE.txt).
+
+See individual files for details that specify the license applicable to each file.
+Files subject to the SSALv1 will be noted in their headers.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,8 +180,8 @@ subprojects {
                     }
                     licenses {
                         license {
-                            name.set("GNU LPGL 3")
-                            url.set("http://www.gnu.org/licenses/lgpl.txt")
+                            name.set("SSALv1")
+                            url.set("https://sonarsource.com/license/ssal/")
                             distribution.set("repo")
                         }
                     }

--- a/its/plugin/src/test/java/org/sonarsource/slang/DuplicationsTest.java
+++ b/its/plugin/src/test/java/org/sonarsource/slang/DuplicationsTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.slang;
 
 import org.junit.jupiter.api.Test;

--- a/its/plugin/src/test/java/org/sonarsource/slang/ExternalReportTest.java
+++ b/its/plugin/src/test/java/org/sonarsource/slang/ExternalReportTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.slang;
 
 import com.sonar.orchestrator.build.SonarScanner;

--- a/its/plugin/src/test/java/org/sonarsource/slang/MeasuresTest.java
+++ b/its/plugin/src/test/java/org/sonarsource/slang/MeasuresTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.slang;
 
 import org.junit.jupiter.api.Test;

--- a/its/plugin/src/test/java/org/sonarsource/slang/SonarLintTest.java
+++ b/its/plugin/src/test/java/org/sonarsource/slang/SonarLintTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.slang;
 
 import com.sonar.orchestrator.junit5.OrchestratorExtension;

--- a/its/plugin/src/test/java/org/sonarsource/slang/SuppressWarningsTest.java
+++ b/its/plugin/src/test/java/org/sonarsource/slang/SuppressWarningsTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.slang;
 
 

--- a/its/plugin/src/test/java/org/sonarsource/slang/SurefireTest.java
+++ b/its/plugin/src/test/java/org/sonarsource/slang/SurefireTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.slang;
 
 import com.sonar.orchestrator.build.MavenBuild;

--- a/its/plugin/src/test/java/org/sonarsource/slang/TestBase.java
+++ b/its/plugin/src/test/java/org/sonarsource/slang/TestBase.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.slang;
 
 import com.sonar.orchestrator.build.SonarScanner;

--- a/its/plugin/src/test/java/org/sonarsource/slang/TestsHelper.java
+++ b/its/plugin/src/test/java/org/sonarsource/slang/TestsHelper.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.slang;
 
 import com.sonar.orchestrator.OrchestratorBuilder;

--- a/its/ruling/src/test/java/org/sonarsource/slang/SlangRulingTest.java
+++ b/its/ruling/src/test/java/org/sonarsource/slang/SlangRulingTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.slang;
 
 import com.sonar.orchestrator.OrchestratorBuilder;

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/AbstractCheck.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/AbstractCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import com.intellij.psi.PsiComment

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/ApiExtensions.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/ApiExtensions.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import com.intellij.psi.PsiComment

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/ArgumentMatcher.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/ArgumentMatcher.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/CallAbstractCheck.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/CallAbstractCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/CollectionExtensions.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/CollectionExtensions.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 /**

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/CommonConstants.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/CommonConstants.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 const val INT_TYPE = "kotlin.Int"

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/FieldMatcher.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/FieldMatcher.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import org.jetbrains.kotlin.descriptors.ClassifierDescriptor

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/FunMatcher.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/FunMatcher.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import org.jetbrains.kotlin.backend.common.descriptors.isSuspend

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/InputFileContext.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/InputFileContext.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import org.sonar.api.batch.fs.InputFile

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/InputFileContextImpl.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/InputFileContextImpl.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import org.slf4j.LoggerFactory

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/KotlinCheck.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/KotlinCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import org.sonar.api.rule.RuleKey

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/common/KotlinLanguage.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/common/KotlinLanguage.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.common
 
 import org.sonar.api.config.Configuration

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/common/MeasureDuration.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/common/MeasureDuration.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.common
 
 import org.sonarsource.performance.measure.PerformanceMeasure

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/common/constants.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/common/constants.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.common
 
 import org.jetbrains.kotlin.config.LanguageVersion

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/AbstractPropertyHandlerSensor.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/AbstractPropertyHandlerSensor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import org.slf4j.LoggerFactory

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/KotlinAnalyzerRegexSource.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/KotlinAnalyzerRegexSource.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import com.intellij.openapi.editor.Document

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/KotlinCodeVerifier.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/KotlinCodeVerifier.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/KotlinCoreEnvironmentTools.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/KotlinCoreEnvironmentTools.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/KotlinFileContext.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/KotlinFileContext.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/KotlinTree.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/KotlinTree.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import com.intellij.openapi.editor.Document

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/ParseException.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/ParseException.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import org.sonar.api.batch.fs.TextPointer

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/RegexCache.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/RegexCache.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import org.jetbrains.kotlin.psi.KtStringTemplateEntry

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/logging/LoggerExtensions.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/logging/LoggerExtensions.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.logging
 
 import org.slf4j.Logger

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/regex/AbstractRegexCheck.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/regex/AbstractRegexCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.regex
 
 import org.jetbrains.kotlin.psi.KtBinaryExpression

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/regex/RegexContext.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/regex/RegexContext.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.regex
 
 import org.jetbrains.kotlin.psi.KtStringTemplateEntry

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/reporting/KotlinTextRanges.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/reporting/KotlinTextRanges.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.reporting
 
 import com.intellij.openapi.editor.Document

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/reporting/Message.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/reporting/Message.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.reporting
 
 class Message(text: String = "", ranges: List<Pair<Int, Int>> = mutableListOf()) {

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/reporting/SecondaryLocation.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/reporting/SecondaryLocation.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.reporting
 
 import org.sonar.api.batch.fs.TextRange

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensor.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.sensors
 
 import org.sonar.api.batch.fs.InputFile

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.sensors
 
 import com.intellij.openapi.util.Disposer

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/visiting/CommentAnnotationsAndTokenVisitor.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/visiting/CommentAnnotationsAndTokenVisitor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.visiting
 
 import com.intellij.openapi.editor.Document

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/visiting/KotlinFileVisitor.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/visiting/KotlinFileVisitor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.visiting
 
 import org.sonarsource.kotlin.api.checks.InputFileContext

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/visiting/KtChecksVisitor.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/visiting/KtChecksVisitor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.visiting
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/visiting/KtTreeVisitor.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/visiting/KtTreeVisitor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.visiting
 
 import org.jetbrains.kotlin.psi.KtElement

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/ast/AstPrinter.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/ast/AstPrinter.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.ast
 
 import org.jetbrains.kotlin.config.LanguageVersion

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/tools/AstPrinter.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/tools/AstPrinter.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.tools
 
 import com.intellij.openapi.editor.Document

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/AbstractCheckTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/AbstractCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/ApiExtensionsKtTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/ApiExtensionsKtTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/CollectionExtensionsKtTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/CollectionExtensionsKtTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/FieldMatcherTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/FieldMatcherTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/FunMatcherTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/FunMatcherTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import io.mockk.Called

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/InputFileContextImplTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/InputFileContextImplTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.checks
 
 import io.mockk.every

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/frontend/KotlinASTTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/frontend/KotlinASTTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import org.assertj.core.api.Assertions

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/frontend/KotlinCodeVerifierTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/frontend/KotlinCodeVerifierTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/frontend/KotlinCoreEnvironmentToolsTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/frontend/KotlinCoreEnvironmentToolsTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/frontend/KotlinSyntaxStructureTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/frontend/KotlinSyntaxStructureTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import io.mockk.every

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/frontend/KotlinTreeTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/frontend/KotlinTreeTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import java.nio.file.Files

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/frontend/TextRangeTrackerTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/frontend/TextRangeTrackerTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.frontend
 
 import org.jetbrains.kotlin.config.LanguageVersion

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/regex/AbstractRegexCheckTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/regex/AbstractRegexCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.regex
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.api.sensors
 
 import io.mockk.every

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/ast/AstPrinterTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/ast/AstPrinterTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.ast
 
 import org.assertj.core.api.Assertions

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/tools/AstPrinterTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/tools/AstPrinterTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.tools
 
 import org.jetbrains.kotlin.config.LanguageVersion

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AbstractBranchDuplication.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AbstractBranchDuplication.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AbstractClassShouldBeInterfaceCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AbstractClassShouldBeInterfaceCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AbstractTooLongFunctionRule.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AbstractTooLongFunctionRule.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtFunction

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AllBranchesIdenticalCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AllBranchesIdenticalCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AnchorPrecedenceCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AnchorPrecedenceCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.sonar.check.Rule

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AndroidBroadcastingCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AndroidBroadcastingCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ArrayHashCodeAndToStringCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ArrayHashCodeAndToStringCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AuthorisingNonAuthenticatedUsersCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AuthorisingNonAuthenticatedUsersCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/BadClassNameCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/BadClassNameCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtClass

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/BadFunctionNameCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/BadFunctionNameCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtNamedFunction

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/BiometricAuthWithoutCryptoCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/BiometricAuthWithoutCryptoCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/BooleanInversionCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/BooleanInversionCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/BooleanLiteralCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/BooleanLiteralCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CipherBlockChainingCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CipherBlockChainingCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CipherModeOperationCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CipherModeOperationCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ClearTextProtocolCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ClearTextProtocolCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CodeAfterJumpCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CodeAfterJumpCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtBlockExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CognitiveComplexity.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CognitiveComplexity.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CollapsibleIfStatementsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CollapsibleIfStatementsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtBlockExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CollectionCallingItselfCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CollectionCallingItselfCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CollectionInappropriateCallsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CollectionInappropriateCallsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CollectionShouldBeImmutableCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CollectionShouldBeImmutableCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CollectionSizeAndArrayLengthCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CollectionSizeAndArrayLengthCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.tree.IElementType

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CommentedCodeCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CommentedCodeCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiComment

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CoroutineScopeFunSuspendingCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CoroutineScopeFunSuspendingCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CoroutinesTimeoutApiUnusedCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/CoroutinesTimeoutApiUnusedCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DataHashingCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DataHashingCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DebugFeatureEnabledCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DebugFeatureEnabledCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DelegationPatternCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DelegationPatternCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DuplicateBranchCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DuplicateBranchCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtBlockExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DuplicatedFunctionImplementationCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DuplicatedFunctionImplementationCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DuplicatesInCharacterClassCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DuplicatesInCharacterClassCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.sonar.check.Rule

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ElseIfWithoutElseCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ElseIfWithoutElseCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtBreakExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EmptyBlockCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EmptyBlockCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtBlockExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EmptyCommentCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EmptyCommentCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiComment

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EmptyFunctionCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EmptyFunctionCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtNamedFunction

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EmptyLineRegexCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EmptyLineRegexCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import java.util.regex.Pattern

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EmptyStringRepetitionCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EmptyStringRepetitionCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.sonar.check.Rule

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EncryptionAlgorithmCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EncryptionAlgorithmCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsArgumentTypeCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsArgumentTypeCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsMethodUsageCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsMethodUsageCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsOverriddenWithArrayFieldCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsOverriddenWithArrayFieldCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtClass

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsOverridenWithHashCodeCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsOverridenWithHashCodeCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtClassBody

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ExposedMutableFlowCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ExposedMutableFlowCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtDeclaration

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ExternalAndroidStorageAccessCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ExternalAndroidStorageAccessCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/FileHeaderCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/FileHeaderCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtFile

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/FinalFlowOperationCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/FinalFlowOperationCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/FixMeCommentCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/FixMeCommentCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiComment

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/FlowChannelReturningFunsNotSuspendingCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/FlowChannelReturningFunsNotSuspendingCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtNamedFunction

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/FunctionCognitiveComplexityCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/FunctionCognitiveComplexityCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtNamedFunction

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/GraphemeClustersInClassesCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/GraphemeClustersInClassesCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.sonar.check.Rule

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/HardcodedCredentialsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/HardcodedCredentialsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import java.net.URI

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/HardcodedIpCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/HardcodedIpCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IdenticalBinaryOperandCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IdenticalBinaryOperandCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IdenticalConditionsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IdenticalConditionsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtContainerNodeForControlStructureBody

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IfConditionalAlwaysTrueOrFalseCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IfConditionalAlwaysTrueOrFalseCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtSingleValueToken

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IgnoredOperationStatusCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IgnoredOperationStatusCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ImplicitParameterInLambdaCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ImplicitParameterInLambdaCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtLambdaArgument

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IndexedAccessCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IndexedAccessCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/InjectableDispatchersCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/InjectableDispatchersCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/InterfaceCouldBeFunctionalCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/InterfaceCouldBeFunctionalCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/InvalidRegexCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/InvalidRegexCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IsInstanceMethodCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IsInstanceMethodCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/JumpInFinallyCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/JumpInFinallyCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtBreakExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/LiftReturnStatementCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/LiftReturnStatementCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/MainSafeCoroutinesCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/MainSafeCoroutinesCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.Call

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/MapValuesShouldBeAccessedSafelyCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/MapValuesShouldBeAccessedSafelyCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/MatchCaseTooBigCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/MatchCaseTooBigCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtWhenEntry

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/MergeIfElseIntoWhenCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/MergeIfElseIntoWhenCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.KtNodeTypes

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/MobileDatabaseEncryptionKeysCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/MobileDatabaseEncryptionKeysCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/NestedMatchCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/NestedMatchCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtWhenExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/OneStatementPerLineCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/OneStatementPerLineCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtBlockExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ParsingErrorCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ParsingErrorCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.sonar.check.Rule

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/PreparedStatementAndResultSetCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/PreparedStatementAndResultSetCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/PropertyGetterAndSetterUsageCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/PropertyGetterAndSetterUsageCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/PseudoRandomCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/PseudoRandomCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.descriptors.ConstructorDescriptor

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ReasonableTypeCastsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ReasonableTypeCastsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.diagnostics.Errors

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ReceivingIntentsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ReceivingIntentsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RedundantMethodsInDataClassesCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RedundantMethodsInDataClassesCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RedundantParenthesesCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RedundantParenthesesCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtParenthesizedExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RedundantSuspendModifierCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RedundantSuspendModifierCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.backend.common.descriptors.isSuspend

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RedundantTypeCastsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RedundantTypeCastsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.diagnostics.Errors

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RegexComplexityCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RegexComplexityCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.sonar.check.Rule

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ReluctantQuantifierCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ReluctantQuantifierCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.sonar.check.Rule

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ReplaceGuavaWithKotlinCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ReplaceGuavaWithKotlinCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RobustCryptographicKeysCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RobustCryptographicKeysCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RunFinalizersCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RunFinalizersCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SamConversionCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SamConversionCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtObjectDeclaration

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ScheduledThreadPoolExecutorZeroCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ScheduledThreadPoolExecutorZeroCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SelfAssignmentCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SelfAssignmentCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ServerCertificateCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ServerCertificateCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SimplifiedPreconditionsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SimplifiedPreconditionsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.impl.source.tree.LeafPsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SimplifyFilteringBeforeTerminalOperationCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SimplifyFilteringBeforeTerminalOperationCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SimplifySizeExpressionCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SimplifySizeExpressionCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SingletonPatternCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SingletonPatternCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.descriptors.ConstructorDescriptor

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/StreamNotConsumedCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/StreamNotConsumedCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/StringLiteralDuplicatedCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/StringLiteralDuplicatedCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/StrongCipherAlgorithmCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/StrongCipherAlgorithmCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/StructuredConcurrencyPrinciplesCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/StructuredConcurrencyPrinciplesCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SuspendingFunCallerDispatcherCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SuspendingFunCallerDispatcherCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.backend.common.descriptors.isSuspend

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SyntacticEquivalence.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SyntacticEquivalence.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TabsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TabsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtFile

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TodoCommentCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TodoCommentCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiComment

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooComplexExpressionCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooComplexExpressionCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooDeeplyNestedStatementsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooDeeplyNestedStatementsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooLongFunctionCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooLongFunctionCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtNamedFunction

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooLongLambdaCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooLongLambdaCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtLambdaExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooLongLineCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooLongLineCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtFile

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooManyCasesCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooManyCasesCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtWhenExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooManyLinesOfCodeFileCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooManyLinesOfCodeFileCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtFile

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooManyParametersCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooManyParametersCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnencryptedDatabaseOnMobileCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnencryptedDatabaseOnMobileCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnencryptedFilesInMobileApplicationsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnencryptedFilesInMobileApplicationsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnicodeAwareCharClassesCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnicodeAwareCharClassesCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnnecessaryImportsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnnecessaryImportsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.descriptors.VariableAccessorDescriptor

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnpredictableHashSaltCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnpredictableHashSaltCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnpredictableSecureRandomSaltCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnpredictableSecureRandomSaltCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnsuitedFindFunctionWithNullComparisonCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnsuitedFindFunctionWithNullComparisonCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens.EQEQ

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnusedDeferredResultCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnusedDeferredResultCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnusedFunctionParameterCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnusedFunctionParameterCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnusedLocalVariableCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnusedLocalVariableCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.diagnostics.Errors

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnusedPrivateMethodCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnusedPrivateMethodCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessAssignmentsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessAssignmentsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.diagnostics.Errors

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessIncrementCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessIncrementCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/VarShouldBeValCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/VarShouldBeValCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.descriptors.CallableDescriptor

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/VariableAndParameterNameCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/VariableAndParameterNameCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtLambdaExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/VerifiedServerHostnamesCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/VerifiedServerHostnamesCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.psi.KtExpression

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ViewModelSuspendingFunctionsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ViewModelSuspendingFunctionsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.descriptors.ClassDescriptor

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/VoidShouldBeUnitCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/VoidShouldBeUnitCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/WeakSSLContextCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/WeakSSLContextCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/WebViewJavaScriptSupportCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/WebViewJavaScriptSupportCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/WebViewsFileAccessCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/WebViewsFileAccessCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/WrongAssignmentOperatorCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/WrongAssignmentOperatorCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/AbstractClassShouldBeInterfaceCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/AbstractClassShouldBeInterfaceCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class AbstractClassShouldBeInterfaceCheckTest : CheckTest(AbstractClassShouldBeInterfaceCheck()),

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/AllBranchesIdenticalCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/AllBranchesIdenticalCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class AllBranchesIdenticalCheckTest : CheckTest(AllBranchesIdenticalCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/AnchorPrecedenceCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/AnchorPrecedenceCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class AnchorPrecedenceCheckTest : CheckTest(AnchorPrecedenceCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/AndroidBroadcastingCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/AndroidBroadcastingCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class AndroidBroadcastingCheckTest : CheckTest(AndroidBroadcastingCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ArrayHashCodeAndToStringCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ArrayHashCodeAndToStringCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class ArrayHashCodeAndToStringCheckTest : CheckTest(ArrayHashCodeAndToStringCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/AuthorisingNonAuthenticatedUsersCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/AuthorisingNonAuthenticatedUsersCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class AuthorisingNonAuthenticatedUsersCheckTest : CheckTest(AuthorisingNonAuthenticatedUsersCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/BadClassNameCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/BadClassNameCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class BadClassNameCheckTest : CheckTest(BadClassNameCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/BadFunctionNameCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/BadFunctionNameCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class BadFunctionNameCheckTest : CheckTest(BadFunctionNameCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/BiometricAuthWithoutCryptoCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/BiometricAuthWithoutCryptoCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class BiometricAuthWithoutCryptoCheckTest : CheckTest(BiometricAuthWithoutCryptoCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/BooleanInversionCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/BooleanInversionCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class BooleanInversionCheckTest : CheckTest(BooleanInversionCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/BooleanLiteralCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/BooleanLiteralCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class BooleanLiteralCheckTest : CheckTest(BooleanLiteralCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CheckTestForAndroidOnly.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CheckTestForAndroidOnly.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CheckTestNonCompiling.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CheckTestNonCompiling.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CheckTestWithNoSemantics.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CheckTestWithNoSemantics.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CipherBlockChainingCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CipherBlockChainingCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class CipherBlockChainingCheckTest : CheckTest(CipherBlockChainingCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CipherModeOperationCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CipherModeOperationCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class CipherModeOperationCheckTest : CheckTest(CipherModeOperationCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ClearTextProtocolCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ClearTextProtocolCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class ClearTextProtocolCheckTest : CheckTest(ClearTextProtocolCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CodeAfterJumpCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CodeAfterJumpCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class CodeAfterJumpCheckTest : CheckTest(CodeAfterJumpCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CollapsibleIfStatementsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CollapsibleIfStatementsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class CollapsibleIfStatementsCheckTest : CheckTest(CollapsibleIfStatementsCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CollectionCallingItselfCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CollectionCallingItselfCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class CollectionCallingItselfCheckTest : CheckTest(CollectionCallingItselfCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CollectionInappropriateCallsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CollectionInappropriateCallsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class CollectionInappropriateCallsCheckTest : CheckTest(CollectionInappropriateCallsCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CollectionShouldBeImmutableCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CollectionShouldBeImmutableCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class CollectionShouldBeImmutableCheckTest : CheckTestWithNoSemantics(CollectionShouldBeImmutableCheck()),

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CollectionSizeAndArrayLengthCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CollectionSizeAndArrayLengthCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class CollectionSizeAndArrayLengthCheckTest : CheckTest(CollectionSizeAndArrayLengthCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CommentedCodeCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CommentedCodeCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class CommentedCodeCheckTest : CheckTest(CommentedCodeCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CoroutineScopeFunSuspendingCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CoroutineScopeFunSuspendingCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class CoroutineScopeFunSuspendingCheckTest: CheckTest(CoroutineScopeFunSuspendingCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CoroutinesTimeoutApiUnusedCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/CoroutinesTimeoutApiUnusedCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class CoroutinesTimeoutApiUnusedCheckTest : CheckTest(CoroutinesTimeoutApiUnusedCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DataHashingCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DataHashingCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class DataHashingCheckTest : CheckTest(DataHashingCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DebugFeatureEnabledCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DebugFeatureEnabledCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class DebugFeatureEnabledCheckTest : CheckTest(DebugFeatureEnabledCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DelegationPatternCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DelegationPatternCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class DelegationPatternCheckTest : CheckTest(DelegationPatternCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DeprecatedCodeCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DeprecatedCodeCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class DeprecatedCodeCheckTest : CheckTestWithNoSemantics(DeprecatedCodeCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class DeprecatedCodeUsedCheckTest : CheckTest(DeprecatedCodeUsedCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DuplicateBranchCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DuplicateBranchCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class DuplicateBranchCheckTest : CheckTest(DuplicateBranchCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DuplicatedFunctionImplementationCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DuplicatedFunctionImplementationCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class DuplicatedFunctionImplementationCheckTest : CheckTest(DuplicatedFunctionImplementationCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DuplicatesInCharacterClassCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/DuplicatesInCharacterClassCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class DuplicatesInCharacterClassCheckTest : CheckTest(DuplicatesInCharacterClassCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ElseIfWithoutElseCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ElseIfWithoutElseCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class ElseIfWithoutElseCheckTest : CheckTest(ElseIfWithoutElseCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EmptyBlockCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EmptyBlockCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class EmptyBlockCheckTest : CheckTest(EmptyBlockCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EmptyCommentCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EmptyCommentCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class EmptyCommentCheckTest : CheckTest(EmptyCommentCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EmptyFunctionCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EmptyFunctionCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class EmptyFunctionCheckTest : CheckTest(EmptyFunctionCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EmptyLineRegexCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EmptyLineRegexCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class EmptyLineRegexCheckTest : CheckTest(EmptyLineRegexCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EmptyStringRepetitionCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EmptyStringRepetitionCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class EmptyStringRepetitionCheckTest : CheckTest(EmptyStringRepetitionCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EncryptionAlgorithmCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EncryptionAlgorithmCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class EncryptionAlgorithmCheckTest : CheckTest(EncryptionAlgorithmCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EqualsArgumentTypeCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EqualsArgumentTypeCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class EqualsArgumentTypeCheckTest : CheckTest(EqualsArgumentTypeCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EqualsMethodUsageCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EqualsMethodUsageCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class EqualsMethodUsageCheckTest : CheckTest(EqualsMethodUsageCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EqualsOverriddenWithArrayFieldCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EqualsOverriddenWithArrayFieldCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class EqualsOverriddenWithArrayFieldCheckTest : CheckTestWithNoSemantics(EqualsOverriddenWithArrayFieldCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EqualsOverridenWithHashCodeCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/EqualsOverridenWithHashCodeCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ExposedMutableFlowCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ExposedMutableFlowCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class ExposedMutableFlowCheckTest : CheckTest(ExposedMutableFlowCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ExternalAndroidStorageAccessCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ExternalAndroidStorageAccessCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class ExternalAndroidStorageAccessCheckTest : CheckTest(ExternalAndroidStorageAccessCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/FileHeaderCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/FileHeaderCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/FinalFlowOperationCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/FinalFlowOperationCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class FinalFlowOperationCheckTest : CheckTest(FinalFlowOperationCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/FixMeCommentCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/FixMeCommentCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class FixMeCommentCheckTest : CheckTest(FixMeCommentCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/FlowChannelReturningFunsNotSuspendingCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/FlowChannelReturningFunsNotSuspendingCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class FlowChannelReturningFunsNotSuspendingCheckTest : CheckTest(FlowChannelReturningFunsNotSuspendingCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/FunctionCognitiveComplexityCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/FunctionCognitiveComplexityCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class FunctionCognitiveComplexityCheckTest : CheckTest(FunctionCognitiveComplexityCheck().apply { threshold = 4 })

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/GraphemeClustersInClassesCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/GraphemeClustersInClassesCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class GraphemeClustersInClassesCheckTest : CheckTest(GraphemeClustersInClassesCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/HardcodedCredentialsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/HardcodedCredentialsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class HardcodedCredentialsCheckTest : CheckTest(HardcodedCredentialsCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/HardcodedIpCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/HardcodedIpCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class HardcodedIpCheckTest : CheckTest(HardcodedIpCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/IdenticalBinaryOperandCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/IdenticalBinaryOperandCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class IdenticalBinaryOperandCheckTest : CheckTest(IdenticalBinaryOperandCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/IdenticalConditionsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/IdenticalConditionsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class IdenticalConditionsCheckTest : CheckTest(IdenticalConditionsCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/IfConditionalAlwaysTrueOrFalseCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/IfConditionalAlwaysTrueOrFalseCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class IfConditionalAlwaysTrueOrFalseCheckTest : CheckTest(IfConditionalAlwaysTrueOrFalseCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/IgnoredOperationStatusCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/IgnoredOperationStatusCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class IgnoredOperationStatusCheckTest : CheckTest(IgnoredOperationStatusCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ImplicitParameterInLambdaCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ImplicitParameterInLambdaCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class ImplicitParameterInLambdaCheckTest : CheckTest(ImplicitParameterInLambdaCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/IndexedAccessCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/IndexedAccessCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class IndexedAccessCheckTest : CheckTest(IndexedAccessCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/InjectableDispatchersCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/InjectableDispatchersCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class InjectableDispatchersCheckTest : CheckTest(InjectableDispatchersCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/InterfaceCouldBeFunctionalCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/InterfaceCouldBeFunctionalCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class InterfaceCouldBeFunctionalCheckTest : CheckTest(InterfaceCouldBeFunctionalCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/InvalidRegexCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/InvalidRegexCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class InvalidRegexCheckTest : CheckTest(InvalidRegexCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/IsInstanceMethodCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/IsInstanceMethodCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class IsInstanceMethodCheckTest : CheckTest(IsInstanceMethodCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/JumpInFinallyCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/JumpInFinallyCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class JumpInFinallyCheckTest : CheckTest(JumpInFinallyCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/LiftReturnStatementCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/LiftReturnStatementCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class LiftReturnStatementCheckTest : CheckTest(LiftReturnStatementCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/MainSafeCoroutinesCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/MainSafeCoroutinesCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class MainSafeCoroutinesCheckTest : CheckTest(MainSafeCoroutinesCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/MapValuesShouldBeAccessedSafelyCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/MapValuesShouldBeAccessedSafelyCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class MapValuesShouldBeAccessedSafelyCheckTest : CheckTest(MapValuesShouldBeAccessedSafelyCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/MatchCaseTooBigCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/MatchCaseTooBigCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class MatchCaseTooBigCheckTest : CheckTest(MatchCaseTooBigCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/MergeIfElseIntoWhenCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/MergeIfElseIntoWhenCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/MobileDatabaseEncryptionKeysCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/MobileDatabaseEncryptionKeysCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class MobileDatabaseEncryptionKeysCheckTest : CheckTest(MobileDatabaseEncryptionKeysCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/NestedMatchCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/NestedMatchCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class NestedMatchCheckTest : CheckTest(NestedMatchCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/OneStatementPerLineCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/OneStatementPerLineCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class OneStatementPerLineCheckTest : CheckTest(OneStatementPerLineCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/PreparedStatementAndResultSetCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/PreparedStatementAndResultSetCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class PreparedStatementAndResultSetCheckTest : CheckTest(PreparedStatementAndResultSetCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/PropertyGetterAndSetterUsageCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/PropertyGetterAndSetterUsageCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/PseudoRandomCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/PseudoRandomCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class PseudoRandomCheckTest : CheckTest(PseudoRandomCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ReasonableTypeCastsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ReasonableTypeCastsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class ReasonableTypeCastsCheckTest : CheckTest(ReasonableTypeCastsCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ReceivingIntentsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ReceivingIntentsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class ReceivingIntentsCheckTest : CheckTest(ReceivingIntentsCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RedundantMethodsInDataClassesCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RedundantMethodsInDataClassesCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class RedundantMethodsInDataClassesCheckTest : CheckTest(RedundantMethodsInDataClassesCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RedundantParenthesesCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RedundantParenthesesCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class RedundantParenthesesCheckTest : CheckTest(RedundantParenthesesCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RedundantSuspendModifierCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RedundantSuspendModifierCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class RedundantSuspendModifierCheckTest : CheckTestWithNoSemantics(RedundantSuspendModifierCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RedundantTypeCastsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RedundantTypeCastsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class RedundantTypeCastsCheckTest : CheckTest(RedundantTypeCastsCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RegexComplexityCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RegexComplexityCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class RegexComplexityCheckTest : CheckTest(RegexComplexityCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ReluctantQuantifierCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ReluctantQuantifierCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class ReluctantQuantifierCheckTest : CheckTest(ReluctantQuantifierCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ReplaceGuavaWithKotlinCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ReplaceGuavaWithKotlinCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class ReplaceGuavaWithKotlinCheckTest : CheckTest(ReplaceGuavaWithKotlinCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RobustCryptographicKeysCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RobustCryptographicKeysCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class RobustCryptographicKeysCheckTest : CheckTest(RobustCryptographicKeysCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RunFinalizersCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/RunFinalizersCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class RunFinalizersCheckTest : CheckTest(RunFinalizersCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SamConversionCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SamConversionCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class SamConversionCheckTest : CheckTest(SamConversionCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ScheduledThreadPoolExecutorZeroCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ScheduledThreadPoolExecutorZeroCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class ScheduledThreadPoolExecutorZeroCheckTest : CheckTest(ScheduledThreadPoolExecutorZeroCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SelfAssignmentCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SelfAssignmentCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class SelfAssignmentCheckTest : CheckTest(SelfAssignmentCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ServerCertificateCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ServerCertificateCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class ServerCertificateCheckTest : CheckTestWithNoSemantics(ServerCertificateCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SimplifiedPreconditionsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SimplifiedPreconditionsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class SimplifiedPreconditionsCheckTest : CheckTest(SimplifiedPreconditionsCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SimplifyFilteringBeforeTerminalOperationCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SimplifyFilteringBeforeTerminalOperationCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class SimplifyFilteringBeforeTerminalOperationCheckTest : CheckTestWithNoSemantics(SimplifyFilteringBeforeTerminalOperationCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SimplifySizeExpressionCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SimplifySizeExpressionCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class SimplifySizeExpressionCheckTest : CheckTest(SimplifySizeExpressionCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SingletonPatternCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SingletonPatternCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/StreamNotConsumedCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/StreamNotConsumedCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class StreamNotConsumedCheckTest : CheckTest(StreamNotConsumedCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/StringLiteralDuplicatedCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/StringLiteralDuplicatedCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class StringLiteralDuplicatedCheckTest : CheckTest(StringLiteralDuplicatedCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/StrongCipherAlgorithmCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/StrongCipherAlgorithmCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class StrongCipherAlgorithmCheckTest : CheckTest(StrongCipherAlgorithmCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/StructuredConcurrencyPrinciplesCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/StructuredConcurrencyPrinciplesCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class StructuredConcurrencyPrinciplesCheckTest : CheckTest(StructuredConcurrencyPrinciplesCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SuspendingFunCallerDispatcherCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/SuspendingFunCallerDispatcherCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class SuspendingFunCallerDispatcherCheckTest : CheckTest(SuspendingFunCallerDispatcherCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TabsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TabsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TodoCommentCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TodoCommentCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class TodoCommentCheckTest : CheckTest(TodoCommentCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooComplexExpressionCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooComplexExpressionCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class TooComplexExpressionCheckTest : CheckTest(TooComplexExpressionCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooDeeplyNestedStatementsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooDeeplyNestedStatementsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class TooDeeplyNestedStatementsCheckTest : CheckTest(TooDeeplyNestedStatementsCheck().apply { max = 1 })

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooLongFunctionCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooLongFunctionCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class TooLongFunctionCheckTest : CheckTest(TooLongFunctionCheck().apply { max = 3 })

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooLongLambdaCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooLongLambdaCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class TooLongLambdaCheckTest : CheckTest(TooLongLambdaCheck().apply { max = 3 })

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooLongLineCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooLongLineCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class TooLongLineCheckTest : CheckTest(TooLongLineCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooManyCasesCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooManyCasesCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class TooManyCasesCheckTest : CheckTest(TooManyCasesCheck().apply { maximum = 2 })

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooManyLinesOfCodeFileCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooManyLinesOfCodeFileCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooManyParametersCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/TooManyParametersCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class TooManyParametersCheckTest : CheckTest(TooManyParametersCheck().apply { max = 2 })

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnencryptedDatabaseOnMobileCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnencryptedDatabaseOnMobileCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class UnencryptedDatabaseOnMobileCheckTest : CheckTest(UnencryptedDatabaseOnMobileCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnencryptedFilesInMobileApplicationsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnencryptedFilesInMobileApplicationsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class UnencryptedFilesInMobileApplicationsCheckTest: CheckTestForAndroidOnly(UnencryptedFilesInMobileApplicationsCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnicodeAwareCharClassesCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnicodeAwareCharClassesCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class UnicodeAwareCharClassesCheckTest : CheckTest(UnicodeAwareCharClassesCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnnecessaryImportsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnnecessaryImportsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnpredictableHashSaltCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnpredictableHashSaltCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class UnpredictableHashSaltCheckTest : CheckTest(UnpredictableHashSaltCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnpredictableSecureRandomSaltCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnpredictableSecureRandomSaltCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class UnpredictableSecureRandomSaltCheckTest : CheckTest(UnpredictableSecureRandomSaltCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnsuitedFindFunctionWithNullComparisonCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnsuitedFindFunctionWithNullComparisonCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class UnsuitedFindFunctionWithNullComparisonCheckTest : CheckTest(UnsuitedFindFunctionWithNullComparisonCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnusedAsyncResultCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnusedAsyncResultCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class UnusedDeferredResultCheckTest : CheckTest(UnusedDeferredResultCheck()) 

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnusedFunctionParameterCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnusedFunctionParameterCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class UnusedFunctionParameterCheckTest : CheckTest(UnusedFunctionParameterCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnusedLocalVariableCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnusedLocalVariableCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnusedPrivateMethodCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnusedPrivateMethodCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class UnusedPrivateMethodCheckTest : CheckTestWithNoSemantics(UnusedPrivateMethodCheck(), shouldReport = true)

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UselessAssignmentsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UselessAssignmentsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class UselessAssignmentsCheckTest : CheckTest(UselessAssignmentsCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UselessIncrementCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UselessIncrementCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class UselessIncrementCheckTest : CheckTest(UselessIncrementCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UselessNullCheckCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UselessNullCheckCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import io.mockk.every

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/VarShouldBeValCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/VarShouldBeValCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/VariableAndParameterNameCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/VariableAndParameterNameCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class VariableAndParameterNameCheckTest : CheckTest(VariableAndParameterNameCheck().apply { format = "^[_a-z][a-zA-Z0-9]*$" })

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/VerifiedServerHostnamesCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/VerifiedServerHostnamesCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class VerifiedServerHostnamesCheckTest : CheckTest(VerifiedServerHostnamesCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ViewModelSuspendingFunctionsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/ViewModelSuspendingFunctionsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 internal class ViewModelSuspendingFunctionsCheckTest : CheckTest(ViewModelSuspendingFunctionsCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/VoidShouldBeUnitCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/VoidShouldBeUnitCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/WeakSSLContextCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/WeakSSLContextCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class WeakSSLContextCheckTest : CheckTest(WeakSSLContextCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/WebViewJavaScriptSupportCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/WebViewJavaScriptSupportCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class WebViewJavaScriptSupportCheckTest : CheckTest(WebViewJavaScriptSupportCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/WebViewsFileAccessCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/WebViewsFileAccessCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class WebViewsFileAccessCheckTest : CheckTest(WebViewsFileAccessCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/WrongAssignmentOperatorCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/WrongAssignmentOperatorCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks
 
 class WrongAssignmentOperatorCheckTest : CheckTest(WrongAssignmentOperatorCheck())

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/testing/DummyKotlinCheck.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/testing/DummyKotlinCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks.testing
 
 import org.jetbrains.kotlin.psi.KtNamedFunction

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/testing/DummyKotlinCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/testing/DummyKotlinCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.checks.testing
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintRulesDefinition.kt
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintRulesDefinition.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.androidlint
 
 import org.sonar.api.server.rule.RulesDefinition

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintSensor.kt
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintSensor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.androidlint
 
 import org.slf4j.LoggerFactory

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintXmlReportReader.kt
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintXmlReportReader.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.androidlint
 
 import java.io.IOException

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/common/CheckstyleFormatImporter.java
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/common/CheckstyleFormatImporter.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.common;
 
 import org.slf4j.Logger;

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/common/CheckstyleFormatImporterWithRuleLoader.java
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/common/CheckstyleFormatImporterWithRuleLoader.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.common;
 
 import javax.annotation.Nullable;

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/common/package-info.java
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/common/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource Kotlin
- * Copyright (C) 2018-$YEAR SonarSource SA
+ * Copyright (C) 2018-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/common/package-info.java
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/common/package-info.java
@@ -1,21 +1,18 @@
 /*
  * SonarSource Kotlin
- * Copyright (C) 2018-2024 SonarSource SA
+ * Copyright (C) 2018-$YEAR SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @javax.annotation.ParametersAreNonnullByDefault
 package org.sonarsource.kotlin.externalreport.common;

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/detekt/DetektRulesDefinition.kt
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/detekt/DetektRulesDefinition.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.detekt
 
 import org.sonar.api.server.rule.RulesDefinition

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/detekt/DetektSensor.kt
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/detekt/DetektSensor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.detekt
 
 import org.slf4j.LoggerFactory

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/ktlint/CheckstyleReportParser.kt
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/ktlint/CheckstyleReportParser.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.ktlint
 
 import org.sonar.api.batch.sensor.SensorContext

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/ktlint/JsonReportParser.kt
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/ktlint/JsonReportParser.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.ktlint
 
 import com.google.gson.Gson

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/ktlint/KtlintRulesDefinition.kt
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/ktlint/KtlintRulesDefinition.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.ktlint
 
 import org.sonar.api.server.rule.RulesDefinition

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/ktlint/KtlintSensor.kt
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/ktlint/KtlintSensor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.ktlint
 
 import org.sonar.api.batch.sensor.SensorContext

--- a/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/ktlint/ReportImporter.kt
+++ b/sonar-kotlin-external-linters/src/main/java/org/sonarsource/kotlin/externalreport/ktlint/ReportImporter.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.ktlint
 
 import org.slf4j.LoggerFactory

--- a/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintRulesDefinitionTest.kt
+++ b/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintRulesDefinitionTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.androidlint
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintSensorTest.kt
+++ b/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintSensorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.androidlint
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/common/CheckstyleFormatImporterTest.java
+++ b/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/common/CheckstyleFormatImporterTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.common;
 
 import java.io.IOException;

--- a/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/common/CheckstyleFormatImporterWithRuleLoaderTest.java
+++ b/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/common/CheckstyleFormatImporterWithRuleLoaderTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.common;
 
 import java.io.IOException;

--- a/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/common/ExternalReportTestUtils.kt
+++ b/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/common/ExternalReportTestUtils.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.common
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/detekt/DetektRulesDefinitionTest.kt
+++ b/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/detekt/DetektRulesDefinitionTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.detekt
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/detekt/DetektSensorTest.kt
+++ b/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/detekt/DetektSensorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.detekt
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/ktlint/KtlintRulesDefinitionTest.kt
+++ b/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/ktlint/KtlintRulesDefinitionTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.ktlint
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/ktlint/KtlintSensorTest.kt
+++ b/sonar-kotlin-external-linters/src/test/java/org/sonarsource/kotlin/externalreport/ktlint/KtlintSensorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.ktlint
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/KotlinGradleCheckList.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/KotlinGradleCheckList.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle
 
 import org.sonarsource.kotlin.api.checks.KotlinCheck

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/KotlinGradleSensor.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/KotlinGradleSensor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle
 
 import org.jetbrains.kotlin.resolve.BindingContext

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/CorePluginsShortcutUsageCheck.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/CorePluginsShortcutUsageCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/DependencyGroupedCheck.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/DependencyGroupedCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/DependencyVersionHardcodedCheck.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/DependencyVersionHardcodedCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/MissingSettingsCheck.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/MissingSettingsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 import org.sonar.check.Rule

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/RootProjectNamePresentCheck.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/RootProjectNamePresentCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/TaskDefinitionsCheck.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/TaskDefinitionsCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/TaskRegisterVsCreateCheck.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/TaskRegisterVsCreateCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/dependencyChecks.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/checks/dependencyChecks.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 import org.jetbrains.kotlin.psi.KtBlockExpression

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/CheckConfigurationIntegrityTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/CheckConfigurationIntegrityTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle
 
 import org.assertj.core.api.Assertions

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/KotlinGradleSensorTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/KotlinGradleSensorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle
 
 import io.mockk.every

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/CheckTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/CheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/CorePluginsShortcutUsageCheckTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/CorePluginsShortcutUsageCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 internal class CorePluginsShortcutUsageCheckTest : CheckTest(CorePluginsShortcutUsageCheck())

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/DependencyGroupedCheckTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/DependencyGroupedCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 internal class DependencyGroupedCheckTest : CheckTest(DependencyGroupedCheck())

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/DependencyVersionHardcodedCheckTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/DependencyVersionHardcodedCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 internal class DependencyVersionHardcodedCheckTest : CheckTest(DependencyVersionHardcodedCheck())

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/RootProjectNamePresentCheckTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/RootProjectNamePresentCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/TaskDefinitionsCheckTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/TaskDefinitionsCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 internal class TaskDefinitionsCheckTest : CheckTest(TaskDefinitionsCheck())

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/TaskRegisterVsCreateCheckTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/TaskRegisterVsCreateCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks
 
 internal class TaskRegisterVsCreateCheckTest : CheckTest(TaskRegisterVsCreateCheck())

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/testing/DummyKotlinGradleCheck.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/testing/DummyKotlinGradleCheck.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks.testing
 
 import org.jetbrains.kotlin.psi.KtNamedFunction

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/testing/DummyKotlinGradleCheckTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/checks/testing/DummyKotlinGradleCheckTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.gradle.checks.testing
 
 import org.junit.jupiter.api.Test

--- a/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/CyclomaticComplexityVisitor.kt
+++ b/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/CyclomaticComplexityVisitor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.metrics
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/IssueSuppressionVisitor.kt
+++ b/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/IssueSuppressionVisitor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.metrics
 
 import org.jetbrains.kotlin.psi.KtAnnotated

--- a/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/MetricVisitor.kt
+++ b/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/MetricVisitor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.metrics
 
 import com.intellij.openapi.editor.Document

--- a/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/StatementsVisitor.kt
+++ b/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/StatementsVisitor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.metrics
 
 import org.jetbrains.kotlin.psi.KtBlockExpression

--- a/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/SyntaxHighlighter.kt
+++ b/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/SyntaxHighlighter.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.metrics
 
 import com.intellij.psi.PsiAnnotation

--- a/sonar-kotlin-metrics/src/test/java/org/sonarsource/kotlin/metrics/CyclomaticComplexityVisitorTest.kt
+++ b/sonar-kotlin-metrics/src/test/java/org/sonarsource/kotlin/metrics/CyclomaticComplexityVisitorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.metrics
 
 import org.assertj.core.api.Assertions

--- a/sonar-kotlin-metrics/src/test/java/org/sonarsource/kotlin/metrics/IssueSuppressionVisitorTest.kt
+++ b/sonar-kotlin-metrics/src/test/java/org/sonarsource/kotlin/metrics/IssueSuppressionVisitorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.metrics
 
 import org.jetbrains.kotlin.config.LanguageVersion

--- a/sonar-kotlin-metrics/src/test/java/org/sonarsource/kotlin/metrics/MetricVisitorTest.kt
+++ b/sonar-kotlin-metrics/src/test/java/org/sonarsource/kotlin/metrics/MetricVisitorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.metrics
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-metrics/src/test/java/org/sonarsource/kotlin/metrics/StatementsVisitorTest.kt
+++ b/sonar-kotlin-metrics/src/test/java/org/sonarsource/kotlin/metrics/StatementsVisitorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.metrics
 
 import org.assertj.core.api.Assertions

--- a/sonar-kotlin-metrics/src/test/java/org/sonarsource/kotlin/metrics/SyntaxHighlighterTest.kt
+++ b/sonar-kotlin-metrics/src/test/java/org/sonarsource/kotlin/metrics/SyntaxHighlighterTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.metrics
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinCheckList.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinCheckList.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.sonarsource.kotlin.checks.AbstractClassShouldBeInterfaceCheck

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinPlugin.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinPlugin.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.sonar.api.Plugin

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProfileDefinition.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProfileDefinition.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinRulesDefinition.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinRulesDefinition.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.sonar.api.SonarRuntime

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinSensor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.jetbrains.kotlin.resolve.BindingContext

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/caching/ContentHashCache.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/caching/ContentHashCache.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin.caching
 
 import org.slf4j.LoggerFactory

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/cpd/Caching.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/cpd/Caching.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin.cpd
 
 import org.slf4j.LoggerFactory

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/cpd/CopyPasteDetector.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/cpd/CopyPasteDetector.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin.cpd
 
 import com.intellij.psi.PsiComment

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/linking/WorkaroundForJarMinimization.java
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/linking/WorkaroundForJarMinimization.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin.linking;
 
 import java.util.List;

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/linking/package-info.java
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/linking/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource Kotlin
- * Copyright (C) 2018-$YEAR SonarSource SA
+ * Copyright (C) 2018-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/linking/package-info.java
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/linking/package-info.java
@@ -1,21 +1,18 @@
 /*
  * SonarSource Kotlin
- * Copyright (C) 2018-2024 SonarSource SA
+ * Copyright (C) 2018-$YEAR SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @javax.annotation.ParametersAreNonnullByDefault
 package org.sonarsource.kotlin.plugin.linking;

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/CheckConfigurationIntegrityTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/CheckConfigurationIntegrityTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.assertj.core.api.Assertions

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/CheckRegistrationTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/CheckRegistrationTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import io.mockk.spyk

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/ContentHashCacheTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/ContentHashCacheTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/DummyReadCache.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/DummyReadCache.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.sonar.api.batch.sensor.cache.ReadCache

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/DummyWriteCache.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/DummyWriteCache.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.sonar.api.batch.sensor.cache.ReadCache

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinLanguageTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinLanguageTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.assertj.core.api.AssertionsForClassTypes

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinPluginTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinPluginTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.assertj.core.api.Assertions

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProfileDefinitionTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProfileDefinitionTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import com.google.gson.Gson

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinRulesDefinitionTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinRulesDefinitionTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.assertj.core.api.Assertions

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import io.mockk.every

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/TextRangeAssert.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/TextRangeAssert.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin
 
 import org.assertj.core.api.AbstractAssert

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/cpd/CachingTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/cpd/CachingTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin.cpd
 
 import io.mockk.every

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/cpd/CopyPasteDetectorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/cpd/CopyPasteDetectorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin.cpd
 
 import org.assertj.core.api.Assertions

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/linking/WorkaroundForJarMinimizationTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/linking/WorkaroundForJarMinimizationTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.plugin.linking
 
 import org.assertj.core.api.Assertions.assertThat

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/KotlinResourcesLocator.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/KotlinResourcesLocator.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire;
 
 import org.slf4j.Logger;

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/KotlinSurefireParser.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/KotlinSurefireParser.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire;
 
 import java.io.File;

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/KotlinSurefireSensor.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/KotlinSurefireSensor.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire;
 
 import org.slf4j.Logger;

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/StaxParser.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/StaxParser.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire;
 
 import com.ctc.wstx.api.WstxInputProperties;

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/api/SurefireUtils.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/api/SurefireUtils.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire.api;
 
 import org.slf4j.Logger;

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/api/package-info.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/api/package-info.java
@@ -1,21 +1,16 @@
 /*
  * SonarSource Kotlin
- * Copyright (C) 2018-2024 SonarSource SA
+ * Copyright (C) 2018-$YEAR SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-@javax.annotation.ParametersAreNonnullByDefault
-package org.sonarsource.kotlin.surefire.api;

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/api/package-info.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/api/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource Kotlin
- * Copyright (C) 2018-$YEAR SonarSource SA
+ * Copyright (C) 2018-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/data/SurefireStaxHandler.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/data/SurefireStaxHandler.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire.data;
 
 import java.text.ParseException;

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/data/UnitTestClassReport.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/data/UnitTestClassReport.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire.data;
 
 import java.util.ArrayList;

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/data/UnitTestIndex.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/data/UnitTestIndex.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire.data;
 
 import java.util.HashMap;

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/data/UnitTestResult.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/data/UnitTestResult.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire.data;
 
 import java.util.UUID;

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/data/package-info.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/data/package-info.java
@@ -1,21 +1,18 @@
 /*
  * SonarSource Kotlin
- * Copyright (C) 2018-2024 SonarSource SA
+ * Copyright (C) 2018-$YEAR SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @javax.annotation.ParametersAreNonnullByDefault
 package org.sonarsource.kotlin.surefire.data;

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/data/package-info.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/data/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource Kotlin
- * Copyright (C) 2018-$YEAR SonarSource SA
+ * Copyright (C) 2018-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/package-info.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource Kotlin
- * Copyright (C) 2018-$YEAR SonarSource SA
+ * Copyright (C) 2018-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/package-info.java
+++ b/sonar-kotlin-surefire/src/main/java/org/sonarsource/kotlin/surefire/package-info.java
@@ -1,21 +1,16 @@
 /*
  * SonarSource Kotlin
- * Copyright (C) 2018-2024 SonarSource SA
+ * Copyright (C) 2018-$YEAR SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-@javax.annotation.ParametersAreNonnullByDefault
-package org.sonarsource.kotlin.surefire;

--- a/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/KotlinResourcesLocatorTest.java
+++ b/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/KotlinResourcesLocatorTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire;
 
 import java.io.File;

--- a/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/KotlinSurefireParserTest.java
+++ b/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/KotlinSurefireParserTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire;
 
 import java.io.File;

--- a/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/KotlinSurefireSensorTest.java
+++ b/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/KotlinSurefireSensorTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire;
 
 import java.io.File;

--- a/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/api/SurefireUtilsTest.java
+++ b/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/api/SurefireUtilsTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire.api;
 
 import java.io.File;

--- a/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/data/SurefireStaxHandlerTest.java
+++ b/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/data/SurefireStaxHandlerTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire.data;
 
 import java.io.File;

--- a/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/data/UnitTestClassReportTest.java
+++ b/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/data/UnitTestClassReportTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire.data;
 
 import org.junit.jupiter.api.Test;

--- a/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/data/UnitTestIndexTest.java
+++ b/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/data/UnitTestIndexTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire.data;
 
 import org.junit.jupiter.api.Test;

--- a/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/data/UnitTestResultTest.java
+++ b/sonar-kotlin-surefire/src/test/java/org/sonarsource/kotlin/surefire/data/UnitTestResultTest.java
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.surefire.data;
 
 import org.assertj.core.api.AbstractAssert;

--- a/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/AbstractSensorTest.kt
+++ b/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/AbstractSensorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.testapi
 
 import org.junit.jupiter.api.BeforeEach

--- a/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/DummyInputFile.kt
+++ b/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/DummyInputFile.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.testapi
 
 import org.jetbrains.kotlin.idea.KotlinLanguage

--- a/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/DummyInputFileContext.kt
+++ b/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/DummyInputFileContext.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.testapi
 
 import org.sonar.api.batch.fs.InputFile

--- a/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/KotlinVerifier.kt
+++ b/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/KotlinVerifier.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.testapi
 
 import io.mockk.InternalPlatformDsl.toStr

--- a/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/KtTestChecksVisitor.kt
+++ b/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/KtTestChecksVisitor.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.testapi
 
 import com.intellij.psi.PsiElement

--- a/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/TestContext.kt
+++ b/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/TestContext.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.testapi
 
 import org.sonar.api.batch.fs.InputFile

--- a/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/TestUtils.kt
+++ b/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/TestUtils.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.testapi
 
 import org.jetbrains.kotlin.diagnostics.Diagnostic

--- a/utils-kotlin/src/main/kotlin/org/sonarsource/kotlin/externalreport/ExternalRule.kt
+++ b/utils-kotlin/src/main/kotlin/org/sonarsource/kotlin/externalreport/ExternalRule.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport
 
 data class ExternalRule(

--- a/utils-kotlin/src/main/kotlin/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintRuleDefinition.kt
+++ b/utils-kotlin/src/main/kotlin/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintRuleDefinition.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.androidlint
 
 import com.google.gson.GsonBuilder

--- a/utils-kotlin/src/main/kotlin/org/sonarsource/kotlin/externalreport/common/Translator.kt
+++ b/utils-kotlin/src/main/kotlin/org/sonarsource/kotlin/externalreport/common/Translator.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.common
 
 object Translator {

--- a/utils-kotlin/src/main/kotlin/org/sonarsource/kotlin/externalreport/detekt/DetektRuleDefinitionGenerator.kt
+++ b/utils-kotlin/src/main/kotlin/org/sonarsource/kotlin/externalreport/detekt/DetektRuleDefinitionGenerator.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 @file:Suppress("DEPRECATION")
 
 package org.sonarsource.kotlin.externalreport.detekt

--- a/utils-kotlin/src/main/kotlin/org/sonarsource/kotlin/externalreport/ktlint/KtlintRuleDefinitionGenerator.kt
+++ b/utils-kotlin/src/main/kotlin/org/sonarsource/kotlin/externalreport/ktlint/KtlintRuleDefinitionGenerator.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.ktlint
 
 import com.google.gson.GsonBuilder

--- a/utils-kotlin/src/test/kotlin/org/sonarsource/kotlin/externalreport/ExternalReportTest.kt
+++ b/utils-kotlin/src/test/kotlin/org/sonarsource/kotlin/externalreport/ExternalReportTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport
 
 import org.assertj.core.api.Assertions

--- a/utils-kotlin/src/test/kotlin/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintDefinitionTest.kt
+++ b/utils-kotlin/src/test/kotlin/org/sonarsource/kotlin/externalreport/androidlint/AndroidLintDefinitionTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.androidlint
 
 import org.assertj.core.api.Assertions.assertThat

--- a/utils-kotlin/src/test/kotlin/org/sonarsource/kotlin/externalreport/common/TranslatorTest.kt
+++ b/utils-kotlin/src/test/kotlin/org/sonarsource/kotlin/externalreport/common/TranslatorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.common
 
 import org.assertj.core.api.Assertions.assertThat

--- a/utils-kotlin/src/test/kotlin/org/sonarsource/kotlin/externalreport/detekt/DetektRuleDefinitionGeneratorTest.kt
+++ b/utils-kotlin/src/test/kotlin/org/sonarsource/kotlin/externalreport/detekt/DetektRuleDefinitionGeneratorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.detekt
 
 import org.assertj.core.api.Assertions.assertThat

--- a/utils-kotlin/src/test/kotlin/org/sonarsource/kotlin/externalreport/ktlint/KtlintRuleDefinitionGeneratorTest.kt
+++ b/utils-kotlin/src/test/kotlin/org/sonarsource/kotlin/externalreport/ktlint/KtlintRuleDefinitionGeneratorTest.kt
@@ -1,22 +1,19 @@
 /*
  * SonarSource Kotlin
  * Copyright (C) 2018-2024 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+  * mailto:info AT sonarsource DOT com
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the Sonar Source-Available License for more details.
+  *
+  * You should have received a copy of the Sonar Source-Available License
+  * along with this program; if not, see https://sonarsource.com/license/ssal/
+  */
 package org.sonarsource.kotlin.externalreport.ktlint
 
 import org.assertj.core.api.Assertions


### PR DESCRIPTION
FWIW I've used the model of this license for the formatting (indenting and uppercase usage) https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt