### PR TITLE
SONARKT-759 Adjust automated release process workflows

### DIFF
--- a/.github/workflows/AutomateRelease.yml
+++ b/.github/workflows/AutomateRelease.yml
@@ -43,20 +43,16 @@ on:
         description: "Test mode: uses Jira sandbox and creates draft GitHub release"
         type: boolean
         default: false
+      verbose:
+        type: boolean
+        description: |
+          Add verbose job summaries
+        default: true
 
 jobs:
-  lock-branch:
-    name: Lock ${{ inputs.branch }} branch
-    uses: ./.github/workflows/ToggleLockBranch.yml
-    permissions:
-      id-token: write
-    with:
-      branch: ${{ inputs.branch }}
-
   release:
     name: Release
-    uses: SonarSource/release-github-actions/.github/workflows/cloud-security-automated-release.yml@v1
-    needs: lock-branch
+    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@v1
     permissions:
       statuses: read
       id-token: write
@@ -79,27 +75,10 @@ jobs:
       release-notes: ${{ inputs.release-notes }}
       sq-ide-short-description: ${{ inputs.sq-ide-short-description }}
       new-version: ${{ inputs.new-version }}
-      create-sli-ticket: true
-      create-slvs-ticket: false
-      create-sle-ticket: false
-      create-slvscode-ticket: false
       require-rule-metadata-update: ${{ inputs.require-rule-metadata-update }}
-
-  unlock-branch:
-    name: Unlock ${{ inputs.branch }} branch
-    uses: ./.github/workflows/ToggleLockBranch.yml
-    needs: release
-    permissions:
-      id-token: write
-    with:
-      branch: ${{ inputs.branch }}
-
-  bump_versions:
-    name: Bump versions
-    needs: [release, unlock-branch]
-    uses: ./.github/workflows/bump-versions.yaml
-    permissions:
-      contents: write
-      pull-requests: write
-    with:
-      version: ${{ needs.release.outputs.new-version }}-SNAPSHOT
+      slack-channel: "squad-security-cloud-notifs"
+      create-sli-ticket: true
+      runner-environment: sonar-xs
+      release-process: "https://xtranet-sonarsource.atlassian.net/wiki/x/RADLAQE"
+      verbose: ${{ inputs.verbose }}
+      bump-version: true

--- a/.github/workflows/AutomateRelease.yml
+++ b/.github/workflows/AutomateRelease.yml
@@ -47,7 +47,7 @@ on:
         type: boolean
         description: |
           Add verbose job summaries
-        default: true
+        default: false
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
         type: string
         description: Version
         required: true
+      dryRun:
+        type: boolean
+        description: Flag to enable the dry-run execution
+        default: false
+        required: false
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,6 @@ on:
         type: string
         description: Version
         required: true
-      releaseId:
-        type: string
-        description: Release ID
-        required: false
-      dryRun:
-        type: boolean
-        description: Flag to enable the dry-run execution
-        default: false
-        required: false
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,20 @@
 ---
 name: sonar-release
-# This workflow is triggered manually via workflow_dispatch
+# This workflow is triggered when publishing a new github release
 # yamllint disable-line rule:truthy
 on:
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
       version:
         type: string
         description: Version
+        required: true
+      releaseId:
+        type: string
+        description: Release ID
         required: true
       dryRun:
         type: boolean
@@ -20,9 +27,10 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
     with:
       version: ${{ inputs.version }}
+      releaseId: ${{ inputs.releaseId }}
       dryRun: ${{ inputs.dryRun }}
       publishToBinaries: true
       mavenCentralSync: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
     with:
       version: ${{ inputs.version }}
+      dryRun: ${{ inputs.dryRun }}
       publishToBinaries: true
       mavenCentralSync: true
       slackChannel: squad-security-cloud-notifs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 ---
 name: sonar-release
-# This workflow is triggered when publishing a new github release
+# This workflow is triggered manually via workflow_dispatch
 # yamllint disable-line rule:truthy
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ name: sonar-release
 # This workflow is triggered when publishing a new github release
 # yamllint disable-line rule:truthy
 on:
-  release:
-    types:
-      - published
   workflow_dispatch:
     inputs:
       version:
@@ -15,7 +12,7 @@ on:
       releaseId:
         type: string
         description: Release ID
-        required: true
+        required: false
       dryRun:
         type: boolean
         description: Flag to enable the dry-run execution
@@ -27,11 +24,9 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
     with:
       version: ${{ inputs.version }}
-      releaseId: ${{ inputs.releaseId }}
-      dryRun: ${{ inputs.dryRun }}
       publishToBinaries: true
       mavenCentralSync: true
       slackChannel: squad-security-cloud-notifs


### PR DESCRIPTION
## Summary

Migrated to the new generic release automation workflow from SonarSource/release-github-actions. Simplified the release orchestration by removing intermediate lock/unlock and version bump jobs (now handled internally) and updated to the latest action versions.

## Changes

- **AutomateRelease.yml**: Replaced `cloud-security-automated-release.yml@v1` with `automated-release.yml@v1`; removed `lock-branch`, `unlock-branch`, and `bump_versions` jobs (now handled internally); added `verbose` input and `slack-channel`, `runner-environment`, `release-process`, `bump-version: true` parameters
