### PR TITLE
SONARKT-343 S6518 should ignore chained setters

### DIFF
--- a/kotlin-checks-test-sources/src/main/kotlin/checks/IndexedAccessCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/IndexedAccessCheckSample.kt
@@ -3,9 +3,6 @@ package checks
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.RangeMap
 import com.google.common.collect.Table
-import okhttp3.Headers
-import otherpackage.KotlinLibContainer
-import otherpackage.get
 import java.nio.ByteBuffer
 import java.util.BitSet
 import java.util.Calendar
@@ -14,6 +11,9 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicIntegerArray
+import okhttp3.Headers
+import otherpackage.KotlinLibContainer
+import otherpackage.get
 
 class IndexedAccessCheckSample {
 
@@ -193,23 +193,15 @@ class ChainableMap {
 }
 
 fun chainedSetters(builder: ChainableBuilder, chainableMap: ChainableMap) {
-    // Chained set calls - the result of set() is used for further chaining, so indexed access would break the chain.
-    // The intermediate set calls (whose return value is used) are compliant.
-    // The last set call in the chain is still noncompliant because its return value is not used.
     builder.set("a", "1").set("b", "2").set("c", "3") // Noncompliant {{Replace function call with indexed accessor.}}
+    //                                  ^^^
     builder.set("a", "1").set("b", "2") // Noncompliant {{Replace function call with indexed accessor.}}
+    //                    ^^^
     builder.set("a", "1").build() // Compliant - set result used in chain
 
-    // Chained get calls - indexed access still works (builder["a"].length is valid)
     builder.get("a").length // Noncompliant {{Replace function call with indexed accessor.}}
 
     chainableMap.set("a", 1).set("b", 2) // Noncompliant {{Replace function call with indexed accessor.}}
     chainableMap.set("a", 1).size() // Compliant - set result used in chain
-
-    // Non-chained calls on types with chainable setters should still be flagged
-    builder.set("a", "1") // Noncompliant {{Replace function call with indexed accessor.}}
-    builder.get("a") // Noncompliant {{Replace function call with indexed accessor.}}
-    chainableMap.set("a", 1) // Noncompliant {{Replace function call with indexed accessor.}}
-    chainableMap.get("a") // Noncompliant {{Replace function call with indexed accessor.}}
 }
 

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/IndexedAccessCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/IndexedAccessCheckSample.kt
@@ -172,3 +172,44 @@ class GenericAccessorClass {
     operator fun <T> get(key: String): T = TODO()
 }
 
+class ChainableBuilder {
+    operator fun set(key: String, value: String): ChainableBuilder {
+        return this
+    }
+
+    operator fun get(key: String): String = ""
+
+    fun build(): String = ""
+}
+
+class ChainableMap {
+    operator fun set(key: String, value: Int): ChainableMap {
+        return this
+    }
+
+    operator fun get(key: String): Int = 0
+
+    fun size(): Int = 0
+}
+
+fun chainedSetters(builder: ChainableBuilder, chainableMap: ChainableMap) {
+    // Chained set calls - the result of set() is used for further chaining, so indexed access would break the chain.
+    // The intermediate set calls (whose return value is used) are compliant.
+    // The last set call in the chain is still noncompliant because its return value is not used.
+    builder.set("a", "1").set("b", "2").set("c", "3") // Noncompliant {{Replace function call with indexed accessor.}}
+    builder.set("a", "1").set("b", "2") // Noncompliant {{Replace function call with indexed accessor.}}
+    builder.set("a", "1").build() // Compliant - set result used in chain
+
+    // Chained get calls - indexed access still works (builder["a"].length is valid)
+    builder.get("a").length // Noncompliant {{Replace function call with indexed accessor.}}
+
+    chainableMap.set("a", 1).set("b", 2) // Noncompliant {{Replace function call with indexed accessor.}}
+    chainableMap.set("a", 1).size() // Compliant - set result used in chain
+
+    // Non-chained calls on types with chainable setters should still be flagged
+    builder.set("a", "1") // Noncompliant {{Replace function call with indexed accessor.}}
+    builder.get("a") // Noncompliant {{Replace function call with indexed accessor.}}
+    chainableMap.set("a", 1) // Noncompliant {{Replace function call with indexed accessor.}}
+    chainableMap.get("a") // Noncompliant {{Replace function call with indexed accessor.}}
+}
+

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/IndexedAccessCheckSampleNoSemantics.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/IndexedAccessCheckSampleNoSemantics.kt
@@ -174,3 +174,44 @@ class GenericAccessorClass2 {
     operator fun <T> get(key: String): T = TODO()
 }
 
+class ChainableBuilder2 {
+    operator fun set(key: String, value: String): ChainableBuilder2 {
+        return this
+    }
+
+    operator fun get(key: String): String = ""
+
+    fun build(): String = ""
+}
+
+class ChainableMap2 {
+    operator fun set(key: String, value: Int): ChainableMap2 {
+        return this
+    }
+
+    operator fun get(key: String): Int = 0
+
+    fun size(): Int = 0
+}
+
+fun chainedSetters2(builder: ChainableBuilder2, chainableMap: ChainableMap2) {
+    // Chained set calls - the result of set() is used for further chaining, so indexed access would break the chain.
+    // The intermediate set calls (whose return value is used) are compliant.
+    // The last set call in the chain is still noncompliant because its return value is not used.
+    builder.set("a", "1").set("b", "2").set("c", "3") // Noncompliant {{Replace function call with indexed accessor.}}
+    builder.set("a", "1").set("b", "2") // Noncompliant {{Replace function call with indexed accessor.}}
+    builder.set("a", "1").build() // Compliant - set result used in chain
+
+    // Chained get calls - indexed access still works (builder["a"].length is valid)
+    builder.get("a").length // Noncompliant {{Replace function call with indexed accessor.}}
+
+    chainableMap.set("a", 1).set("b", 2) // Noncompliant {{Replace function call with indexed accessor.}}
+    chainableMap.set("a", 1).size() // Compliant - set result used in chain
+
+    // Non-chained calls on types with chainable setters should still be flagged
+    builder.set("a", "1") // Noncompliant {{Replace function call with indexed accessor.}}
+    builder.get("a") // Noncompliant {{Replace function call with indexed accessor.}}
+    chainableMap.set("a", 1) // Noncompliant {{Replace function call with indexed accessor.}}
+    chainableMap.get("a") // Noncompliant {{Replace function call with indexed accessor.}}
+}
+

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/IndexedAccessCheckSampleNoSemantics.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/IndexedAccessCheckSampleNoSemantics.kt
@@ -3,9 +3,6 @@ package checks
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.RangeMap
 import com.google.common.collect.Table
-import okhttp3.Headers
-import otherpackage.KotlinLibContainer
-import otherpackage.get
 import java.nio.ByteBuffer
 import java.util.BitSet
 import java.util.Calendar
@@ -14,6 +11,9 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicIntegerArray
+import okhttp3.Headers
+import otherpackage.KotlinLibContainer
+import otherpackage.get
 
 class IndexedAccessCheckSampleNoSemantics {
 
@@ -195,23 +195,14 @@ class ChainableMap2 {
 }
 
 fun chainedSetters2(builder: ChainableBuilder2, chainableMap: ChainableMap2) {
-    // Chained set calls - the result of set() is used for further chaining, so indexed access would break the chain.
-    // The intermediate set calls (whose return value is used) are compliant.
-    // The last set call in the chain is still noncompliant because its return value is not used.
     builder.set("a", "1").set("b", "2").set("c", "3") // Noncompliant {{Replace function call with indexed accessor.}}
+    //                                  ^^^
     builder.set("a", "1").set("b", "2") // Noncompliant {{Replace function call with indexed accessor.}}
+    //                    ^^^
     builder.set("a", "1").build() // Compliant - set result used in chain
 
-    // Chained get calls - indexed access still works (builder["a"].length is valid)
     builder.get("a").length // Noncompliant {{Replace function call with indexed accessor.}}
 
     chainableMap.set("a", 1).set("b", 2) // Noncompliant {{Replace function call with indexed accessor.}}
     chainableMap.set("a", 1).size() // Compliant - set result used in chain
-
-    // Non-chained calls on types with chainable setters should still be flagged
-    builder.set("a", "1") // Noncompliant {{Replace function call with indexed accessor.}}
-    builder.get("a") // Noncompliant {{Replace function call with indexed accessor.}}
-    chainableMap.set("a", 1) // Noncompliant {{Replace function call with indexed accessor.}}
-    chainableMap.get("a") // Noncompliant {{Replace function call with indexed accessor.}}
 }
-

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IndexedAccessCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IndexedAccessCheck.kt
@@ -85,8 +85,26 @@ class IndexedAccessCheck : CallAbstractCheck() {
         if (dotExpression.receiverExpression is KtSuperExpression) return
         if (callExpression.typeArgumentList != null) return
         if(callExpression.valueArguments.any {  it.isNamed() }) return
+        if (isChainedSetCall(callExpression, dotExpression)) return
         if (isJavaInteropOperator(resolvedCall) && !isAllowedJavaInteropType(resolvedCall)) return
         kotlinFileContext.reportIssue(callExpression.calleeExpression!!, "Replace function call with indexed accessor.")
+    }
+
+    /**
+     * Checks whether a `set` call is part of a method chain, meaning its return value is used
+     * for further chaining. For example, in `builder.set("a", "1").set("b", "2")`, the inner
+     * `builder.set("a", "1")` is the receiver of the outer dot-qualified expression. Replacing
+     * such calls with indexed access operators would break the chain, since indexed access
+     * assignment (`a[k] = v`) returns Unit.
+     *
+     * This only applies to `set` calls. `get` calls can always be replaced with indexed access
+     * because the indexed access expression (`a[k]`) returns the same value as `a.get(k)`,
+     * so chaining still works (e.g., `map.get("a").length` can become `map["a"].length`).
+     */
+    private fun isChainedSetCall(callExpression: KtCallExpression, dotExpression: KtDotQualifiedExpression): Boolean {
+        if (callExpression.calleeExpression?.text != "set") return false
+        val parent = dotExpression.parent as? KtDotQualifiedExpression ?: return false
+        return parent.receiverExpression == dotExpression
     }
 
     /**

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IndexedAccessCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IndexedAccessCheck.kt
@@ -94,12 +94,7 @@ class IndexedAccessCheck : CallAbstractCheck() {
      * Checks whether a `set` call is part of a method chain, meaning its return value is used
      * for further chaining. For example, in `builder.set("a", "1").set("b", "2")`, the inner
      * `builder.set("a", "1")` is the receiver of the outer dot-qualified expression. Replacing
-     * such calls with indexed access operators would break the chain, since indexed access
-     * assignment (`a[k] = v`) returns Unit.
-     *
-     * This only applies to `set` calls. `get` calls can always be replaced with indexed access
-     * because the indexed access expression (`a[k]`) returns the same value as `a.get(k)`,
-     * so chaining still works (e.g., `map.get("a").length` can become `map["a"].length`).
+     * such calls with indexed access operators would break the chain.
      */
     private fun isChainedSetCall(callExpression: KtCallExpression, dotExpression: KtDotQualifiedExpression): Boolean {
         if (callExpression.calleeExpression?.text != "set") return false


### PR DESCRIPTION
## Summary
Indexed Access Check improvements

## Changes
- Modified IndexedAccessCheck.kt to enhance implementation
- Updated IndexedAccessCheckSample.kt with test cases
- Updated IndexedAccessCheckSampleNoSemantics.kt with additional samples

## Testing
Changes tested locally with existing unit tests

## Ticket
SONARKT-343

----
## Summary by Gitar

- **Bug fix:**
  - Added `isChainedSetCall` to prevent `IndexedAccessCheck` from breaking method chains where `set` results are reused.
- **Testing:**
  - Added `ChainableBuilder` and `ChainableMap` classes to test cases for chained setter validation.

<sub>This will update automatically on new commits.</sub>