### PR TITLE
SONARKT-769 Add telemetry for Kotlin parse failures

### DIFF
--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
@@ -78,6 +78,10 @@ abstract class AbstractKotlinSensorExecuteContext(
 
     abstract val classpath: List<String>
 
+    open fun onFileRead() {
+        // no-op by default; subclasses override to react to each file being processed (e.g. increment a telemetry counter)
+    }
+
     open fun onParseFailure() {
         // no-op by default; subclasses override to react to parse failures (e.g. increment a telemetry counter)
     }
@@ -100,6 +104,7 @@ abstract class AbstractKotlinSensorExecuteContext(
 
     val kotlinFiles: List<KotlinSyntaxStructure> by lazy {
         inputFiles.mapNotNull {
+            onFileRead()
             val inputFileContext = InputFileContextImpl(sensorContext, it, isInAndroidContext)
             try {
                 // The current logic relies on eager loading of all files before the analysis starts.

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
@@ -78,7 +78,9 @@ abstract class AbstractKotlinSensorExecuteContext(
 
     abstract val classpath: List<String>
 
-    open fun onParseFailure() {}
+    open fun onParseFailure() {
+        // no-op by default; subclasses override to react to parse failures (e.g. increment a telemetry counter)
+    }
 
     val environment: Environment by lazy {
         /** [analyzeFiles] */

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
@@ -86,6 +86,10 @@ abstract class AbstractKotlinSensorExecuteContext(
         // no-op by default; subclasses override to react to parse failures (e.g. increment a telemetry counter)
     }
 
+    open fun onReadFailure() {
+        // no-op by default; subclasses override to react to read failures (e.g. increment a telemetry counter)
+    }
+
     val environment: Environment by lazy {
         /** [analyzeFiles] */
         val env = Environment(
@@ -121,6 +125,7 @@ abstract class AbstractKotlinSensorExecuteContext(
                 val parseException = toParseException("read", it, e)
                 logParsingError(it, parseException)
                 inputFileContext.reportAnalysisParseError(KOTLIN_REPOSITORY_KEY, it, parseException.position)
+                onReadFailure()
                 null
             }
         }

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
@@ -78,6 +78,8 @@ abstract class AbstractKotlinSensorExecuteContext(
 
     abstract val classpath: List<String>
 
+    open fun onParseFailure() {}
+
     val environment: Environment by lazy {
         /** [analyzeFiles] */
         val env = Environment(
@@ -106,6 +108,7 @@ abstract class AbstractKotlinSensorExecuteContext(
             } catch (e: ParseException) {
                 logParsingError(it, toParseException("parse", it, e))
                 inputFileContext.reportAnalysisParseError(KOTLIN_REPOSITORY_KEY, it, e.position)
+                onParseFailure()
                 null
             } catch (e: Exception) {
                 val parseException = toParseException("read", it, e)

--- a/sonar-kotlin-gradle/build.gradle.kts
+++ b/sonar-kotlin-gradle/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(libs.sonar.analyzer.commons.recognizers)
 
     implementation(project(":sonar-kotlin-api"))
+    implementation(project(":sonar-kotlin-metrics"))
     implementation(project(":sonar-kotlin-surefire"))
 
     testImplementation(testLibs.junit.jupiter)

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/KotlinGradleSensor.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/KotlinGradleSensor.kt
@@ -69,7 +69,13 @@ class KotlinGradleSensor(
         }
 
         override fun onParseFailure() {
+            telemetryData.parseFailures++
             telemetryData.scriptParseFailures++
+        }
+
+        override fun onReadFailure() {
+            telemetryData.readFailures++
+            telemetryData.scriptReadFailures++
         }
     }
 

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/KotlinGradleSensor.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/KotlinGradleSensor.kt
@@ -29,6 +29,7 @@ import org.sonarsource.kotlin.api.common.KotlinLanguage
 import org.sonarsource.kotlin.api.sensors.AbstractKotlinSensor
 import org.sonarsource.kotlin.api.sensors.AbstractKotlinSensorExecuteContext
 import org.sonarsource.kotlin.api.visiting.KtChecksVisitor
+import org.sonarsource.kotlin.metrics.TelemetryData
 import java.io.File
 import java.nio.file.Files
 
@@ -41,6 +42,7 @@ private val LOG = LoggerFactory.getLogger(KotlinGradleSensor::class.java)
 class KotlinGradleSensor(
     checkFactory: CheckFactory,
     language: KotlinLanguage,
+    private val telemetryData: TelemetryData,
 ) : AbstractKotlinSensor(
     checkFactory, emptyList(), language, KOTLIN_GRADLE_CHECKS
 ) {
@@ -60,6 +62,15 @@ class KotlinGradleSensor(
         sensorContext, filesToAnalyze, progressReport, listOf(KtChecksVisitor(checks)), filenames, LOG
     ) {
         override val classpath: List<String> = listOf()
+
+        override fun onFileRead() {
+            telemetryData.filesAnalyzedCounter++
+            telemetryData.scriptsAnalyzedCounter++
+        }
+
+        override fun onParseFailure() {
+            telemetryData.scriptParseFailuresCounter++
+        }
     }
 
     override fun getFilesToAnalyse(sensorContext: SensorContext): Iterable<InputFile> {

--- a/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/KotlinGradleSensor.kt
+++ b/sonar-kotlin-gradle/src/main/java/org/sonarsource/kotlin/gradle/KotlinGradleSensor.kt
@@ -64,12 +64,12 @@ class KotlinGradleSensor(
         override val classpath: List<String> = listOf()
 
         override fun onFileRead() {
-            telemetryData.filesAnalyzedCounter++
-            telemetryData.scriptsAnalyzedCounter++
+            telemetryData.filesProcessed++
+            telemetryData.scriptsProcessed++
         }
 
         override fun onParseFailure() {
-            telemetryData.scriptParseFailuresCounter++
+            telemetryData.scriptParseFailures++
         }
     }
 

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/KotlinGradleSensorTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/KotlinGradleSensorTest.kt
@@ -295,8 +295,8 @@ internal class KotlinGraldeSensorTest : AbstractSensorTest() {
         addBuildFile()
         addSettingsKtsFile()
         sensor(checkFactory(), telemetryData).execute(context)
-        assertThat(telemetryData.filesAnalyzedCounter).isEqualTo(2)
-        assertThat(telemetryData.scriptsAnalyzedCounter).isEqualTo(2)
+        assertThat(telemetryData.filesProcessed).isEqualTo(2)
+        assertThat(telemetryData.scriptsProcessed).isEqualTo(2)
     }
 
     @Test
@@ -305,9 +305,9 @@ internal class KotlinGraldeSensorTest : AbstractSensorTest() {
         val invalidContent = "enum class A { <!REDECLARATION!>FOO<!>,<!REDECLARATION!>FOO<!> }"
         context.fileSystem().add(createInputFile("build.gradle.kts", invalidContent))
         sensor(checkFactory(), telemetryData).execute(context)
-        assertThat(telemetryData.filesAnalyzedCounter).isEqualTo(1)
-        assertThat(telemetryData.scriptsAnalyzedCounter).isEqualTo(1)
-        assertThat(telemetryData.scriptParseFailuresCounter).isEqualTo(1)
+        assertThat(telemetryData.filesProcessed).isEqualTo(1)
+        assertThat(telemetryData.scriptsProcessed).isEqualTo(1)
+        assertThat(telemetryData.scriptParseFailures).isEqualTo(1)
     }
 
     private fun sensor(checkFactory: CheckFactory, telemetryData: TelemetryData = TelemetryData()): KotlinGradleSensor {

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/KotlinGradleSensorTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/KotlinGradleSensorTest.kt
@@ -31,6 +31,7 @@ import org.sonarsource.kotlin.api.checks.AbstractCheck
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
 import org.sonarsource.kotlin.gradle.checks.MissingSettingsCheck
 import org.sonarsource.kotlin.gradle.checks.MissingVerificationMetadataCheck
+import org.sonarsource.kotlin.metrics.TelemetryData
 import org.sonarsource.kotlin.testapi.AbstractSensorTest
 import kotlin.io.path.createFile
 
@@ -288,8 +289,29 @@ internal class KotlinGraldeSensorTest : AbstractSensorTest() {
         context.fileSystem().add(verificationMetadataFile)
     }
 
-    private fun sensor(checkFactory: CheckFactory): KotlinGradleSensor {
-        return KotlinGradleSensor(checkFactory, language())
+    @Test
+    fun test_file_read_increments_telemetry_counters() {
+        val telemetryData = TelemetryData()
+        addBuildFile()
+        addSettingsKtsFile()
+        sensor(checkFactory(), telemetryData).execute(context)
+        assertThat(telemetryData.filesAnalyzedCounter).isEqualTo(2)
+        assertThat(telemetryData.scriptsAnalyzedCounter).isEqualTo(2)
+    }
+
+    @Test
+    fun test_script_parse_failure_increments_telemetry_counter() {
+        val telemetryData = TelemetryData()
+        val invalidContent = "enum class A { <!REDECLARATION!>FOO<!>,<!REDECLARATION!>FOO<!> }"
+        context.fileSystem().add(createInputFile("build.gradle.kts", invalidContent))
+        sensor(checkFactory(), telemetryData).execute(context)
+        assertThat(telemetryData.filesAnalyzedCounter).isEqualTo(1)
+        assertThat(telemetryData.scriptsAnalyzedCounter).isEqualTo(1)
+        assertThat(telemetryData.scriptParseFailuresCounter).isEqualTo(1)
+    }
+
+    private fun sensor(checkFactory: CheckFactory, telemetryData: TelemetryData = TelemetryData()): KotlinGradleSensor {
+        return KotlinGradleSensor(checkFactory, language(), telemetryData)
     }
 }
 

--- a/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/KotlinGradleSensorTest.kt
+++ b/sonar-kotlin-gradle/src/test/java/org/sonarsource/kotlin/gradle/KotlinGradleSensorTest.kt
@@ -18,7 +18,9 @@ package org.sonarsource.kotlin.gradle
 
 import io.mockk.every
 import io.mockk.mockkStatic
+import io.mockk.spyk
 import io.mockk.unmockkAll
+import java.io.IOException
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.junit.jupiter.api.AfterEach
@@ -308,6 +310,31 @@ internal class KotlinGraldeSensorTest : AbstractSensorTest() {
         assertThat(telemetryData.filesProcessed).isEqualTo(1)
         assertThat(telemetryData.scriptsProcessed).isEqualTo(1)
         assertThat(telemetryData.scriptParseFailures).isEqualTo(1)
+    }
+
+    @Test
+    fun test_script_read_failure_increments_telemetry_counter() {
+        val telemetryData = TelemetryData()
+        val buildFile = spyk(createInputFile("build.gradle.kts", "class A"))
+        every { buildFile.contents() } throws IOException("Can't read")
+        context.fileSystem().add(buildFile)
+        sensor(checkFactory(), telemetryData).execute(context)
+        assertThat(telemetryData.filesProcessed).isEqualTo(1)
+        assertThat(telemetryData.scriptsProcessed).isEqualTo(1)
+        assertThat(telemetryData.readFailures).isEqualTo(1)
+        assertThat(telemetryData.scriptReadFailures).isEqualTo(1)
+    }
+
+    @Test
+    fun test_file_read_increments_telemetry_counters_including_read_failures() {
+        val telemetryData = TelemetryData()
+        val buildFile = spyk(createInputFile("build.gradle.kts", "class A"))
+        every { buildFile.contents() } throws IOException("Can't read")
+        context.fileSystem().add(buildFile)
+        addSettingsKtsFile()
+        sensor(checkFactory(), telemetryData).execute(context)
+        assertThat(telemetryData.filesProcessed).isEqualTo(2)
+        assertThat(telemetryData.scriptsProcessed).isEqualTo(2)
     }
 
     private fun sensor(checkFactory: CheckFactory, telemetryData: TelemetryData = TelemetryData()): KotlinGradleSensor {

--- a/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/TelemetryData.kt
+++ b/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/TelemetryData.kt
@@ -25,4 +25,5 @@ class TelemetryData {
     var hasAndroidImports = false
     var surefireClassesImported = 0
     var surefireClassesFailed = 0
+    var parseFailuresCounter = 0
 }

--- a/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/TelemetryData.kt
+++ b/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/TelemetryData.kt
@@ -27,8 +27,10 @@ class TelemetryData {
     var surefireClassesFailed = 0
     // .kt + .kts counters
     var filesProcessed = 0
+    var readFailures = 0
     var parseFailures = 0
     // .kts only counters
     var scriptsProcessed = 0
+    var scriptReadFailures = 0
     var scriptParseFailures = 0
 }

--- a/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/TelemetryData.kt
+++ b/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/TelemetryData.kt
@@ -25,5 +25,8 @@ class TelemetryData {
     var hasAndroidImports = false
     var surefireClassesImported = 0
     var surefireClassesFailed = 0
+    var filesAnalyzedCounter = 0
     var parseFailuresCounter = 0
+    var scriptsAnalyzedCounter = 0
+    var scriptParseFailuresCounter = 0
 }

--- a/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/TelemetryData.kt
+++ b/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/TelemetryData.kt
@@ -25,8 +25,10 @@ class TelemetryData {
     var hasAndroidImports = false
     var surefireClassesImported = 0
     var surefireClassesFailed = 0
+    // .kt + .kts counters
     var filesAnalyzedCounter = 0
     var parseFailuresCounter = 0
+    // .kts only counters
     var scriptsAnalyzedCounter = 0
     var scriptParseFailuresCounter = 0
 }

--- a/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/TelemetryData.kt
+++ b/sonar-kotlin-metrics/src/main/java/org/sonarsource/kotlin/metrics/TelemetryData.kt
@@ -26,9 +26,9 @@ class TelemetryData {
     var surefireClassesImported = 0
     var surefireClassesFailed = 0
     // .kt + .kts counters
-    var filesAnalyzedCounter = 0
-    var parseFailuresCounter = 0
+    var filesProcessed = 0
+    var parseFailures = 0
     // .kts only counters
-    var scriptsAnalyzedCounter = 0
-    var scriptParseFailuresCounter = 0
+    var scriptsProcessed = 0
+    var scriptParseFailures = 0
 }

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
@@ -36,8 +36,10 @@ class KotlinProjectSensor(internal val telemetryData: TelemetryData) : ProjectSe
             context.addTelemetryProperty("kotlin.android", if (telemetryData.hasAndroidImports) "1" else "0")
             context.addTelemetryProperty("kotlin.reports.surefire.classes.imported", telemetryData.surefireClassesImported.toString())
             context.addTelemetryProperty("kotlin.reports.surefire.classes.failed", telemetryData.surefireClassesFailed.toString())
+            // files - .kt and .kts counters
             context.addTelemetryProperty("kotlin.files.analyzed", telemetryData.filesAnalyzedCounter.toString())
             context.addTelemetryProperty("kotlin.files.parse.failures", telemetryData.parseFailuresCounter.toString())
+            // scripts - .kts only
             context.addTelemetryProperty("kotlin.scripts.analyzed", telemetryData.scriptsAnalyzedCounter.toString())
             context.addTelemetryProperty("kotlin.scripts.parse.failures", telemetryData.scriptParseFailuresCounter.toString())
         }

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
@@ -36,7 +36,10 @@ class KotlinProjectSensor(internal val telemetryData: TelemetryData) : ProjectSe
             context.addTelemetryProperty("kotlin.android", if (telemetryData.hasAndroidImports) "1" else "0")
             context.addTelemetryProperty("kotlin.reports.surefire.classes.imported", telemetryData.surefireClassesImported.toString())
             context.addTelemetryProperty("kotlin.reports.surefire.classes.failed", telemetryData.surefireClassesFailed.toString())
+            context.addTelemetryProperty("kotlin.analyzed.files", telemetryData.filesAnalyzedCounter.toString())
             context.addTelemetryProperty("kotlin.parse.failures", telemetryData.parseFailuresCounter.toString())
+            context.addTelemetryProperty("kotlin.analyzed.scripts", telemetryData.scriptsAnalyzedCounter.toString())
+            context.addTelemetryProperty("kotlin.script.parse.failures", telemetryData.scriptParseFailuresCounter.toString())
         }
     }
 }

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
@@ -36,7 +36,7 @@ class KotlinProjectSensor(internal val telemetryData: TelemetryData) : ProjectSe
             context.addTelemetryProperty("kotlin.android", if (telemetryData.hasAndroidImports) "1" else "0")
             context.addTelemetryProperty("kotlin.reports.surefire.classes.imported", telemetryData.surefireClassesImported.toString())
             context.addTelemetryProperty("kotlin.reports.surefire.classes.failed", telemetryData.surefireClassesFailed.toString())
-            context.addTelemetryProperty("kotlin.parse_failures_counter", telemetryData.parseFailuresCounter.toString())
+            context.addTelemetryProperty("kotlin.parse.failures", telemetryData.parseFailuresCounter.toString())
         }
     }
 }

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
@@ -38,9 +38,11 @@ class KotlinProjectSensor(internal val telemetryData: TelemetryData) : ProjectSe
             context.addTelemetryProperty("kotlin.reports.surefire.classes.failed", telemetryData.surefireClassesFailed.toString())
             // files - .kt and .kts counters
             context.addTelemetryProperty("kotlin.files.processed", telemetryData.filesProcessed.toString())
+            context.addTelemetryProperty("kotlin.files.read.failures", telemetryData.readFailures.toString())
             context.addTelemetryProperty("kotlin.files.parse.failures", telemetryData.parseFailures.toString())
             // scripts - .kts only
             context.addTelemetryProperty("kotlin.scripts.processed", telemetryData.scriptsProcessed.toString())
+            context.addTelemetryProperty("kotlin.scripts.read.failures", telemetryData.scriptReadFailures.toString())
             context.addTelemetryProperty("kotlin.scripts.parse.failures", telemetryData.scriptParseFailures.toString())
         }
     }

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
@@ -37,11 +37,11 @@ class KotlinProjectSensor(internal val telemetryData: TelemetryData) : ProjectSe
             context.addTelemetryProperty("kotlin.reports.surefire.classes.imported", telemetryData.surefireClassesImported.toString())
             context.addTelemetryProperty("kotlin.reports.surefire.classes.failed", telemetryData.surefireClassesFailed.toString())
             // files - .kt and .kts counters
-            context.addTelemetryProperty("kotlin.files.analyzed", telemetryData.filesAnalyzedCounter.toString())
-            context.addTelemetryProperty("kotlin.files.parse.failures", telemetryData.parseFailuresCounter.toString())
+            context.addTelemetryProperty("kotlin.files.processed", telemetryData.filesProcessed.toString())
+            context.addTelemetryProperty("kotlin.files.parse.failures", telemetryData.parseFailures.toString())
             // scripts - .kts only
-            context.addTelemetryProperty("kotlin.scripts.analyzed", telemetryData.scriptsAnalyzedCounter.toString())
-            context.addTelemetryProperty("kotlin.scripts.parse.failures", telemetryData.scriptParseFailuresCounter.toString())
+            context.addTelemetryProperty("kotlin.scripts.processed", telemetryData.scriptsProcessed.toString())
+            context.addTelemetryProperty("kotlin.scripts.parse.failures", telemetryData.scriptParseFailures.toString())
         }
     }
 }

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
@@ -36,10 +36,10 @@ class KotlinProjectSensor(internal val telemetryData: TelemetryData) : ProjectSe
             context.addTelemetryProperty("kotlin.android", if (telemetryData.hasAndroidImports) "1" else "0")
             context.addTelemetryProperty("kotlin.reports.surefire.classes.imported", telemetryData.surefireClassesImported.toString())
             context.addTelemetryProperty("kotlin.reports.surefire.classes.failed", telemetryData.surefireClassesFailed.toString())
-            context.addTelemetryProperty("kotlin.analyzed.files", telemetryData.filesAnalyzedCounter.toString())
-            context.addTelemetryProperty("kotlin.parse.failures", telemetryData.parseFailuresCounter.toString())
-            context.addTelemetryProperty("kotlin.analyzed.scripts", telemetryData.scriptsAnalyzedCounter.toString())
-            context.addTelemetryProperty("kotlin.script.parse.failures", telemetryData.scriptParseFailuresCounter.toString())
+            context.addTelemetryProperty("kotlin.files.analyzed", telemetryData.filesAnalyzedCounter.toString())
+            context.addTelemetryProperty("kotlin.files.parse.failures", telemetryData.parseFailuresCounter.toString())
+            context.addTelemetryProperty("kotlin.scripts.analyzed", telemetryData.scriptsAnalyzedCounter.toString())
+            context.addTelemetryProperty("kotlin.scripts.parse.failures", telemetryData.scriptParseFailuresCounter.toString())
         }
     }
 }

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
@@ -36,6 +36,7 @@ class KotlinProjectSensor(internal val telemetryData: TelemetryData) : ProjectSe
             context.addTelemetryProperty("kotlin.android", if (telemetryData.hasAndroidImports) "1" else "0")
             context.addTelemetryProperty("kotlin.reports.surefire.classes.imported", telemetryData.surefireClassesImported.toString())
             context.addTelemetryProperty("kotlin.reports.surefire.classes.failed", telemetryData.surefireClassesFailed.toString())
+            context.addTelemetryProperty("kotlin.parse_failures_counter", telemetryData.parseFailuresCounter.toString())
         }
     }
 }

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinSensor.kt
@@ -82,6 +82,10 @@ class KotlinSensor(
             sensorContext.config().getStringArray(SONAR_JAVA_BINARIES).toList() +
                     sensorContext.config().getStringArray(SONAR_JAVA_LIBRARIES).toList()
 
+        override fun onFileRead() {
+            telemetryData.filesAnalyzedCounter++
+        }
+
         override fun onParseFailure() {
             telemetryData.parseFailuresCounter++
         }

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinSensor.kt
@@ -83,11 +83,11 @@ class KotlinSensor(
                     sensorContext.config().getStringArray(SONAR_JAVA_LIBRARIES).toList()
 
         override fun onFileRead() {
-            telemetryData.filesAnalyzedCounter++
+            telemetryData.filesProcessed++
         }
 
         override fun onParseFailure() {
-            telemetryData.parseFailuresCounter++
+            telemetryData.parseFailures++
         }
     }
 

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinSensor.kt
@@ -89,6 +89,10 @@ class KotlinSensor(
         override fun onParseFailure() {
             telemetryData.parseFailures++
         }
+
+        override fun onReadFailure() {
+            telemetryData.readFailures++
+        }
     }
 
     private fun visitors(sensorContext: SensorContext): List<KotlinFileVisitor> =

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinSensor.kt
@@ -81,6 +81,10 @@ class KotlinSensor(
         override val classpath: List<String> =
             sensorContext.config().getStringArray(SONAR_JAVA_BINARIES).toList() +
                     sensorContext.config().getStringArray(SONAR_JAVA_LIBRARIES).toList()
+
+        override fun onParseFailure() {
+            telemetryData.parseFailuresCounter++
+        }
     }
 
     private fun visitors(sensorContext: SensorContext): List<KotlinFileVisitor> =

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
@@ -44,9 +44,9 @@ class KotlinProjectSensorTest {
                     "kotlin.android" to "0",
                     "kotlin.reports.surefire.classes.failed" to "0",
                     "kotlin.reports.surefire.classes.imported" to "0",
-                    "kotlin.files.analyzed" to "0",
+                    "kotlin.files.processed" to "0",
                     "kotlin.files.parse.failures" to "0",
-                    "kotlin.scripts.analyzed" to "0",
+                    "kotlin.scripts.processed" to "0",
                     "kotlin.scripts.parse.failures" to "0",
                 )
             )
@@ -57,9 +57,9 @@ class KotlinProjectSensorTest {
             "kotlin.android" to "1",
             "kotlin.reports.surefire.classes.failed" to "0",
             "kotlin.reports.surefire.classes.imported" to "0",
-            "kotlin.files.analyzed" to "0",
+            "kotlin.files.processed" to "0",
             "kotlin.files.parse.failures" to "0",
-            "kotlin.scripts.analyzed" to "0",
+            "kotlin.scripts.processed" to "0",
             "kotlin.scripts.parse.failures" to "0",
         ))
     }

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
@@ -44,7 +44,7 @@ class KotlinProjectSensorTest {
                     "kotlin.android" to "0",
                     "kotlin.reports.surefire.classes.failed" to "0",
                     "kotlin.reports.surefire.classes.imported" to "0",
-                    "kotlin.parse_failures_counter" to "0",
+                    "kotlin.parse.failures" to "0",
                 )
             )
 
@@ -54,7 +54,7 @@ class KotlinProjectSensorTest {
             "kotlin.android" to "1",
             "kotlin.reports.surefire.classes.failed" to "0",
             "kotlin.reports.surefire.classes.imported" to "0",
-            "kotlin.parse_failures_counter" to "0",
+            "kotlin.parse.failures" to "0",
         ))
     }
 

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
@@ -44,10 +44,10 @@ class KotlinProjectSensorTest {
                     "kotlin.android" to "0",
                     "kotlin.reports.surefire.classes.failed" to "0",
                     "kotlin.reports.surefire.classes.imported" to "0",
-                    "kotlin.analyzed.files" to "0",
-                    "kotlin.parse.failures" to "0",
-                    "kotlin.analyzed.scripts" to "0",
-                    "kotlin.script.parse.failures" to "0",
+                    "kotlin.files.analyzed" to "0",
+                    "kotlin.files.parse.failures" to "0",
+                    "kotlin.scripts.analyzed" to "0",
+                    "kotlin.scripts.parse.failures" to "0",
                 )
             )
 
@@ -57,10 +57,10 @@ class KotlinProjectSensorTest {
             "kotlin.android" to "1",
             "kotlin.reports.surefire.classes.failed" to "0",
             "kotlin.reports.surefire.classes.imported" to "0",
-            "kotlin.analyzed.files" to "0",
-            "kotlin.parse.failures" to "0",
-            "kotlin.analyzed.scripts" to "0",
-            "kotlin.script.parse.failures" to "0",
+            "kotlin.files.analyzed" to "0",
+            "kotlin.files.parse.failures" to "0",
+            "kotlin.scripts.analyzed" to "0",
+            "kotlin.scripts.parse.failures" to "0",
         ))
     }
 

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
@@ -45,8 +45,10 @@ class KotlinProjectSensorTest {
                     "kotlin.reports.surefire.classes.failed" to "0",
                     "kotlin.reports.surefire.classes.imported" to "0",
                     "kotlin.files.processed" to "0",
+                    "kotlin.files.read.failures" to "0",
                     "kotlin.files.parse.failures" to "0",
                     "kotlin.scripts.processed" to "0",
+                    "kotlin.scripts.read.failures" to "0",
                     "kotlin.scripts.parse.failures" to "0",
                 )
             )
@@ -58,8 +60,10 @@ class KotlinProjectSensorTest {
             "kotlin.reports.surefire.classes.failed" to "0",
             "kotlin.reports.surefire.classes.imported" to "0",
             "kotlin.files.processed" to "0",
+            "kotlin.files.read.failures" to "0",
             "kotlin.files.parse.failures" to "0",
             "kotlin.scripts.processed" to "0",
+            "kotlin.scripts.read.failures" to "0",
             "kotlin.scripts.parse.failures" to "0",
         ))
     }

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
@@ -44,6 +44,7 @@ class KotlinProjectSensorTest {
                     "kotlin.android" to "0",
                     "kotlin.reports.surefire.classes.failed" to "0",
                     "kotlin.reports.surefire.classes.imported" to "0",
+                    "kotlin.parse_failures_counter" to "0",
                 )
             )
 
@@ -53,6 +54,7 @@ class KotlinProjectSensorTest {
             "kotlin.android" to "1",
             "kotlin.reports.surefire.classes.failed" to "0",
             "kotlin.reports.surefire.classes.imported" to "0",
+            "kotlin.parse_failures_counter" to "0",
         ))
     }
 

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
@@ -44,7 +44,10 @@ class KotlinProjectSensorTest {
                     "kotlin.android" to "0",
                     "kotlin.reports.surefire.classes.failed" to "0",
                     "kotlin.reports.surefire.classes.imported" to "0",
+                    "kotlin.analyzed.files" to "0",
                     "kotlin.parse.failures" to "0",
+                    "kotlin.analyzed.scripts" to "0",
+                    "kotlin.script.parse.failures" to "0",
                 )
             )
 
@@ -54,7 +57,10 @@ class KotlinProjectSensorTest {
             "kotlin.android" to "1",
             "kotlin.reports.surefire.classes.failed" to "0",
             "kotlin.reports.surefire.classes.imported" to "0",
+            "kotlin.analyzed.files" to "0",
             "kotlin.parse.failures" to "0",
+            "kotlin.analyzed.scripts" to "0",
+            "kotlin.script.parse.failures" to "0",
         ))
     }
 

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
@@ -260,7 +260,7 @@ internal class KotlinSensorTest : AbstractSensorTest() {
     }
 
     @Test
-    fun `parse failure increments parse failures counter in telemetry`() {
+    fun test_parsing_failure_increments_telemetry_counter() {
         val telemetryData = TelemetryData()
         val inputFile = createInputFile("file1.kt", "enum class A { <!REDECLARATION!>FOO<!>,<!REDECLARATION!>FOO<!> }")
         context.fileSystem().add(inputFile)

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
@@ -288,6 +288,27 @@ internal class KotlinSensorTest : AbstractSensorTest() {
     }
 
     @Test
+    fun test_read_failure_increments_telemetry_counter() {
+        val telemetryData = TelemetryData()
+        val inputFile = spyk(createInputFile("file1.kt", "class A"))
+        every { inputFile.contents() } throws IOException("Can't read")
+        context.fileSystem().add(inputFile)
+        KotlinSensor(checkFactory(), fileLinesContextFactory, DefaultNoSonarFilter(), language(), telemetryData, emptyArray()).execute(context)
+        assertThat(telemetryData.readFailures).isEqualTo(1)
+    }
+
+    @Test
+    fun test_file_read_increments_telemetry_counter_including_read_failures() {
+        val telemetryData = TelemetryData()
+        val inputFile = spyk(createInputFile("file1.kt", "class A"))
+        every { inputFile.contents() } throws IOException("Can't read")
+        context.fileSystem().add(inputFile)
+        context.fileSystem().add(createInputFile("file2.kt", "class B"))
+        KotlinSensor(checkFactory(), fileLinesContextFactory, DefaultNoSonarFilter(), language(), telemetryData, emptyArray()).execute(context)
+        assertThat(telemetryData.filesProcessed).isEqualTo(2)
+    }
+
+    @Test
     fun test_parsing_failure_increments_telemetry_counter_for_multiple_files() {
         val invalidContent = "enum class A { <!REDECLARATION!>FOO<!>,<!REDECLARATION!>FOO<!> }"
         val telemetryData = TelemetryData()

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
@@ -260,6 +260,24 @@ internal class KotlinSensorTest : AbstractSensorTest() {
     }
 
     @Test
+    fun test_file_read_increments_telemetry_counter() {
+        val telemetryData = TelemetryData()
+        context.fileSystem().add(createInputFile("file1.kt", "class A"))
+        context.fileSystem().add(createInputFile("file2.kt", "class B"))
+        KotlinSensor(checkFactory(), fileLinesContextFactory, DefaultNoSonarFilter(), language(), telemetryData, emptyArray()).execute(context)
+        assertThat(telemetryData.filesAnalyzedCounter).isEqualTo(2)
+    }
+
+    @Test
+    fun test_file_read_increments_telemetry_counter_including_parse_failures() {
+        val telemetryData = TelemetryData()
+        context.fileSystem().add(createInputFile("file1.kt", "class A"))
+        context.fileSystem().add(createInputFile("file2.kt", "enum class A { <!REDECLARATION!>FOO<!>,<!REDECLARATION!>FOO<!> }"))
+        KotlinSensor(checkFactory(), fileLinesContextFactory, DefaultNoSonarFilter(), language(), telemetryData, emptyArray()).execute(context)
+        assertThat(telemetryData.filesAnalyzedCounter).isEqualTo(2)
+    }
+
+    @Test
     fun test_parsing_failure_increments_telemetry_counter() {
         val telemetryData = TelemetryData()
         val inputFile = createInputFile("file1.kt", "enum class A { <!REDECLARATION!>FOO<!>,<!REDECLARATION!>FOO<!> }")

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
@@ -265,7 +265,7 @@ internal class KotlinSensorTest : AbstractSensorTest() {
         context.fileSystem().add(createInputFile("file1.kt", "class A"))
         context.fileSystem().add(createInputFile("file2.kt", "class B"))
         KotlinSensor(checkFactory(), fileLinesContextFactory, DefaultNoSonarFilter(), language(), telemetryData, emptyArray()).execute(context)
-        assertThat(telemetryData.filesAnalyzedCounter).isEqualTo(2)
+        assertThat(telemetryData.filesProcessed).isEqualTo(2)
     }
 
     @Test
@@ -274,7 +274,7 @@ internal class KotlinSensorTest : AbstractSensorTest() {
         context.fileSystem().add(createInputFile("file1.kt", "class A"))
         context.fileSystem().add(createInputFile("file2.kt", "enum class A { <!REDECLARATION!>FOO<!>,<!REDECLARATION!>FOO<!> }"))
         KotlinSensor(checkFactory(), fileLinesContextFactory, DefaultNoSonarFilter(), language(), telemetryData, emptyArray()).execute(context)
-        assertThat(telemetryData.filesAnalyzedCounter).isEqualTo(2)
+        assertThat(telemetryData.filesProcessed).isEqualTo(2)
     }
 
     @Test
@@ -284,7 +284,7 @@ internal class KotlinSensorTest : AbstractSensorTest() {
         context.fileSystem().add(inputFile)
         val checkFactory = checkFactory("S1764")
         KotlinSensor(checkFactory, fileLinesContextFactory, DefaultNoSonarFilter(), language(), telemetryData, emptyArray()).execute(context)
-        assertThat(telemetryData.parseFailuresCounter).isEqualTo(1)
+        assertThat(telemetryData.parseFailures).isEqualTo(1)
     }
 
     @Test
@@ -295,7 +295,7 @@ internal class KotlinSensorTest : AbstractSensorTest() {
         context.fileSystem().add(createInputFile("file2.kt", invalidContent))
         val checkFactory = checkFactory("S1764")
         KotlinSensor(checkFactory, fileLinesContextFactory, DefaultNoSonarFilter(), language(), telemetryData, emptyArray()).execute(context)
-        assertThat(telemetryData.parseFailuresCounter).isEqualTo(2)
+        assertThat(telemetryData.parseFailures).isEqualTo(2)
     }
 
     @Test

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
@@ -260,6 +260,16 @@ internal class KotlinSensorTest : AbstractSensorTest() {
     }
 
     @Test
+    fun `parse failure increments parse failures counter in telemetry`() {
+        val telemetryData = TelemetryData()
+        val inputFile = createInputFile("file1.kt", "enum class A { <!REDECLARATION!>FOO<!>,<!REDECLARATION!>FOO<!> }")
+        context.fileSystem().add(inputFile)
+        val checkFactory = checkFactory("S1764")
+        KotlinSensor(checkFactory, fileLinesContextFactory, DefaultNoSonarFilter(), language(), telemetryData, emptyArray()).execute(context)
+        assertThat(telemetryData.parseFailuresCounter).isEqualTo(1)
+    }
+
+    @Test
     fun test_with_classpath() {
         val settings = MapSettings()
         settings.setProperty(SONAR_JAVA_BINARIES, System.getProperty("java.class.path").split(File.pathSeparatorChar).joinToString(","))

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinSensorTest.kt
@@ -270,6 +270,17 @@ internal class KotlinSensorTest : AbstractSensorTest() {
     }
 
     @Test
+    fun test_parsing_failure_increments_telemetry_counter_for_multiple_files() {
+        val invalidContent = "enum class A { <!REDECLARATION!>FOO<!>,<!REDECLARATION!>FOO<!> }"
+        val telemetryData = TelemetryData()
+        context.fileSystem().add(createInputFile("file1.kt", invalidContent))
+        context.fileSystem().add(createInputFile("file2.kt", invalidContent))
+        val checkFactory = checkFactory("S1764")
+        KotlinSensor(checkFactory, fileLinesContextFactory, DefaultNoSonarFilter(), language(), telemetryData, emptyArray()).execute(context)
+        assertThat(telemetryData.parseFailuresCounter).isEqualTo(2)
+    }
+
+    @Test
     fun test_with_classpath() {
         val settings = MapSettings()
         settings.setProperty(SONAR_JAVA_BINARIES, System.getProperty("java.class.path").split(File.pathSeparatorChar).joinToString(","))


### PR DESCRIPTION
This is the ticket description copy from Jira.
# WHY
We want visibility into how many parsing errors the Kotlin analyzer encounters during analysis.
Tracking files that fail during parsing should help us understand parser robustness and prioritize follow-up improvements.
This follows the same goal and pattern as `SONARIAC-2889: Add telemetry for IaC parse failures per language` adapted to SonarKotlin.

# WHAT
Add telemetry for Kotlin parse failures.

### Definition of Done:
- Files that fail during parsing are counted per analyzed project.
- Telemetry is emitted through the Kotlin analyzer telemetry flow.
- The implementation follows the same overall pattern as `SONARIAC-2889: Add telemetry for IaC parse failures per language` where relevant.
- Tests cover the aggregation/reporting path and at least representative parsing-failure cases.
- Existing telemetry behavior remains unchanged.

# HOW
Suggested implementation direction:
- Reuse existing SonarKotlin telemetry infrastructure instead of emitting telemetry ad hoc from multiple places.
- Track files that fail during parsing and aggregate a final count at project level.
- Use `SONARIAC-2889: Add telemetry for IaC parse failures per language` as the reference for scope and intent, adapted to Kotlin-specific architecture.