### PR TITLE
BUILD-7780: Use monthly cache for orchestrator

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,6 +63,30 @@ windows_16_cpu_32G_template: &WINDOWS_16_CPU_32G
     preemptible: false
     use_ssd: true
 
+orchestrator_cache_definition: &ORCHESTRATOR_CACHE_DEFINITION
+  set_orchestrator_home_script: |
+    # Check if SQ_VERSION exists and create an intermediary variable
+    if [ -n "$SQ_VERSION" ]; then
+        FOLDER="${SQ_VERSION}"
+    else
+        FOLDER="DEFAULT"
+    fi
+
+    CURRENT_MONTH=$(date +"%B")
+    echo "CURRENT_MONTH=${CURRENT_MONTH}" >> $CIRRUS_ENV
+    echo "ORCHESTRATOR_HOME=${CIRRUS_WORKING_DIR}/orchestrator/${FOLDER}/${CURRENT_MONTH}" >> $CIRRUS_ENV
+    echo "FOLDER=${FOLDER}" >> $CIRRUS_ENV
+  mkdir_orchestrator_home_script: |
+    echo "Create dir ${ORCHESTRATOR_HOME} if needed"
+    mkdir -p ${ORCHESTRATOR_HOME}
+  orchestrator_cache:
+    folder: ${ORCHESTRATOR_HOME}
+    fingerprint_script: echo ${FOLDER}-${CURRENT_MONTH}
+    reupload_on_changes: "true"
+
+cleanup_orchestrator_cache_script_template: &CLEANUP_ORCHESTRATOR_CACHE_SCRIPT
+  cleanup_orchestrator_cache_script: .cirrus/clean-orchestrator-cache.sh
+
 setup_gradle_cache_template: &SETUP_GRADLE_CACHE
   gradle_cache:
      folder: .gradle/caches
@@ -78,6 +102,7 @@ cleanup_gradle_cache_script_template: &CLEANUP_GRADLE_CACHE_SCRIPT
 
 gradle_its_template: &GRADLE_ITS_TEMPLATE
   <<: *SETUP_GRADLE_CACHE
+  <<: *ORCHESTRATOR_CACHE_DEFINITION
   run_its_script:
     - |
       if [ -n "${GIT_SUB_MODULE}" ]; then
@@ -89,6 +114,7 @@ gradle_its_template: &GRADLE_ITS_TEMPLATE
       "-DbuildNumber=$BUILD_NUMBER"
       --info --console plain --no-daemon --build-cache
   <<: *CLEANUP_GRADLE_CACHE_SCRIPT
+  <<: *CLEANUP_ORCHESTRATOR_CACHE_SCRIPT
 
 only_if_sonarsource_qa_template: &ONLY_IF_SONARSOURCE_QA
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*")
@@ -198,6 +224,7 @@ qa_ruling_kotlin_compiler_task:
     GIT_SUB_MODULE: "its/sources"
   <<: *LINUX_6_CPU_12G_JAVA_17
   <<: *SETUP_GRADLE_CACHE
+  <<: *ORCHESTRATOR_CACHE_DEFINITION
   run_its_script:
     - |
       if [ -n "${GIT_SUB_MODULE}" ]; then
@@ -209,6 +236,7 @@ qa_ruling_kotlin_compiler_task:
       "-DbuildNumber=$BUILD_NUMBER"
       --info --console plain --no-daemon --build-cache
   <<: *CLEANUP_GRADLE_CACHE_SCRIPT
+  <<: *CLEANUP_ORCHESTRATOR_CACHE_SCRIPT
 
 build_win_task:
   <<: *QA_TASK_FILTER

--- a/.cirrus/clean-orchestrator-cache.sh
+++ b/.cirrus/clean-orchestrator-cache.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$ORCHESTRATOR_HOME" || exit 1
+
+# Find all sonar-application-* JAR files, sort them by version, and list them
+files=$(/usr/bin/find . -name 'sonar-application-*' | /usr/bin/sort --field-separator=- --key=3V --reverse)
+
+echo "File that will not be deleted:"
+echo "$files" | head -n 1
+
+kotlin_files=$(/usr/bin/find . -name 'sonar-kotlin-plugin-*.jar')
+
+# Get the files to delete: all sonar-application except the latest one, and all sonar-kotlin-plugin JAR files
+files_to_delete=$(echo "$files" | tail -n +2; echo "$kotlin_files")
+
+echo ""
+if [ -z "$files_to_delete" ]; then
+  echo "No files will be deleted."
+else
+  echo "Files that will be deleted:"
+  echo "$files_to_delete"
+
+  # Delete obsolete sonar-application files
+  # shellcheck disable=SC2016
+  echo "$files_to_delete" | xargs -I {} sh -c 'rm -f "{}" && rmdir "$(dirname "{}")" 2>/dev/null || true'
+fi


### PR DESCRIPTION
[BUILD-7780](https://sonarsource.atlassian.net/browse/BUILD-7780)

Part of https://sonarsource.atlassian.net/browse/BUILD-7780
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

This PR introduces caching of artifacts downloaded by orchestrator in the pipeline. It is necessary to reduce bandwidth consumption from repox.

[BUILD-7780]: https://sonarsource.atlassian.net/browse/BUILD-7780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ