### PR TITLE
SONAR-22876 Remove from integration tests assertions for `executable_lines_data` and `ncloc_data`

### DIFF
--- a/its/plugin/src/test/java/org/sonarsource/slang/MeasuresTest.java
+++ b/its/plugin/src/test/java/org/sonarsource/slang/MeasuresTest.java
@@ -53,12 +53,6 @@ public class MeasuresTest extends TestBase {
     assertThat(getMeasureAsInt(file1, "cognitive_complexity")).isEqualTo(0);
     assertThat(getMeasureAsInt(file2, "cognitive_complexity")).isEqualTo(2);
 
-    assertThat(getMeasure(emptyFile, "ncloc_data")).isNull();
-    assertThat(getMeasure(file1, "ncloc_data").getValue()).isEqualTo("1=1;3=1;4=1;7=1;8=1;13=1;14=1");
-    assertThat(getMeasure(file2, "ncloc_data").getValue()).isEqualTo("1=1;2=1;3=1;4=1;5=1;7=1;10=1;11=1");
-
-    assertThat(getMeasure(file1, "executable_lines_data").getValue()).isEqualTo("4=1;8=1;13=1");
-
     List<Issues.Issue> issuesForRule = getIssuesForRule(projectKey, "kotlin:S100");
     assertThat(issuesForRule).extracting(Issues.Issue::getLine).containsExactly(2, 7);
     assertThat(issuesForRule).extracting(Issues.Issue::getComponent).containsExactly(file2, file2);


### PR DESCRIPTION
Related to https://sonarsource.atlassian.net/browse/SONAR-22876