### PR TITLE
SONARKT-535 Migrate DeprecatedCodeUsedCheck to kotlin-analysis-api

### DIFF
--- a/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
@@ -15,8 +15,9 @@ class DeprecatedCodeUsedCheckSample {
     fun usesDeprecated(kStr: DeprecatedString): String { // Noncompliant
 //                           ^^^^^^^^^^^^^^^^
 
-        //Noncompliant@+1
-        val d = DeprecatedCode("") // Noncompliant
+        DeprecatedConstructor("") // Noncompliant
+
+        val d = DeprecatedCode() // Noncompliant
 //              ^^^^^^^^^^^^^^
 
         d.prop // Noncompliant
@@ -34,19 +35,18 @@ class DeprecatedCodeUsedCheckSample {
 //      ^^^^^^^^^^^^^^^^^^
 
         return kStr - "" // Noncompliant
-//             ^^^^^^^^^
     }
 
 }
 
-@Deprecated("")
-open class DeprecatedCode {
-
+class DeprecatedConstructor {
     @Deprecated("")
     constructor(s: String) {
     }
+}
 
-    constructor() {}
+@Deprecated("")
+open class DeprecatedCode {
 
     @Deprecated("")
     val prop: String = ""

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/KtModuleProviderByCompilerConfiguration.java
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/KtModuleProviderByCompilerConfiguration.java
@@ -17,10 +17,13 @@
 package org.sonarsource.kotlin.api.frontend;
 
 import kotlin.jvm.functions.Function1;
+import org.jetbrains.kotlin.analysis.api.descriptors.components.KaFe10Diagnostic;
+import org.jetbrains.kotlin.analysis.api.lifetime.KaLifetimeToken;
 import org.jetbrains.kotlin.analysis.api.standalone.StandaloneAnalysisAPISessionBuilder;
 import org.jetbrains.kotlin.analysis.api.standalone.base.projectStructure.KotlinStaticProjectStructureProvider;
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreProjectEnvironment;
 import org.jetbrains.kotlin.config.CompilerConfiguration;
+import org.jetbrains.kotlin.diagnostics.Diagnostic;
 import org.jetbrains.kotlin.psi.KtFile;
 
 import java.util.List;
@@ -46,6 +49,11 @@ final class KtModuleProviderByCompilerConfiguration {
   }
 
   private KtModuleProviderByCompilerConfiguration() {
+  }
+
+  @SuppressWarnings("KotlinInternalInJava")
+  static KaFe10Diagnostic kaFe10Diagnostic(Diagnostic diagnostic, KaLifetimeToken token) {
+    return new KaFe10Diagnostic(diagnostic, token);
   }
 
 }

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheck.kt
@@ -26,15 +26,15 @@ import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.AbstractCheck
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
+import org.sonarsource.kotlin.api.visiting.withKaSession
 
-@org.sonarsource.kotlin.api.frontend.K1only
 @Rule(key = "S1874")
 class DeprecatedCodeUsedCheck : AbstractCheck() {
 
-    override fun visitKtFile(file: KtFile, context: KotlinFileContext) {
-        context.diagnostics
-            .filter { it.factory == Errors.DEPRECATION }
-            .forEach { context.reportIssue(it.psiElement.elementToReport(), "Deprecated code should not be used.") }
+    override fun visitKtFile(file: KtFile, context: KotlinFileContext) = withKaSession {
+        context.kaDiagnostics
+            .filter { it.factoryName == Errors.DEPRECATION.name }
+            .forEach { context.reportIssue(it.psi.elementToReport(), "Deprecated code should not be used.") }
     }
 
 }


### PR DESCRIPTION
[SONARKT-535](https://sonarsource.atlassian.net/browse/SONARKT-535)

Part of 
SONARKT-532


[SONARKT-535]: https://sonarsource.atlassian.net/browse/SONARKT-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ