### PR TITLE
SCA-119 Enable recursive SCA scans

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -109,7 +109,7 @@ build_task:
     DEPLOY_PULL_REQUEST: true
   build_script:
     - source cirrus-env BUILD-PRIVATE
-    - regular_gradle_build_deploy_analyze -x test -x sonar -Dsonar.sca.recursiveManifestSearch=true
+    - regular_gradle_build_deploy_analyze -x test -x sonar
   on_failure:
     error_log_artifacts:
       path: "hs_err_pid*.log"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -109,7 +109,7 @@ build_task:
     DEPLOY_PULL_REQUEST: true
   build_script:
     - source cirrus-env BUILD-PRIVATE
-    - regular_gradle_build_deploy_analyze -x test -x sonar
+    - regular_gradle_build_deploy_analyze -x test -x sonar -Dsonar.sca.recursiveManifestSearch=true
   on_failure:
     error_log_artifacts:
       path: "hs_err_pid*.log"
@@ -128,7 +128,7 @@ build_test_analyze_task:
     DEPLOY_PULL_REQUEST: true
   build_script:
     - source cirrus-env BUILD-PRIVATE
-    - regular_gradle_build_deploy_analyze -x artifactoryPublish
+    - regular_gradle_build_deploy_analyze -x artifactoryPublish -Dsonar.sca.recursiveManifestSearch=true
   on_failure:
     error_log_artifacts:
       path: "hs_err_pid*.log"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.sonarsource.kotlin
-version=3.0.0-SNAPSHOT
+version=3.1.0-SNAPSHOT
 description=Code Analyzer for Kotlin
 projectTitle=Kotlin
 kotlinVersion=2.1.10


### PR DESCRIPTION
[SCA-119](https://sonarsource.atlassian.net/browse/SCA-119)

We need to use recursive mode in order to find the dependencies of the sub-projects.

With this PR, the Dependencies tab is showing 295 dependencies (up from 7 on the master branch):
https://next.sonarqube.com/sonarqube/dependencies?id=org.sonarsource.kotlin%3Akotlin&pullRequest=590

[SCA-119]: https://sonarsource.atlassian.net/browse/SCA-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ