### PR TITLE
SONARKT-753 Exclude BouncyCastle introduced by buildSrc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,6 +96,13 @@ allprojects {
             }
         }
     }
+
+    configurations.matching { it.name == "kotlinBouncyCastleConfiguration" }.configureEach {
+        // Workaround for https://github.com/gradle/gradle/issues/35309.
+        // When any of cloud-native Gradle plugins is applied in a project
+        // whose Gradle version embeds Kotlin <2.3.20, there will be an unnecessary dependency on build classpath.
+        withDependencies { clear() }
+    }
 }
 
 subprojects {

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -1331,34 +1331,14 @@
             <sha256 value="c4a445426c3c2861666863b842cc4ec7bbb1c4226fefd370b6d2fe83d6c4ff0f" origin="Verified"/>
          </artifact>
       </component>
-      <component group="org.bouncycastle" name="bcpg-jdk18on" version="1.80">
-         <artifact name="bcpg-jdk18on-1.80.jar">
-            <sha256 value="3799a0d53511b860780af43c44ae8e0519afabb263195af40174f46312cd58bd" origin="Verified"/>
-         </artifact>
-      </component>
-      <component group="org.bouncycastle" name="bcpkix-jdk18on" version="1.80">
-         <artifact name="bcpkix-jdk18on-1.80.jar">
-            <sha256 value="4f4ba6a92617ea19dc183f0fa5db492eee426fdde2a0a2d6c94777ffd1af6413" origin="Verified"/>
-         </artifact>
-      </component>
       <component group="org.bouncycastle" name="bcprov-jdk18on" version="1.78.1">
          <artifact name="bcprov-jdk18on-1.78.1.jar">
             <sha256 value="add5915e6acfc6ab5836e1fd8a5e21c6488536a8c1f21f386eeb3bf280b702d7" origin="Verified"/>
          </artifact>
       </component>
-      <component group="org.bouncycastle" name="bcprov-jdk18on" version="1.80">
-         <artifact name="bcprov-jdk18on-1.80.jar">
-            <sha256 value="e8ad209f8c58d291a37ca9750e9e9fac60596956c983e49dd8282381dd8b3249" origin="Verified"/>
-         </artifact>
-      </component>
       <component group="org.bouncycastle" name="bcprov-jdk18on" version="1.83">
          <artifact name="bcprov-jdk18on-1.83.jar">
             <sha256 value="82cf3a2af766c3bc874f6d36b9f20a8b99a8f09762dc776e8a227a45d8daaafb" origin="Verified"/>
-         </artifact>
-      </component>
-      <component group="org.bouncycastle" name="bcutil-jdk18on" version="1.80">
-         <artifact name="bcutil-jdk18on-1.80.jar">
-            <sha256 value="22eca687f7955411f456af33e6ea8e68fc73cd80cb8b32aa5f7a8b1827d7c678" origin="Verified"/>
          </artifact>
       </component>
       <component group="org.checkerframework" name="checker-qual" version="3.19.0">


### PR DESCRIPTION
The fix integrated in #710 removed BouncyCastle from `build-logic/common`, but there is still a source of this dependency in `buildSrc`. This PR ensures the dependency is removed.