### PR TITLE
SONARKT-400 Migrate FunMatcher

### DIFF
--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/ApiExtensions.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/ApiExtensions.kt
@@ -346,7 +346,7 @@ fun KtCallExpression.expressionTypeFqn(bindingContext: BindingContext): String? 
  * > Avoid using [org.jetbrains.kotlin.name.FqName]s or raw strings for type comparison.
  * > Use [org.jetbrains.kotlin.name.ClassId]s instead
  */
-private fun KaType.asFqNameString(): String? = withKaSession {
+internal fun KaType.asFqNameString(): String? = withKaSession {
     (lowerBoundIfFlexible() as? KaClassType)?.classId?.asFqNameString()
 }
 

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/ArgumentMatcher.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/ArgumentMatcher.kt
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.kotlin.api.checks
 
+import org.jetbrains.kotlin.analysis.api.symbols.KaValueParameterSymbol
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName
 import org.jetbrains.kotlin.js.descriptorUtils.nameIfStandardType
@@ -37,20 +38,33 @@ class ArgumentMatcher(
         val ANY = ArgumentMatcher()
     }
 
+    @Deprecated("use kotlin-analysis-api instead")
     fun matches(descriptor: ValueParameterDescriptor) = (isVararg == (descriptor.varargElementType != null)) &&
         matchesNullability(descriptor) && matchesName(if (isVararg) descriptor.varargElementType else descriptor.type)
 
+    fun matches(valueParameter: KaValueParameterSymbol): Boolean {
+        if (!qualified) TODO()
+        if (nullability != null) TODO()
+        if (isVararg) TODO()
+        if (typeName == null) return true
+        return typeName == valueParameter.returnType.asFqNameString()
+    }
+
+    @Deprecated("use kotlin-analysis-api instead")
     private fun matchesName(kotlinType: KotlinType?) =
         if (qualified) matchesQualifiedName(kotlinType) else matchesUnqualifiedName(kotlinType)
 
+    @Deprecated("use kotlin-analysis-api instead")
     private fun matchesNullability(descriptor: ValueParameterDescriptor) =
         nullability?.let { it == descriptor.type.nullability() } ?: true
 
+    @Deprecated("use kotlin-analysis-api instead")
     private fun matchesQualifiedName(kotlinType: KotlinType?) =
         // Note that getKotlinTypeFqName(...) is from the kotlin.js package. We use it anyway,
         // as it seems to be the best option to get a type's fully qualified name
         typeName?.let { it == kotlinType?.getKotlinTypeFqName(false) } ?: true
 
+    @Deprecated("use kotlin-analysis-api instead")
     private fun matchesUnqualifiedName(kotlinType: KotlinType?) =
         // Note that nameIfStandardType is from the kotlin.js package. We use it anyway,
         // as it seems to be the best option to get a type's simple name

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/CallAbstractCheck.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/CallAbstractCheck.kt
@@ -16,14 +16,18 @@
  */
 package org.sonarsource.kotlin.api.checks
 
+import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
+import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
+import org.sonarsource.kotlin.api.visiting.withKaSession
 
 abstract class CallAbstractCheck : AbstractCheck() {
     abstract val functionsToVisit: Iterable<FunMatcherImpl>
 
+    @Deprecated("use kotlin-analysis-api")
     open fun visitFunctionCall(
         callExpression: KtCallExpression,
         resolvedCall: ResolvedCall<*>,
@@ -31,9 +35,29 @@ abstract class CallAbstractCheck : AbstractCheck() {
         kotlinFileContext: KotlinFileContext
     ) = visitFunctionCall(callExpression, resolvedCall, kotlinFileContext)
 
+    open fun visitFunctionCall(
+        callExpression: KtCallExpression,
+        resolvedCall: KaFunctionCall<*>,
+        matchedFun: FunMatcherImpl,
+        kotlinFileContext: KotlinFileContext
+    ) = visitFunctionCall(callExpression, resolvedCall, kotlinFileContext)
+
+    @Deprecated("use kotlin-analysis-api")
     open fun visitFunctionCall(callExpression: KtCallExpression, resolvedCall: ResolvedCall<*>, kotlinFileContext: KotlinFileContext) = Unit
 
+    open fun visitFunctionCall(callExpression: KtCallExpression, resolvedCall: KaFunctionCall<*>, kotlinFileContext: KotlinFileContext) = Unit
+
     final override fun visitCallExpression(callExpression: KtCallExpression, kotlinFileContext: KotlinFileContext) {
+        withKaSession {
+            val resolvedCall = callExpression.resolveToCall()
+                // TODO
+                //   seems that `singleFunctionCallOrNull` better matches behavior prior to use of Kotlin Analysis API,
+                //   however consider using `successfulFunctionCallOrNull` instead to avoid potential FPs
+                ?.singleFunctionCallOrNull() ?: return
+            functionsToVisit.firstOrNull { it.matches(resolvedCall) }
+                ?.let { visitFunctionCall(callExpression, resolvedCall, it, kotlinFileContext) }
+        }
+
         val resolvedCall = callExpression.getResolvedCall(kotlinFileContext.bindingContext) ?: return
         functionsToVisit.firstOrNull { resolvedCall matches it }
             ?.let { visitFunctionCall(callExpression, resolvedCall, it, kotlinFileContext) }

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
@@ -42,6 +42,7 @@ import org.sonarsource.kotlin.api.frontend.KotlinSyntaxStructure
 import org.sonarsource.kotlin.api.frontend.KotlinTree
 import org.sonarsource.kotlin.api.frontend.ParseException
 import org.sonarsource.kotlin.api.frontend.RegexCache
+import org.sonarsource.kotlin.api.frontend.transferDiagnostics
 import org.sonarsource.kotlin.api.logging.debug
 import org.sonarsource.kotlin.api.visiting.KotlinFileVisitor
 
@@ -135,7 +136,7 @@ abstract class AbstractKotlinSensorExecuteContext(
 
     private val diagnostics: Map<PsiFile, List<Diagnostic>> by lazy {
         measureDuration("Diagnostics") {
-            bindingContext.diagnostics.noSuppression().groupBy { it.psiFile }.toMap()
+            transferDiagnostics(bindingContext).groupBy { it.psiFile }.toMap()
         }
     }
 

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/BiometricAuthWithoutCryptoCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/BiometricAuthWithoutCryptoCheck.kt
@@ -16,10 +16,10 @@
  */
 package org.sonarsource.kotlin.checks
 
+import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 import org.jetbrains.kotlin.psi.psiUtil.isNull
-import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.CallAbstractCheck
 import org.sonarsource.kotlin.api.checks.FunMatcher
@@ -33,14 +33,13 @@ private val ANDROIDX_AUTH = FunMatcher(qualifier = "androidx.biometric.Biometric
 
 private const val MESSAGE = """Make sure performing a biometric authentication without a "CryptoObject" is safe here."""
 
-@org.sonarsource.kotlin.api.frontend.K1only
 @Rule(key = "S6293")
 class BiometricAuthWithoutCryptoCheck : CallAbstractCheck() {
     override val functionsToVisit = setOf(ANDROID_HARDWARE_AUTH, ANDROIDX_AUTH)
 
     override fun visitFunctionCall(
         callExpression: KtCallExpression,
-        resolvedCall: ResolvedCall<*>,
+        resolvedCall: KaFunctionCall<*>,
         matchedFun: FunMatcherImpl,
         kotlinFileContext: KotlinFileContext,
     ) {

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsMethodUsageCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsMethodUsageCheck.kt
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.kotlin.checks
 
+import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
@@ -23,7 +24,6 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtPrefixExpression
 import org.jetbrains.kotlin.psi.KtSuperExpression
 import org.jetbrains.kotlin.psi.KtThisExpression
-import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.ANY_TYPE
 import org.sonarsource.kotlin.api.checks.CallAbstractCheck
@@ -33,12 +33,11 @@ import org.sonarsource.kotlin.api.reporting.SecondaryLocation
 import org.sonarsource.kotlin.api.reporting.KotlinTextRanges.textRange
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
 
-@org.sonarsource.kotlin.api.frontend.K1only
 @Rule(key = "S6519")
 class EqualsMethodUsageCheck : CallAbstractCheck() {
     override val functionsToVisit = setOf(FunMatcher { name = EQUALS_METHOD_NAME; withArguments(ANY_TYPE) })
 
-    override fun visitFunctionCall(callExpression: KtCallExpression, resolvedCall: ResolvedCall<*>, kotlinFileContext: KotlinFileContext) {
+    override fun visitFunctionCall(callExpression: KtCallExpression, resolvedCall: KaFunctionCall<*>, kotlinFileContext: KotlinFileContext) {
         val parent = callExpression.parent
         if (parent is KtDotQualifiedExpression && parent.selectorExpression == callExpression && !parent.receiverExpression.isSuperOrOuterClass()) {
             val grandParent = parent.parent.skipParentParentheses()

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsOverridenWithHashCodeCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/EqualsOverridenWithHashCodeCheck.kt
@@ -39,7 +39,6 @@ private val hashCodeMatcher = FunMatcher {
     withNoArguments()
 }
 
-@org.sonarsource.kotlin.api.frontend.K1only
 @Rule(key = "S1206")
 class EqualsOverridenWithHashCodeCheck : AbstractCheck() {
 
@@ -49,8 +48,8 @@ class EqualsOverridenWithHashCodeCheck : AbstractCheck() {
 
         klass.functions.forEach {
             when {
-                hashCodeMethod == null && hashCodeMatcher.matches(it, ctx.bindingContext) -> hashCodeMethod = it
-                equalsMethod == null && equalsMatcher.matches(it, ctx.bindingContext) -> equalsMethod = it
+                hashCodeMethod == null && hashCodeMatcher.matches(it) -> hashCodeMethod = it
+                equalsMethod == null && equalsMatcher.matches(it) -> equalsMethod = it
             }
             if (hashCodeMethod != null && equalsMethod != null) return
         }

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/FinalFlowOperationCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/FinalFlowOperationCheck.kt
@@ -16,24 +16,23 @@
  */
 package org.sonarsource.kotlin.checks
 
+import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsStatement
-import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.COROUTINES_FLOW
 import org.sonarsource.kotlin.api.checks.CallAbstractCheck
 import org.sonarsource.kotlin.api.checks.FunMatcher
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
+import org.sonarsource.kotlin.api.visiting.withKaSession
 
 private const val MESSAGE = "Unused coroutines Flow."
 
-@org.sonarsource.kotlin.api.frontend.K1only
 @Rule(key = "S6314")
 class FinalFlowOperationCheck : CallAbstractCheck() {
     override val functionsToVisit = listOf(FunMatcher(returnType = COROUTINES_FLOW))
 
-    override fun visitFunctionCall(callExpression: KtCallExpression, resolvedCall: ResolvedCall<*>, kotlinFileContext: KotlinFileContext) {
-        if (callExpression.isUsedAsStatement(kotlinFileContext.bindingContext)) {
+    override fun visitFunctionCall(callExpression: KtCallExpression, resolvedCall: KaFunctionCall<*>, kotlinFileContext: KotlinFileContext) = withKaSession {
+        if (!callExpression.isUsedAsExpression) {
             kotlinFileContext.reportIssue(callExpression.calleeExpression!!, MESSAGE)
         }
     }

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IndexedAccessCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IndexedAccessCheck.kt
@@ -16,17 +16,16 @@
  */
 package org.sonarsource.kotlin.checks
 
+import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtSuperExpression
-import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.CallAbstractCheck
 import org.sonarsource.kotlin.api.checks.FunMatcher
 import org.sonarsource.kotlin.api.checks.FunMatcherImpl
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
 
-@org.sonarsource.kotlin.api.frontend.K1only
 @Rule(key = "S6518")
 class IndexedAccessCheck : CallAbstractCheck() {
 
@@ -38,7 +37,7 @@ class IndexedAccessCheck : CallAbstractCheck() {
 
     override fun visitFunctionCall(
         callExpression: KtCallExpression,
-        resolvedCall: ResolvedCall<*>,
+        resolvedCall: KaFunctionCall<*>,
         matchedFun: FunMatcherImpl,
         kotlinFileContext: KotlinFileContext,
     ) {

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RunFinalizersCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/RunFinalizersCheck.kt
@@ -16,14 +16,13 @@
  */
 package org.sonarsource.kotlin.checks
 
+import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.CallAbstractCheck
 import org.sonarsource.kotlin.api.checks.FunMatcher
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
 
-@org.sonarsource.kotlin.api.frontend.K1only
 @Rule(key = "S2151")
 class RunFinalizersCheck : CallAbstractCheck() {
 
@@ -32,7 +31,7 @@ class RunFinalizersCheck : CallAbstractCheck() {
         FunMatcher(qualifier = "java.lang.System", name = "runFinalizersOnExit") { withArguments("kotlin.Boolean") },
     )
 
-    override fun visitFunctionCall(callExpression: KtCallExpression, resolvedCall: ResolvedCall<*>, kotlinFileContext: KotlinFileContext) {
+    override fun visitFunctionCall(callExpression: KtCallExpression, resolvedCall: KaFunctionCall<*>, kotlinFileContext: KotlinFileContext) {
         kotlinFileContext.reportIssue(callExpression.calleeExpression!!, "Remove this call to \"runFinalizersOnExit()\".")
     }
 }

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/StreamNotConsumedCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/StreamNotConsumedCheck.kt
@@ -16,14 +16,14 @@
  */
 package org.sonarsource.kotlin.checks
 
+import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsStatement
-import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.CallAbstractCheck
 import org.sonarsource.kotlin.api.checks.FunMatcher
 import org.sonarsource.kotlin.api.checks.FunMatcherImpl
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
+import org.sonarsource.kotlin.api.visiting.withKaSession
 
 private const val STREAM_MESSAGE = "Refactor the code so this stream pipeline is used."
 
@@ -44,7 +44,6 @@ private val SEQUENCE_MATCHER = FunMatcher(qualifier = "kotlin.sequences") {
     )
 }
 
-@org.sonarsource.kotlin.api.frontend.K1only
 @Rule(key = "S3958")
 class StreamNotConsumedCheck : CallAbstractCheck() {
 
@@ -73,11 +72,11 @@ class StreamNotConsumedCheck : CallAbstractCheck() {
 
     override fun visitFunctionCall(
         callExpression: KtCallExpression,
-        resolvedCall: ResolvedCall<*>,
+        resolvedCall: KaFunctionCall<*>,
         matchedFun: FunMatcherImpl,
         kotlinFileContext: KotlinFileContext,
-    ) {
-        if (callExpression.isUsedAsStatement(kotlinFileContext.bindingContext)) {
+    ) = withKaSession {
+        if (!callExpression.isUsedAsExpression) {
             val message = if (matchedFun == SEQUENCE_MATCHER) SEQUENCE_MESSAGE else STREAM_MESSAGE;
             kotlinFileContext.reportIssue(callExpression.calleeExpression!!, message)
         }

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnencryptedFilesInMobileApplicationsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnencryptedFilesInMobileApplicationsCheck.kt
@@ -16,8 +16,8 @@
  */
 package org.sonarsource.kotlin.checks
 
+import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.CallAbstractCheck
 import org.sonarsource.kotlin.api.checks.ConstructorMatcher
@@ -26,7 +26,6 @@ import org.sonarsource.kotlin.api.frontend.KotlinFileContext
 
 private const val MESSAGE = "Make sure using unencrypted files is safe here."
 
-@org.sonarsource.kotlin.api.frontend.K1only
 @Rule(key = "S6300")
 class UnencryptedFilesInMobileApplicationsCheck : CallAbstractCheck() {
     override val functionsToVisit = setOf(
@@ -36,7 +35,7 @@ class UnencryptedFilesInMobileApplicationsCheck : CallAbstractCheck() {
         FunMatcher(qualifier = "java.nio.file.Files", name = "write"),
     )
 
-    override fun visitFunctionCall(callExpression: KtCallExpression, resolvedCall: ResolvedCall<*>, kotlinFileContext: KotlinFileContext) {
+    override fun visitFunctionCall(callExpression: KtCallExpression, resolvedCall: KaFunctionCall<*>, kotlinFileContext: KotlinFileContext) {
         if (kotlinFileContext.isInAndroid()) {
             kotlinFileContext.reportIssue(callExpression.calleeExpression!!, MESSAGE)
         }

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnsuitedFindFunctionWithNullComparisonCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnsuitedFindFunctionWithNullComparisonCheck.kt
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.kotlin.checks
 
+import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
 import org.jetbrains.kotlin.lexer.KtTokens.EQEQ
 import org.jetbrains.kotlin.lexer.KtTokens.EXCLEQ
 import org.jetbrains.kotlin.psi.KtBinaryExpression
@@ -27,7 +28,6 @@ import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
 import org.jetbrains.kotlin.psi.psiUtil.isNull
-import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.CallAbstractCheck
 import org.sonarsource.kotlin.api.checks.FunMatcher
@@ -42,7 +42,6 @@ import org.sonarsource.kotlin.api.reporting.message
  *
  * The rule suggests to replace the pattern with `any(predicate)`, `none(predicate)`, and `contains(element)` depending on the case.
  */
-@org.sonarsource.kotlin.api.frontend.K1only
 @Rule(key = "S6528")
 class UnsuitedFindFunctionWithNullComparisonCheck : CallAbstractCheck() {
 
@@ -51,7 +50,7 @@ class UnsuitedFindFunctionWithNullComparisonCheck : CallAbstractCheck() {
         withArguments("kotlin.Function1")
     })
 
-    override fun visitFunctionCall(callExpression: KtCallExpression, resolvedCall: ResolvedCall<*>, kotlinFileContext: KotlinFileContext) {
+    override fun visitFunctionCall(callExpression: KtCallExpression, resolvedCall: KaFunctionCall<*>, kotlinFileContext: KotlinFileContext) {
         callExpression.findClosestAncestorOfType<KtBinaryExpression>()?.takeIf { it.right!!.isNull() || it.left!!.isNull() }
             ?.let { report(it, callExpression, kotlinFileContext) }
     }

--- a/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/TestUtils.kt
+++ b/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/TestUtils.kt
@@ -28,6 +28,7 @@ import org.sonarsource.kotlin.api.frontend.KotlinVirtualFile
 import org.sonarsource.kotlin.api.frontend.RegexCache
 import org.sonarsource.kotlin.api.frontend.analyzeAndGetBindingContext
 import org.sonarsource.kotlin.api.frontend.createK2AnalysisSession
+import org.sonarsource.kotlin.api.frontend.transferDiagnostics
 import java.io.File
 
 fun kotlinTreeOf(content: String, environment: Environment, inputFile: InputFile, doResolve: Boolean = true, providedDiagnostics: List<Diagnostic>? = null): KotlinTree {
@@ -50,5 +51,5 @@ fun kotlinTreeOf(content: String, environment: Environment, inputFile: InputFile
         environment.env,
         listOf(ktFile),
     ) else BindingContext.EMPTY
-    return KotlinTree(ktFile, document, bindingContext, providedDiagnostics ?: bindingContext.diagnostics.noSuppression().toList(), RegexCache(), doResolve)
+    return KotlinTree(ktFile, document, bindingContext, providedDiagnostics ?: transferDiagnostics(bindingContext), RegexCache(), doResolve)
 }


### PR DESCRIPTION
Depends on
- [x] https://github.com/SonarSource/sonar-kotlin/pull/499

Blocks
- [ ] `AndroidBroadcastingCheck` - `CallAbstractCheck`
- [ ] `ServerCertificateCheck`

Also blocks
- [ ] `PseudoRandomCheck` - `FunMatcher`
- [ ] `EqualsArgumentTypeCheck` - `determineType` + `FunMatcher`
- [ ] `UselessIncrementCheck` - `isLocalVariable`
- [ ] `MapValuesShouldBeAccessedSafelyCheck`
