### PR TITLE
SONARKT-544 Migrate UselessNullCheckCheck to kotlin-analysis-api

### DIFF
--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6619.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6619.json
@@ -40,9 +40,6 @@
 78,
 82
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/ExpectedInfos.kt": [
-456
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/KotlinScriptDependenciesClassFinder.kt": [
 107
 ],
@@ -70,14 +67,8 @@
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MergeIfsIntention.kt": [
 43
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/SplitIfIntention.kt": [
-122
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/IfThenUtils.kt": [
 126
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/IfToWhenIntention.kt": [
-59
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/result/MaxOrMinTransformation.kt": [
 86,
@@ -111,9 +102,6 @@
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractLookupTrackerTest.kt": [
 122
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/runners/BasicJvmScriptEvaluator.kt": [
-26
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/misc/preconditions.kt": [
 13

--- a/kotlin-checks-test-sources/src/main/files/non-compiling/checks/UselessNullCheckCheckSampleNonCompiling.kt
+++ b/kotlin-checks-test-sources/src/main/files/non-compiling/checks/UselessNullCheckCheckSampleNonCompiling.kt
@@ -1,0 +1,8 @@
+package checks
+
+class UselessNullCheckCheckSampleNonCompiling : UnresolvedBaseClass {
+    fun example() {
+        if (unresolvedBaseClassProperty == null) {
+        }
+    }
+}

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/UselessNullCheckCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/UselessNullCheckCheckSample.kt
@@ -36,7 +36,7 @@ class UselessNullCheckCheckSample {
         null ?: doSomething() // Noncompliant
         null != "" // Noncompliant
         0 != null // Noncompliant
-        doSomething() ?: null // Noncompliant
+        doSomething() ?: null // FN, don't support Unit type
         42!! // Noncompliant
         42 != null // Noncompliant
     }
@@ -133,4 +133,13 @@ private class FooBar(
     private val someString: String? = something as? String
     val isString: Boolean
         get() = someString != null // Compliant
+}
+
+class ParametrisedClass<out T>(
+    val list: List<T>,
+) {
+    override fun hashCode(): Int {
+        var result = list.first()?.hashCode() ?: 0
+        return result
+    }
 }

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/UselessNullCheckCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/UselessNullCheckCheckSample.kt
@@ -58,9 +58,10 @@ class UselessNullCheckCheckSample {
         var b: String? = null
         b!! // Compliant FN. We don't currently resolve the value of vars.
 
-        var c: String? = null
-        c = "foo"
-        c!! // Compliant FN. We don't currently resolve the value of vars.
+        // TODO improved in K2
+//        var c: String? = null
+//        c = "foo"
+//        c!! // Compliant FN. We don't currently resolve the value of vars.
 
         var d: String = ""
         d!! // Noncompliant
@@ -135,15 +136,6 @@ private class FooBar(
         get() = someString != null // Compliant
 }
 
-fun <T> example(list: List<T>): Int? {
+private fun <T> testParametrised(list: List<T>): Int? {
     return list.first()?.hashCode()
-}
-
-class ParametrisedClass<out T>(
-    val list: List<T>,
-) {
-    override fun hashCode(): Int {
-        var result = list.first()?.hashCode() ?: 0
-        return result
-    }
 }

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/UselessNullCheckCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/UselessNullCheckCheckSample.kt
@@ -36,7 +36,7 @@ class UselessNullCheckCheckSample {
         null ?: doSomething() // Noncompliant
         null != "" // Noncompliant
         0 != null // Noncompliant
-        doSomething() ?: null // FN, don't support Unit type
+        doSomething() ?: null // Noncompliant
         42!! // Noncompliant
         42 != null // Noncompliant
     }
@@ -133,6 +133,10 @@ private class FooBar(
     private val someString: String? = something as? String
     val isString: Boolean
         get() = someString != null // Compliant
+}
+
+fun <T> example(list: List<T>): Int? {
+    return list.first()?.hashCode()
 }
 
 class ParametrisedClass<out T>(

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/K1internals.java
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/K1internals.java
@@ -17,14 +17,19 @@
 package org.sonarsource.kotlin.api.frontend;
 
 import com.intellij.psi.PsiElement;
+import org.jetbrains.kotlin.analysis.api.KaSession;
 import org.jetbrains.kotlin.analysis.api.diagnostics.KaDiagnosticWithPsi;
 import org.jetbrains.kotlin.analysis.api.lifetime.KaLifetimeToken;
 import org.jetbrains.kotlin.diagnostics.Diagnostic;
 
 @SuppressWarnings("KotlinInternalInJava")
-final class K1internals {
+public final class K1internals {
 
   private K1internals() {
+  }
+
+  public static boolean isK1(KaSession kaSession) {
+    return kaSession instanceof org.jetbrains.kotlin.analysis.api.descriptors.KaFe10Session;
   }
 
   static org.jetbrains.kotlin.analysis.api.descriptors.CliFe10AnalysisFacade createCliFe10AnalysisFacade() {

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
@@ -48,7 +48,6 @@ private val NON_NULL_CHECK_FUNS = FunMatcher("kotlin") {
     withNames("requireNotNull", "checkNotNull")
 }
 
-//@org.sonarsource.kotlin.api.frontend.K1only//("result differs in fixing 1 FN")
 @Rule(key = "S6619")
 class UselessNullCheckCheck : AbstractCheck() {
 
@@ -108,8 +107,8 @@ class UselessNullCheckCheck : AbstractCheck() {
     override fun visitCallExpression(callExpression: KtCallExpression, kfc: KotlinFileContext) {
         val resolvedCall = withKaSession { callExpression.resolveToCall()?.successfulFunctionCallOrNull() } ?: return
         if (resolvedCall matches NON_NULL_CHECK_FUNS) {
-            val argExpression = resolvedCall.argumentMapping.keys.toList().first()
             // requireNotNull and checkNotNull have no implementations without parameters. The first parameter is always the value to check.
+            val argExpression = resolvedCall.argumentMapping.keys.first()
             raiseIssueIfUselessCheck(
                 kfc,
                 argExpression,

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
@@ -34,7 +34,10 @@ import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtUnaryExpression
 import org.jetbrains.kotlin.psi.psiUtil.isNull
 import org.sonar.check.Rule
-import org.sonarsource.kotlin.api.checks.*
+import org.sonarsource.kotlin.api.checks.AbstractCheck
+import org.sonarsource.kotlin.api.checks.FunMatcher
+import org.sonarsource.kotlin.api.checks.matches
+import org.sonarsource.kotlin.api.checks.predictRuntimeValueExpression
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
 import org.sonarsource.kotlin.api.reporting.Message
 import org.sonarsource.kotlin.api.visiting.withKaSession
@@ -43,7 +46,7 @@ private val NON_NULL_CHECK_FUNS = FunMatcher("kotlin") {
     withNames("requireNotNull", "checkNotNull")
 }
 
-@org.sonarsource.kotlin.api.frontend.K1only("result differs in fixing 1 FN")
+@org.sonarsource.kotlin.api.frontend.K1only//("result differs in fixing 1 FN")
 @Rule(key = "S6619")
 class UselessNullCheckCheck : AbstractCheck() {
 
@@ -165,9 +168,7 @@ class UselessNullCheckCheck : AbstractCheck() {
  * Since it is not always clear where this diagnostic might be raised, we over-approximate and ignore all files where such an error is
  * found.
  */
-private fun KotlinFileContext.mayBeAffectedByErrorInSemantics() = diagnostics.any {
-    it.factory == Errors.MISSING_BUILT_IN_DECLARATION
-}
+private fun KotlinFileContext.mayBeAffectedByErrorInSemantics() = diagnostics.any { it.factory == Errors.MISSING_BUILT_IN_DECLARATION }
 
 private fun KtExpression.isNotNullable(): Boolean =
     when (this) {
@@ -179,7 +180,7 @@ private fun KtExpression.isNotNullable(): Boolean =
                 resolvedType !is KaErrorType &&
                         // TODO Remove when migrate to K2 mode
                         // In K1 mode in case of missing types the resolved type is Unit, which is NON_NULLABLE
-                        !resolvedType.isUnitType &&
+//                        !resolvedType.isUnitType &&
                         resolvedType !is KaTypeParameterType &&
                         resolvedType.nullability == KaTypeNullability.NON_NULLABLE
             }

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
@@ -179,12 +179,9 @@ private fun KtExpression.isNotNullable(bc: BindingContext): Boolean =
         else -> withKaSession {
             this@isNotNullable.expressionType?.let { resolvedType ->
                 resolvedType !is KaErrorType &&
-                        // TODO Remove when migrate to K2 mode
-                        // In K1 mode in case of missing types the resolved type is Unit, which is NON_NULLABLE
-                        // TODO add link to source code
+                        // TODO in K1 might be Unit when should be KaErrorType
                         // https://github.com/JetBrains/kotlin/blob/2.1.0/analysis/analysis-api-fe10/src/org/jetbrains/kotlin/analysis/api/descriptors/components/KaFe10ExpressionTypeProvider.kt#L68
-                        (!K1internals.isK1(this) || bc.getType(this@isNotNullable) != null) &&
-//                        !resolvedType.isUnitType &&
+                        (!K1internals.isK1(this) || !resolvedType.isUnitType || bc.getType(this@isNotNullable) != null) &&
                         resolvedType !is KaTypeParameterType &&
                         resolvedType.nullability == KaTypeNullability.NON_NULLABLE
             }

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
@@ -17,6 +17,12 @@
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.analysis.api.resolution.successfulFunctionCallOrNull
+import org.jetbrains.kotlin.analysis.api.resolution.symbol
+import org.jetbrains.kotlin.analysis.api.symbols.name
+import org.jetbrains.kotlin.analysis.api.types.KaErrorType
+import org.jetbrains.kotlin.analysis.api.types.KaTypeNullability
+import org.jetbrains.kotlin.analysis.api.types.KaTypeParameterType
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
@@ -27,46 +33,39 @@ import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtUnaryExpression
 import org.jetbrains.kotlin.psi.psiUtil.isNull
-import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.resolve.calls.util.getArgumentByParameterIndex
-import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
-import org.jetbrains.kotlin.types.checker.SimpleClassicTypeSystemContext.isError
-import org.jetbrains.kotlin.types.typeUtil.TypeNullability
-import org.jetbrains.kotlin.types.typeUtil.nullability
 import org.sonar.check.Rule
-import org.sonarsource.kotlin.api.checks.AbstractCheck
-import org.sonarsource.kotlin.api.checks.FunMatcher
-import org.sonarsource.kotlin.api.checks.determineType
-import org.sonarsource.kotlin.api.checks.matches
-import org.sonarsource.kotlin.api.checks.predictRuntimeValueExpression
+import org.sonarsource.kotlin.api.checks.*
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
 import org.sonarsource.kotlin.api.reporting.Message
+import org.sonarsource.kotlin.api.visiting.withKaSession
 
 private val NON_NULL_CHECK_FUNS = FunMatcher("kotlin") {
     withNames("requireNotNull", "checkNotNull")
 }
 
-@org.sonarsource.kotlin.api.frontend.K1only
+@org.sonarsource.kotlin.api.frontend.K1only("result differs in fixing 1 FN")
 @Rule(key = "S6619")
 class UselessNullCheckCheck : AbstractCheck() {
 
-
     override fun visitBinaryExpression(binaryExpression: KtBinaryExpression, kotlinFileContext: KotlinFileContext) {
-        val bc = kotlinFileContext.bindingContext
-
         when (binaryExpression.operationToken) {
-            KtTokens.EQEQ -> binaryExpression.operandComparedToNull(bc)?.let {
-                handleNullCheck(kotlinFileContext, it, binaryExpression) { +"null check" }
+            KtTokens.EQEQ -> binaryExpression.operandComparedToNull()?.let {
+                raiseIssueIfUselessCheck(kotlinFileContext, it, binaryExpression, comparesToNull = true) {
+                    +"null check"
+                }
             }
 
-            KtTokens.EXCLEQ -> binaryExpression.operandComparedToNull(bc)?.let {
-                handleNonNullCheck(kotlinFileContext, it, binaryExpression) { +"non-null check" }
+            KtTokens.EXCLEQ -> binaryExpression.operandComparedToNull()?.let {
+                raiseIssueIfUselessCheck(kotlinFileContext, it, binaryExpression, comparesToNull = false) {
+                    +"non-null check"
+                }
             }
 
-            KtTokens.ELVIS -> handleNonNullCheck(
+            KtTokens.ELVIS -> raiseIssueIfUselessCheck(
                 kotlinFileContext,
                 binaryExpression.left!!,
-                binaryExpression.operationReference
+                binaryExpression.operationReference,
+                comparesToNull = false,
             ) {
                 +"elvis operation "
                 code("?:")
@@ -76,7 +75,12 @@ class UselessNullCheckCheck : AbstractCheck() {
     }
 
     override fun visitSafeQualifiedExpression(safeDotExpression: KtSafeQualifiedExpression, kfc: KotlinFileContext) {
-        handleNonNullCheck(kfc, safeDotExpression.receiverExpression, safeDotExpression.operationTokenNode.psi) {
+        raiseIssueIfUselessCheck(
+            kfc,
+            safeDotExpression.receiverExpression,
+            safeDotExpression.operationTokenNode.psi,
+            comparesToNull = false,
+        ) {
             +"null-safe access "
             code("?.")
         }
@@ -84,10 +88,11 @@ class UselessNullCheckCheck : AbstractCheck() {
 
     override fun visitUnaryExpression(unaryExpression: KtUnaryExpression, kfc: KotlinFileContext) {
         if (unaryExpression.operationToken == KtTokens.EXCLEXCL) {
-            handleNonNullCheck(
+            raiseIssueIfUselessCheck(
                 kfc,
                 unaryExpression.baseExpression!!,
-                unaryExpression.operationReference
+                unaryExpression.operationReference,
+                comparesToNull = false,
             ) {
                 +"non-null assertion "
                 code("!!")
@@ -96,23 +101,25 @@ class UselessNullCheckCheck : AbstractCheck() {
     }
 
     override fun visitCallExpression(callExpression: KtCallExpression, kfc: KotlinFileContext) {
-        val resolvedCall = callExpression.getResolvedCall(kfc.bindingContext)
+        val resolvedCall = withKaSession { callExpression.resolveToCall()?.successfulFunctionCallOrNull() } ?: return
         if (resolvedCall matches NON_NULL_CHECK_FUNS) {
+            val argExpression = resolvedCall.argumentMapping.keys.toList().first()
             // requireNotNull and checkNotNull have no implementations without parameters. The first parameter is always the value to check.
-            handleNonNullCheck(
+            raiseIssueIfUselessCheck(
                 kfc,
-                callExpression.getArgumentByParameterIndex(0, kfc.bindingContext).first().getArgumentExpression()!!,
-                callExpression
+                argExpression,
+                callExpression,
+                comparesToNull = false,
             ) {
                 +"non-null check "
-                code(resolvedCall!!.resultingDescriptor.name.asString())
+                code(resolvedCall.partiallyAppliedSymbol.symbol.name.toString())
             }
         }
     }
 
-    private fun KtBinaryExpression.operandComparedToNull(bc: BindingContext): KtExpression? {
-        val leftResolved = left?.predictRuntimeValueExpression(bc) ?: return null
-        val rightResolved = right?.predictRuntimeValueExpression(bc) ?: return null
+    private fun KtBinaryExpression.operandComparedToNull(): KtExpression? {
+        val leftResolved = left?.predictRuntimeValueExpression() ?: return null
+        val rightResolved = right?.predictRuntimeValueExpression() ?: return null
 
         return when {
             leftResolved.isNull() -> right
@@ -120,22 +127,6 @@ class UselessNullCheckCheck : AbstractCheck() {
             else -> null
         }
     }
-
-    private fun handleNullCheck(
-        kfc: KotlinFileContext,
-        expression: KtExpression,
-        issueLocation: PsiElement,
-        nullCheckTypeForMessage: Message.() -> Unit
-    ) =
-        raiseIssueIfUselessCheck(kfc, expression, issueLocation, true, nullCheckTypeForMessage)
-
-    private fun handleNonNullCheck(
-        kfc: KotlinFileContext,
-        expression: KtExpression,
-        issueLocation: PsiElement,
-        nullCheckTypeForMessage: Message.() -> Unit
-    ) =
-        raiseIssueIfUselessCheck(kfc, expression, issueLocation, false, nullCheckTypeForMessage)
 
     private fun raiseIssueIfUselessCheck(
         kfc: KotlinFileContext,
@@ -146,13 +137,13 @@ class UselessNullCheckCheck : AbstractCheck() {
     ) {
         if (kfc.mayBeAffectedByErrorInSemantics()) return
 
-        val resolvedExpression = expression.predictRuntimeValueExpression(kfc.bindingContext)
+        val resolvedExpression = expression.predictRuntimeValueExpression()
 
         val result = if (resolvedExpression.isNull()) {
             if (comparesToNull) "succeeds" else "fails"
         } else if (
         // We are not using the resolvedExpression on purpose here, as it can cause FPs. See SONARKT-373.
-            expression.isNotNullable(kfc.bindingContext)
+            expression.isNotNullable()
         ) {
             if (comparesToNull) "fails" else "succeeds"
         } else {
@@ -174,13 +165,23 @@ class UselessNullCheckCheck : AbstractCheck() {
  * Since it is not always clear where this diagnostic might be raised, we over-approximate and ignore all files where such an error is
  * found.
  */
-private fun KotlinFileContext.mayBeAffectedByErrorInSemantics() = diagnostics.any { it.factory == Errors.MISSING_BUILT_IN_DECLARATION }
+private fun KotlinFileContext.mayBeAffectedByErrorInSemantics() = diagnostics.any {
+    it.factory == Errors.MISSING_BUILT_IN_DECLARATION
+}
 
-private fun KtExpression.isNotNullable(bc: BindingContext) =
+private fun KtExpression.isNotNullable(): Boolean =
     when (this) {
         is KtConstantExpression -> !isNull()
         is KtStringTemplateExpression -> true
-        else -> determineType(bc)?.let { resolvedType ->
-            !resolvedType.isError() && resolvedType.nullability() == TypeNullability.NOT_NULL
+
+        else -> withKaSession {
+            this@isNotNullable.expressionType?.let { resolvedType ->
+                resolvedType !is KaErrorType &&
+                        // TODO Remove when migrate to K2 mode
+                        // In K1 mode in case of missing types the resolved type is Unit, which is NON_NULLABLE
+                        !resolvedType.isUnitType &&
+                        resolvedType !is KaTypeParameterType &&
+                        resolvedType.nullability == KaTypeNullability.NON_NULLABLE
+            }
         } == true
     }

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UselessNullCheckCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UselessNullCheckCheckTest.kt
@@ -24,6 +24,8 @@ import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.junit.jupiter.api.Test
 import org.sonarsource.kotlin.testapi.KotlinVerifier
+import java.io.File
+import java.nio.file.Paths
 
 internal class UselessNullCheckCheckTest : CheckTestWithNoSemantics(UselessNullCheckCheck()) {
     @Test
@@ -38,6 +40,28 @@ internal class UselessNullCheckCheckTest : CheckTestWithNoSemantics(UselessNullC
         KotlinVerifier(check) {
             this.fileName = sampleFileNoSemantics ?: "UselessNullCheckCheckSampleWithErrorDiagnostics.kt"
             this.customDiagnostics = listOf(diagnostic)
+        }.verifyNoIssue()
+    }
+
+    @Test
+    fun `with partial semantics k1`() {
+        KotlinVerifier(check) {
+            this.baseDir = Paths.get("..", "kotlin-checks-test-sources", "src", "main", "files", "non-compiling", "checks")
+            this.fileName = "${checkName}SampleNonCompiling.kt"
+            this.classpath = System.getProperty("java.class.path").split(File.pathSeparatorChar)
+            this.deps = emptyList()
+            this.useK2 = false
+        }.verifyNoIssue()
+    }
+
+    @Test
+    fun `with partial semantics k2`() {
+        KotlinVerifier(check) {
+            this.baseDir = Paths.get("..", "kotlin-checks-test-sources", "src", "main", "files", "non-compiling", "checks")
+            this.fileName = "${checkName}SampleNonCompiling.kt"
+            this.classpath = System.getProperty("java.class.path").split(File.pathSeparatorChar)
+            this.deps = emptyList()
+            this.useK2 = true
         }.verifyNoIssue()
     }
 }


### PR DESCRIPTION
[SONARKT-544](https://sonarsource.atlassian.net/browse/SONARKT-544)

Part of 
SONARKT-532

Added test case is not previously existing FP but part of rewrite.

[SONARKT-544]: https://sonarsource.atlassian.net/browse/SONARKT-544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ