### PR TITLE
SONARKT-644 Fix FP in S6311 when no Dispatcher is used explicitly

### DIFF
--- a/kotlin-checks-test-sources/src/main/kotlin/checks/SuspendingFunCallerDispatcherCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/SuspendingFunCallerDispatcherCheckSample.kt
@@ -42,7 +42,7 @@ class SuspendingFunCallerDispatcherCheckSample(val injectable: CoroutineDispatch
                 Thread.sleep(500L)
             }
 
-            async { // Compliant, no other Dispatcher is used
+            async { // Compliant, no Dispatcher is used explicitly
                 complex()
             }
         }

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/SuspendingFunCallerDispatcherCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/SuspendingFunCallerDispatcherCheckSample.kt
@@ -41,6 +41,10 @@ class SuspendingFunCallerDispatcherCheckSample(val injectable: CoroutineDispatch
             launch(Dispatchers.IO) { // Compliant
                 Thread.sleep(500L)
             }
+
+            async { // Compliant, no other Dispatcher is used
+                complex()
+            }
         }
     }
 

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SuspendingFunCallerDispatcherCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/SuspendingFunCallerDispatcherCheck.kt
@@ -43,6 +43,7 @@ class SuspendingFunCallerDispatcherCheck : CallAbstractCheck() {
             && callExpressions.all {
                 (it.resolveToCall()?.singleFunctionCallOrNull()?.partiallyAppliedSymbol?.signature?.symbol as? KaNamedFunctionSymbol)?.isSuspend == true
             }
+            && arguments.size == 2
         ) {
             val argExpr = arguments.elementAt(0)
             kotlinFileContext.reportIssue(argExpr, "Remove this dispatcher. It is pointless when used with only suspending functions.")


### PR DESCRIPTION
A regression occurred in 166b85190b9b95ee6d0c763752271fe845a9d218, which causes this rule to raise whenever `launch`, `async` or `withContext` is used with one suspending function, regardless of if a `Dispatcher` is set or not.

A user [raised the issue](https://community.sonarsource.com/t/kotlin-s6311-raises-a-false-positive-for-android-viewmodel-coroutines-usage/138038) a few days ago. This PR is a simple fix for the issue, and also adds the [compliant sample](https://sonarsource.github.io/rspec/#/rspec/S6311) as a test case.