### PR TITLE
SONARKT-749 Align bundled deps with Kotlin 2.3.20 and reconfigure Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,6 +79,19 @@
         "its/sources/**"
       ],
       "enabled": false
+    },
+    {
+      // These versions must stay aligned with the Kotlin compiler version used in the project.
+      // Check the correct versions at: https://github.com/JetBrains/kotlin/blob/v2.3.20/gradle/libs.versions.toml
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchPackageNames": [
+        "org.jetbrains.kotlinx:kotlinx-serialization-core",
+        "com.github.ben-manes.caffeine:caffeine",
+        "com.google.code.gson:gson"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -2699,6 +2699,11 @@
             <sha256 value="eba7f1c854296e4ce1418fb01360f8f10c5683e7c45aa3472018417a067636f3" origin="Verified"/>
          </artifact>
       </component>
+      <component group="org.jetbrains.kotlinx" name="kotlinx-serialization-core-jvm" version="1.7.3">
+         <artifact name="kotlinx-serialization-core-jvm-1.7.3.jar">
+            <sha256 value="f0adde45864144475385cf4aa7e0b7feb27f61fcf9472665ed98cc971b06b1eb" origin="Verified"/>
+         </artifact>
+      </component>
       <component group="org.jetbrains.kotlinx" name="kotlinx-serialization-core-jvm" version="1.9.0">
          <artifact name="kotlinx-serialization-core-jvm-1.9.0.jar">
             <sha256 value="1f0afa172110e45a7231ef1b44ae8fd84c1ebaff96f3fc3ad68ef8c48120b59c" origin="Verified"/>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,7 +37,7 @@ dependencyResolutionManagement {
 
         create("libs") {
             val analyzerCommons = version("analyzerCommons", analyzerCommonsVersionStr)
-            val gson = version("gson", "2.10.1")
+            val gson = version("gson", "2.11.0")
             val staxmate = version("staxmate", "2.4.1")
 
             library("gson", "com.google.code.gson", "gson").versionRef(gson)

--- a/sonar-kotlin-api/build.gradle.kts
+++ b/sonar-kotlin-api/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
             isTransitive = false
         }
     }
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.10.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3")
     implementation("com.github.ben-manes.caffeine:caffeine:2.9.3")
     compileOnly(libs.sonar.plugin.api)
     compileOnly(libs.slf4j.api)


### PR DESCRIPTION
## Summary

- Downgrade `kotlinx-serialization-core` 1.10.0 → 1.7.3 to match the version the Kotlin Analysis API (K2) was compiled against
- Upgrade `gson` 2.10.1 → 2.11.0 to match Kotlin 2.3.20
- Exclude `kotlinx-serialization-core`, `caffeine`, and `gson` from Renovate auto-updates — these must stay aligned with the Kotlin compiler version; versions are documented at https://github.com/JetBrains/kotlin/blob/v2.3.20/gradle/libs.versions.toml
- Verify SHA256 of `kotlinx-serialization-core-jvm:1.7.3` in `verification-metadata.xml`

## Test plan

- [x] `./gradlew :sonar-kotlin-plugin:dist` passes with jar size within new bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)