### PR TITLE
SONARKT-552 Migrate DelegationPatternCheck to kotlin-analysis-api

### DIFF
--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6514.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6514.json
@@ -85,6 +85,9 @@
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/IdeaModuleInfos.kt": [
 443
 ],
+"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/output/InlayScratchOutputHandler.kt": [
+45
+],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/baseTransformations.kt": [
 140
 ],

--- a/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6514.json
+++ b/its/ruling/src/test/resources/expected/kotlin/kotlin/kotlin-S6514.json
@@ -1,6 +1,6 @@
 {
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/range/ReversedRangeValue.kt": [
-26
+"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/AggregatedReplState.kt": [
+95
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/repl/GenericReplCompilingEvaluator.kt": [
 77,
@@ -11,10 +11,6 @@
 30,
 32,
 34,
-37,
-39,
-44,
-46,
 48
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/repl/GenericReplCompiler.kt": [
@@ -24,16 +20,7 @@
 36
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowBuilderAdapter.kt": [
-33,
-37,
-40,
-43,
-45,
 48,
-55,
-58,
-65,
-73,
 79,
 81,
 83,
@@ -43,23 +30,12 @@
 99,
 103,
 107,
-111,
 115,
-117,
-119,
-121,
-123,
-127,
-134,
 138,
 142,
 146,
-155,
-159,
 163,
 166,
-176,
-180,
 184,
 188,
 192,
@@ -73,23 +49,9 @@
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/descriptors/annotations/AnnotationSplitter.kt": [
 133,
-134,
-135,
 136,
 137,
 138
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/context/ResolutionResultsCache.kt": [
-69
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/InvokeProcessors.kt": [
-47,
-165
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/scopes/utils/ScopeUtils.kt": [
-153,
-155,
-157
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/annotations/AnnotationsImpl.kt": [
 47
@@ -97,20 +59,17 @@
 "kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/scopes/AbstractScopeAdapter.kt": [
 56,
 57,
-58,
-60
+58
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/scopes/InnerClassesScopeWrapper.kt": [
 43,
 44,
-45,
-47
+45
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/scopes/SubstitutingScope.kt": [
 82,
 83,
-84,
-86
+84
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedAnnotations.kt": [
 38
@@ -124,14 +83,19 @@
 107
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/IdeaModuleInfos.kt": [
-443,
-450
+443
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/baseTransformations.kt": [
 140
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/HashMap.kt": [
 30
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/collections/LinkedHashMap.kt": [
+202
+],
+"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/Iterators.kt": [
+39
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/MapWithDefault.kt": [
 72,

--- a/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S6514.json
+++ b/its/ruling/src/test/resources/expected/kotlin/okio/kotlin-S6514.json
@@ -24,6 +24,11 @@
 "kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/InflaterSource.kt": [
 111
 ],
+"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Okio.kt": [
+78,
+80,
+113
+],
 "kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/RealBufferedSink.kt": [
 250
 ],

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/ApiExtensions.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/ApiExtensions.kt
@@ -28,7 +28,6 @@ import org.jetbrains.kotlin.analysis.api.resolution.KaExplicitReceiverValue
 import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
 import org.jetbrains.kotlin.analysis.api.resolution.KaImplicitReceiverValue
 import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
-import org.jetbrains.kotlin.analysis.api.resolution.singleVariableAccessCall
 import org.jetbrains.kotlin.analysis.api.resolution.successfulCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.successfulFunctionCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
@@ -64,14 +63,12 @@ import org.jetbrains.kotlin.psi.KtCallElement
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtFunctionLiteral
 import org.jetbrains.kotlin.psi.KtLambdaArgument
-import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameter
@@ -882,7 +879,6 @@ fun KaType.simpleName(): String? = withKaSession {
     return lowerBoundIfFlexible().symbol?.name?.asString()
 }
 
-@Deprecated("use kotlin-analysis-api instead", ReplaceWith("this.determineType()"))
 fun PsiElement?.determineType(bindingContext: BindingContext): KotlinType? =
     this?.let {
         when (this) {
@@ -900,34 +896,6 @@ fun PsiElement?.determineType(bindingContext: BindingContext): KotlinType? =
         }
 
     }
-
-fun PsiElement?.determineType(): KaType? = withKaSession {
-    this?.let {
-        when (this@determineType) {
-            is KtCallExpression -> determineTypeFromCall()
-            is KtParameter -> symbol.returnType
-            is KtTypeReference -> type
-            is KtProperty -> determineTypeFromCall()
-            is KtDotQualifiedExpression -> determineTypeFromCall()
-            is KtReferenceExpression -> determineTypeFromCall()
-            is KtFunction -> (symbol as KaFunctionSymbol).returnType
-            is KtClass -> returnType
-            is KtConstantExpression -> this@determineType.expressionType
-            is KtStringTemplateExpression -> this@determineType.expressionType
-            is KtLambdaExpression -> this@determineType.expressionType
-            is KtExpression -> determineTypeFromCall()
-            is KtValueArgument -> this@determineType.getArgumentExpression()?.determineType()
-            else -> null
-        }
-    }
-}
-
-private fun KtElement.determineTypeFromCall(): KaType? = withKaSession {
-    this@determineTypeFromCall.resolveToCall()?.let {
-        (it.successfulFunctionCallOrNull() ?: it.singleVariableAccessCall())
-            ?.partiallyAppliedSymbol?.symbol?.returnType
-    }
-}
 
 fun KotlinType.isSupertypeOf(other: KotlinType): Boolean {
     return findCorrespondingSupertype(other, this).let { it != null && it != other }

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DelegationPatternCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DelegationPatternCheck.kt
@@ -17,106 +17,114 @@
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
-import org.jetbrains.kotlin.descriptors.ClassDescriptorWithResolutionScopes
-import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName
-import org.jetbrains.kotlin.psi.KtBlockExpression
-import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtNameReferenceExpression
-import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.KtParameter
-import org.jetbrains.kotlin.psi.KtReturnExpression
-import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.analysis.api.symbols.*
+import org.jetbrains.kotlin.analysis.api.types.KaType
+import org.jetbrains.kotlin.analysis.api.types.KaTypeParameterType
+import org.jetbrains.kotlin.analysis.api.types.symbol
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
-import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.types.TypeUtils
-import org.jetbrains.kotlin.types.typeUtil.isInterface
-import org.jetbrains.kotlin.types.typeUtil.supertypes
 import org.sonar.check.Rule
-import org.sonarsource.kotlin.api.checks.AbstractCheck
-import org.sonarsource.kotlin.api.checks.allPaired
-import org.sonarsource.kotlin.api.checks.determineType
-import org.sonarsource.kotlin.api.checks.determineTypeAsString
-import org.sonarsource.kotlin.api.checks.overrides
-import org.sonarsource.kotlin.api.checks.returnType
-import org.sonarsource.kotlin.api.checks.returnTypeAsString
+import org.sonarsource.kotlin.api.checks.*
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
+import org.sonarsource.kotlin.api.visiting.withKaSession
 
-@org.sonarsource.kotlin.api.frontend.K1only
 @Rule(key = "S6514")
 class DelegationPatternCheck : AbstractCheck() {
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject, context: KotlinFileContext) {
-        val classType = classOrObject.determineType(context.bindingContext) ?: return
-        if (classType.isInterface()) return
-        val superInterfaces = getSuperInterfaces(classType).toSet()
-        if (superInterfaces.isEmpty()) return
+        withKaSession {
+            val classSymbol = classOrObject.classSymbol ?: return
+            if (classSymbol.classKind == KaClassKind.INTERFACE) return
+            val superInterfaces: Set<KaClassSymbol> = classSymbol.getSuperInterfaces()
 
-        classOrObject.declarations.forEach {
-            if (it is KtNamedFunction) {
-                checkNamedFunction(it, superInterfaces, context)
+            classOrObject.declarations.forEach {
+                if (it is KtNamedFunction) {
+                    checkNamedFunction(it, context, superInterfaces)
+                }
             }
         }
     }
 
-    private fun checkNamedFunction(function: KtNamedFunction, superInterfaces: Set<KotlinType>, context: KotlinFileContext) {
+    private fun checkNamedFunction(
+        function: KtNamedFunction,
+        context: KotlinFileContext,
+        superInterfaces: Set<KaClassSymbol>
+    ) {
         if (!(function.isPublic && function.overrides())) return
-        val bindingContext = context.bindingContext
-        val delegeeType = getDelegeeOrNull(function, bindingContext)?.determineType(bindingContext) ?: return
+        val delegeeType1 = getDelegeeOrNull(function)?.determineType() ?: return
 
-        if (getCommonSuperInterfaces(superInterfaces, delegeeType).any {
-            isFunctionInInterface(function, it, bindingContext)
-        }) {
+        val commonSuperInterfaces = getCommonSuperInterfaces(superInterfaces, delegeeType1)
+
+        if (commonSuperInterfaces.any {
+                isFunctionInInterface(function, it)
+            }) {
             context.reportIssue(function.nameIdentifier!!, """Replace with interface delegation using "by" in the class header.""")
         }
     }
 }
 
-private fun isFunctionInInterface(function: KtNamedFunction, superInterface: KotlinType, bindingContext: BindingContext): Boolean {
-    val classDescriptor = TypeUtils.getClassDescriptor(superInterface) as? ClassDescriptorWithResolutionScopes ?: return false
-    return classDescriptor.declaredCallableMembers.any {
-        isEqualFunctionSignature(function, it, bindingContext)
+private fun isFunctionInInterface(
+    function: KtNamedFunction,
+    superInterface1: KaClassSymbol
+): Boolean = withKaSession {
+    val classDeclaration = superInterface1.psi as? KtClass ?: return false
+    return classDeclaration.declarations.any {
+        it is KtNamedFunction && haveCompatibleFunctionSignature(it.symbol, function.symbol)
     }
 }
 
-private fun isEqualFunctionSignature(
-    function: KtNamedFunction,
-    functionDescriptor: CallableMemberDescriptor,
-    bindingContext: BindingContext,
-) = function.name == functionDescriptor.name.identifier &&
-    function.returnTypeAsString(bindingContext) == functionDescriptor.returnType?.getKotlinTypeFqName(false) &&
-    function.valueParameters.allPaired(functionDescriptor.valueParameters) { parameter, paramerterDescriptor ->
-        parameter.typeReference?.determineTypeAsString(bindingContext) == paramerterDescriptor.type.getKotlinTypeFqName(false)
-    }
+private fun haveCompatibleFunctionSignature(
+    function1: KaFunctionSymbol,
+    function2: KaFunctionSymbol,
+) = withKaSession {
+    function1.returnType.sameOrTypeParam(function2.returnType) &&
+            function1.name == function2.name &&
+            function1.valueParameters.allPaired(function2.valueParameters) { p1, p2 ->
+                p1.returnType.sameOrTypeParam(p2.returnType)
+            }
+}
 
-fun getCommonSuperInterfaces(superInterfaces: Set<KotlinType>, otherType: KotlinType) =
-    getSuperInterfaces(otherType).intersect(superInterfaces)
+fun KaType.sameOrTypeParam(other: KaType): Boolean = withKaSession {
+    if (this@sameOrTypeParam is KaTypeParameterType && other is KaTypeParameterType) return true
+    return symbol != null && other.symbol != null && symbol == other.symbol
+}
 
-private fun getSuperInterfaces(kotlinType: KotlinType): List<KotlinType> =
-    kotlinType.supertypes().filter(KotlinType::isInterface).let {
-        if (kotlinType.isInterface()) it + kotlinType else it
-    }
+fun getCommonSuperInterfaces(superInterfaces: Set<KaClassSymbol>, otherType: KaType) =
+    (otherType.symbol as? KaClassSymbol)?.let {
+        (it.getSuperInterfaces() + it).intersect(superInterfaces)
+    } ?: emptySet()
 
-private fun getDelegeeOrNull(function: KtNamedFunction, bindingContext: BindingContext): KtNameReferenceExpression? {
+fun KaType.getSuperInterfaces(): Set<KaClassSymbol> =
+    (symbol as? KaClassSymbol)?.getSuperInterfaces() ?: emptySet()
+
+fun KaClassSymbol.getSuperInterfaces(): Set<KaClassSymbol> = withKaSession {
+    val superTypes = this@getSuperInterfaces.superTypes.filter { !it.isAnyType }
+    val symbols: Collection<KaClassSymbol> = superTypes.mapNotNull { it.symbol as? KaClassSymbol }
+    val hierarchy: List<KaClassSymbol> = superTypes.flatMap { it.getSuperInterfaces() }
+    return (symbols + hierarchy)
+        .filter { it.classKind == KaClassKind.INTERFACE }
+        .toSet()
+}
+
+private fun getDelegeeOrNull(function: KtNamedFunction): KtNameReferenceExpression? = withKaSession {
     val qualifiedCallExpression = getFunctionSingleBodyElementOrNull(function) as? KtDotQualifiedExpression ?: return null
     val receiverExpression = qualifiedCallExpression.receiverExpression as? KtNameReferenceExpression ?: return null
     val callExpression = qualifiedCallExpression.selectorExpression as? KtCallExpression ?: return null
+    val callExpressionType = callExpression.expressionType ?: return null
 
     return if (function.name!! == callExpression.getCallNameExpression()?.getReferencedName() &&
-        function.returnType(bindingContext) == callExpression.determineType(bindingContext) &&
+        function.returnType.semanticallyEquals(callExpressionType) &&
         function.valueParameters.allPaired(callExpression.valueArguments) { parameter, argument ->
-            isDelegatedParameter(parameter, argument, bindingContext)
+            isDelegatedParameter(parameter, argument)
         }) receiverExpression else null
 }
 
-private fun isDelegatedParameter(parameter: KtParameter, arguments: KtValueArgument, bindingContext: BindingContext): Boolean {
+private fun isDelegatedParameter(parameter: KtParameter, arguments: KtValueArgument): Boolean = withKaSession {
     val argumentExpression = arguments.getArgumentExpression() as? KtNameReferenceExpression ?: return false
-    return parameter.name == argumentExpression.getReferencedName() &&
-        parameter.determineType(bindingContext) == argumentExpression.determineType(bindingContext)
+    if (parameter.name != argumentExpression.getReferencedName()) return false
+    val argumentType = argumentExpression.determineType() ?: return false
+    return parameter.symbol.returnType.semanticallyEquals(argumentType)
 }
 
 private fun getFunctionSingleBodyElementOrNull(function: KtNamedFunction): PsiElement? {

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DelegationPatternCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DelegationPatternCheck.kt
@@ -26,7 +26,6 @@ import org.jetbrains.kotlin.analysis.api.types.KaTypeParameterType
 import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
@@ -39,7 +38,6 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.AbstractCheck
 import org.sonarsource.kotlin.api.checks.allPaired
-import org.sonarsource.kotlin.api.checks.determineType
 import org.sonarsource.kotlin.api.checks.overrides
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
 import org.sonarsource.kotlin.api.visiting.withKaSession


### PR DESCRIPTION
[SONARKT-552](https://sonarsource.atlassian.net/browse/SONARKT-552)

Part of 
SONARKT-532

[SONARKT-552]: https://sonarsource.atlassian.net/browse/SONARKT-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ