### PR TITLE
Prepare for the next development iteration 3.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.sonarsource.kotlin
-version=2.22.0-SNAPSHOT
+version=3.0.0-SNAPSHOT
 description=Code Analyzer for Kotlin
 projectTitle=Kotlin
 kotlinVersion=2.0.21


### PR DESCRIPTION
The next release should contain migration to Kotlin Analysis API with K2 mode. so it makes sense to bump the major version