### PR TITLE
SONARKT-771 Should not log InvalidFirElementTypeException as error

### DIFF
--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/K2.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/frontend/K2.kt
@@ -38,6 +38,7 @@ import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
+import org.slf4j.LoggerFactory
 
 /**
  * @see [org.jetbrains.kotlin.analysis.api.standalone.StandaloneAnalysisAPISessionBuilder.buildKtModuleProviderByCompilerConfiguration]
@@ -88,8 +89,12 @@ private class SonarLogger(category: String) : DefaultLogger(category) {
      * Unlike overridden does not throw [AssertionError].
      */
     override fun error(message: String?, t: Throwable?, vararg details: String?) {
-        System.err.println("ERROR: " + message + detailsToString(*details) + attachmentsToString(t))
-        t?.printStackTrace(System.err)
+        LOG.debug("ERROR: " + message + detailsToString(*details) + attachmentsToString(t), t)
+    }
+
+    companion object {
+        @JvmStatic
+        internal val LOG = LoggerFactory.getLogger(SonarLogger::class.java)
     }
 }
 

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/visiting/KotlinFileVisitor.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/visiting/KotlinFileVisitor.kt
@@ -23,12 +23,8 @@ import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.KaCompilationResult
 import org.jetbrains.kotlin.analysis.api.components.KaCompilerTarget
 import org.jetbrains.kotlin.analysis.api.diagnostics.KaDiagnostic
-import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtTypeReference
-import org.slf4j.LoggerFactory
 import org.sonarsource.kotlin.api.checks.InputFileContext
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
 import org.sonarsource.kotlin.api.frontend.KotlinTree
@@ -47,27 +43,6 @@ internal class SonarKaSession(
     private val originalKaSession: KaSession
 ) : KaSession by originalKaSession {
     /**
-     * Unlike original [org.jetbrains.kotlin.analysis.api.components.KaTypeProvider.type], instead of
-     * [raising exception](https://github.com/JetBrains/kotlin/blob/v2.4.0/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/components/KaTypeProvider.kt#L222-L227)
-     * such as
-     *
-     * > org.jetbrains.kotlin.analysis.low.level.api.fir.api.InvalidFirElementTypeException: unexpected element of type: no element found
-     *
-     * returns [org.jetbrains.kotlin.analysis.api.types.KaErrorType] in case of absence of some types.
-     */
-    override val KtTypeReference.type: KaType
-        get() {
-            return try {
-                with(originalKaSession) {
-                    this@type.type
-                }
-            } catch (e: Exception) {
-                LOG.debug("Unexpected result during type resolution", e)
-                buildClassType(ClassId.fromString("<error>"))
-            }
-        }
-
-    /**
      * Always throws [UnsupportedOperationException] to get rid of dependency on codegen.
      */
     @OptIn(KaExperimentalApi::class)
@@ -78,11 +53,6 @@ internal class SonarKaSession(
         allowedErrorFilter: (KaDiagnostic) -> Boolean,
     ): KaCompilationResult =
         throw UnsupportedOperationException()
-
-    companion object {
-        @JvmStatic
-        private val LOG = LoggerFactory.getLogger(SonarKaSession::class.java)
-    }
 }
 
 /**

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/visiting/KotlinFileVisitor.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/visiting/KotlinFileVisitor.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtTypeReference
+import org.slf4j.LoggerFactory
 import org.sonarsource.kotlin.api.checks.InputFileContext
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
 import org.sonarsource.kotlin.api.frontend.KotlinTree
@@ -46,6 +47,27 @@ internal class SonarKaSession(
     private val originalKaSession: KaSession
 ) : KaSession by originalKaSession {
     /**
+     * Unlike original [org.jetbrains.kotlin.analysis.api.components.KaTypeProvider.type], instead of
+     * [raising exception](https://github.com/JetBrains/kotlin/blob/v2.4.0/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/components/KaTypeProvider.kt#L222-L227)
+     * such as
+     *
+     * > org.jetbrains.kotlin.analysis.low.level.api.fir.api.InvalidFirElementTypeException: unexpected element of type: no element found
+     *
+     * returns [org.jetbrains.kotlin.analysis.api.types.KaErrorType] in case of absence of some types.
+     */
+    override val KtTypeReference.type: KaType
+        get() {
+            return try {
+                with(originalKaSession) {
+                    this@type.type
+                }
+            } catch (e: Exception) {
+                LOG.debug("Unexpected result during type resolution", e)
+                buildClassType(ClassId.fromString("<error>"))
+            }
+        }
+
+    /**
      * Always throws [UnsupportedOperationException] to get rid of dependency on codegen.
      */
     @OptIn(KaExperimentalApi::class)
@@ -56,6 +78,11 @@ internal class SonarKaSession(
         allowedErrorFilter: (KaDiagnostic) -> Boolean,
     ): KaCompilationResult =
         throw UnsupportedOperationException()
+
+    companion object {
+        @JvmStatic
+        private val LOG = LoggerFactory.getLogger(SonarKaSession::class.java)
+    }
 }
 
 /**

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/visiting/SonarKaSessionTest.kt
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/visiting/SonarKaSessionTest.kt
@@ -32,6 +32,15 @@ import org.sonarsource.kotlin.api.frontend.KotlinVirtualFile
 import org.sonarsource.kotlin.api.frontend.compilerConfiguration
 import org.sonarsource.kotlin.api.frontend.createK2AnalysisSession
 import java.io.File
+import org.jetbrains.kotlin.analysis.api.KaSession
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.types.KaErrorType
+import org.jetbrains.kotlin.analysis.api.types.KaType
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstance
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.assertDoesNotThrow
 
 private class SonarKaSessionTest {
 
@@ -53,6 +62,44 @@ private class SonarKaSessionTest {
                 assertThrows<UnsupportedOperationException> {
                     this.compile(ktFile, c, t) { _ -> false }
                 }
+            }
+        }
+    }
+
+    @Test
+    fun `should return KaErrorType instead of raising exception when obtaining type for KtTypeReference`() {
+        val ktFile = ktFile(
+            """
+//class ObservableList<K> {
+//    fun addListener(listener: Listener<K>) {
+//    }
+//
+//    fun interface Listener<K> {
+//        fun callback(change: Change<out K>)
+//
+//        interface Change<K>
+//    }
+//}
+
+fun <K> example(list: ObservableList<K>) {
+    list.addListener { _: ObservableList.Listener.Change<out K> ->
+    }
+}
+        """.trimIndent()
+        )
+
+        val action: KaSession.() -> KaType = {
+            ktFile.collectDescendantsOfType<KtTypeReference>()[2].type
+        }
+
+        kaSession(ktFile) {
+            val type = withKaSession(action)
+            assertTrue(type is KaErrorType)
+        }
+
+        assertDoesNotThrow {
+            analyze(ktFile) {
+                action()
             }
         }
     }


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **Error handling:**
  - Overrode `KtTypeReference.type` in `SonarKaSession` to catch exceptions during type resolution.
  - Returns `KaErrorType` instead of logging `InvalidFirElementTypeException` as an error.
  - Changed `SonarLogger.error` to use `LOG.debug` instead of printing directly to `System.err`.
- **Testing:**
  - Added a regression test in `SonarKaSessionTest` to verify `KaErrorType` is returned for invalid type references.

<sub>This will update automatically on new commits.</sub>