### PR TITLE
SONARKT-751 Enable Gradle build cache and parallel build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,7 @@ version=3.5-SNAPSHOT
 description=Code Analyzer for Kotlin
 projectTitle=Kotlin
 kotlinVersion=2.3.20
+
 org.gradle.jvmargs=-Xmx4096M
+org.gradle.parallel=true
+org.gradle.caching=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -121,3 +121,10 @@ develocity {
         }
     }
 }
+
+buildCache {
+    remote(develocity.buildCache) {
+        isEnabled = true
+        isPush = isCI
+    }
+}


### PR DESCRIPTION
Part of SONARKT-713

First build after enabling remote cache shows 4% of time savings. When rerunning the same job for the second time, 60% of time was saved due to cache.