### PR TITLE
SONARKT-494 Migrate UnpredictableHashSaltCheck to kotlin-analysis-api

### DIFF
--- a/kotlin-checks-test-sources/src/main/kotlin/checks/EqualsOverridenWithHashCodeCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/EqualsOverridenWithHashCodeCheckSample.kt
@@ -2,7 +2,6 @@ package checks
 
 class EqualsOverridenWithHashCodeCheckSample {
 
-
     override fun equals(other: Any?): Boolean { // Noncompliant {{This class overrides "equals()" and should therefore also override "hashCode()".}}
         return super.equals(other)
     }
@@ -86,6 +85,12 @@ abstract class AmbiguousParent3 {
         return super.hashCode()
     }
     fun equals(other: String?): Boolean {
+        return super.equals(other)
+    }
+}
+
+private val testAnonymousClass = object : Any() {
+    override fun equals(other: Any?): Boolean { // Noncompliant
         return super.equals(other)
     }
 }


### PR DESCRIPTION
[SONARKT-494](https://sonarsource.atlassian.net/browse/SONARKT-494)

Part of 
SONARKT-423

- [x] `getter` - `java.lang.String.getBytes`
- [x] `isBytesInitializedFromString`

[SONARKT-494]: https://sonarsource.atlassian.net/browse/SONARKT-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ