### PR TITLE
SONARKT-735 S7435 should not crash on when conditions with unstable smart cast

### DIFF
--- a/kotlin-checks-test-sources/src/main/kotlin/checks/AndroidPersistentUniqueIdentifierCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/AndroidPersistentUniqueIdentifierCheckSample.kt
@@ -14,6 +14,18 @@ typealias AndroidxAdsAdvertisingIdClient = androidx.ads.identifier.AdvertisingId
 typealias ComHuaweiAdvertisingIdClient = com.huawei.hms.ads.identifier.AdvertisingIdClient
 typealias SettingsSecureAlias = android.provider.Settings.Secure
 
+interface SomeHolder {
+    val element: Any?  // interface property -> unstable for smart cast
+}
+
+private fun reproduceSmartcastCrash(holder: SomeHolder, list: List<String>) {
+    when (holder.element) {
+        !is String -> return
+        !in list -> return  // Compliant - should not crash
+        else -> {}
+    }
+}
+
 class AndroidPersistentUniqueIdentifierCheckSample {
 
     class BluetoothAdapterTests {

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AndroidPersistentUniqueIdentifierCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AndroidPersistentUniqueIdentifierCheck.kt
@@ -25,8 +25,8 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtReferenceExpression
-import org.jetbrains.kotlin.psi.KtWhenConditionInRange
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.CallAbstractCheck
 import org.sonarsource.kotlin.api.checks.FunMatcher
@@ -86,7 +86,7 @@ class AndroidPersistentUniqueIdentifierCheck : CallAbstractCheck() {
     override val functionsToVisit = instanceMatches.keys
 
     override fun visitReferenceExpression(expression: KtReferenceExpression, data: KotlinFileContext) = withKaSession {
-        if (expression.parent is KtWhenConditionInRange) return@withKaSession
+        if (expression !is KtNameReferenceExpression) return@withKaSession
         val resolvedCall = expression.resolveToCall()
         val call = resolvedCall?.successfulCallOrNull<KaCallableMemberCall<*, *>>() ?: return@withKaSession
         if (staticSettingsSecureGetStringFunMatcher.matches(call)) {

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AndroidPersistentUniqueIdentifierCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AndroidPersistentUniqueIdentifierCheck.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtWhenConditionInRange
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.CallAbstractCheck
 import org.sonarsource.kotlin.api.checks.FunMatcher
@@ -85,6 +86,7 @@ class AndroidPersistentUniqueIdentifierCheck : CallAbstractCheck() {
     override val functionsToVisit = instanceMatches.keys
 
     override fun visitReferenceExpression(expression: KtReferenceExpression, data: KotlinFileContext) = withKaSession {
+        if (expression.parent is KtWhenConditionInRange) return@withKaSession
         val resolvedCall = expression.resolveToCall()
         val call = resolvedCall?.successfulCallOrNull<KaCallableMemberCall<*, *>>() ?: return@withKaSession
         if (staticSettingsSecureGetStringFunMatcher.matches(call)) {


### PR DESCRIPTION
## Summary

- Fix crash in `AndroidPersistentUniqueIdentifierCheck` (S7435) when analyzing `when` expressions that combine a `!is` condition and a `!in` condition on a subject that is unstable for smart cast
- Root cause: `visitReferenceExpression` was calling `resolveToCall()` on `KtOperationReferenceExpression` nodes inside `KtWhenConditionInRange`, triggering a K2 Analysis API bug when `SMARTCAST_IMPOSSIBLE` diagnostic fails on non-`KtExpression` nodes
- Fix: added a one-line guard to return early when `expression.parent is KtWhenConditionInRange`

## Test plan

- [ ] Added reproducer test case to `AndroidPersistentUniqueIdentifierCheckSample.kt` with an interface property (unstable for smart cast) in a `when` expression combining `!is` and `!in` conditions
- [ ] `./gradlew :sonar-kotlin-checks:test --tests "org.sonarsource.kotlin.checks.AndroidPersistentUniqueIdentifierCheckTest"` passes
- [ ] No regression in existing tests

Fixes SONARKT-735

🤖 Generated with [Claude Code](https://claude.com/claude-code)