### PR TITLE
`:sonar-kotlin-checks:test` should depend on `:kotlin-checks-test-sources`

### DIFF
--- a/sonar-kotlin-checks/build.gradle.kts
+++ b/sonar-kotlin-checks/build.gradle.kts
@@ -26,3 +26,6 @@ dependencies {
 
     testImplementation(project(":sonar-kotlin-test-api"))
 }
+
+val test: Test by tasks
+test.dependsOn(project(":kotlin-checks-test-sources").tasks.named("build"))


### PR DESCRIPTION
Otherwise execution of

    ./gradlew clean
    ./gradlew :sonar-kotlin-checks:test

leads to test failures.