### PR TITLE
SONARKT-508 Migrate ExternalAndroidStorageAccessCheck to kotlin-analysis-api

### DIFF
--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/FunMatcher.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/FunMatcher.kt
@@ -133,7 +133,9 @@ class FunMatcherImpl(
                         checkName(symbolForNameCheck) &&
                                 checkCallParameters(getterSignature) &&
                                 checkReturnType(getterSignature) &&
-                                checkTypeOrSupertype(null, propertySymbol)
+                                (checkTypeOrSupertype(null, propertySymbol) ||
+                                        // TODO propertySymbol works only in K2 (see ExternalAndroidStorageAccessCheck):
+                                        checkTypeOrSupertype(null, symbolForNameCheck))
                     }
                     is KaSimpleVariableAccess.Write -> {
                         val symbolForNameCheck =


### PR DESCRIPTION
[SONARKT-508](https://sonarsource.atlassian.net/browse/SONARKT-508)

Part of 
SONARKT-423


[SONARKT-508]: https://sonarsource.atlassian.net/browse/SONARKT-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ