### PR TITLE
SONARKT-779 Add SQAA integration to automated release workflow

### DIFF
--- a/.github/workflows/AutomateRelease.yml
+++ b/.github/workflows/AutomateRelease.yml
@@ -48,6 +48,11 @@ on:
         description: |
           Add verbose job summaries
         default: false
+      sqaa-integration:
+        type: boolean
+        description: |
+          Integrate into SQAA (create a PR in sonar-analysis-as-a-service).
+        default: true
 
 jobs:
   release:
@@ -81,5 +86,6 @@ jobs:
       runner-environment: sonar-xs
       release-process: "https://xtranet-sonarsource.atlassian.net/wiki/x/RADLAQE"
       verbose: ${{ inputs.verbose }}
+      sqaa-integration: ${{ inputs.sqaa-integration }}
       bump-version: true
       bump-version-exclusions: "its,sonar-kotlin-surefire"

--- a/.github/workflows/AutomateRelease.yml
+++ b/.github/workflows/AutomateRelease.yml
@@ -48,11 +48,6 @@ on:
         description: |
           Add verbose job summaries
         default: false
-      sqaa-integration:
-        type: boolean
-        description: |
-          Integrate into SQAA (create a PR in sonar-analysis-as-a-service).
-        default: true
 
 jobs:
   release:
@@ -70,6 +65,7 @@ jobs:
       plugin-name: "kotlin"
       plugin-artifacts-sqs: "kotlin"
       plugin-artifacts-sqc: "kotlin"
+      sqaa-integration: true
       use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}
       pm-email: "alexandre.gigleux@sonarsource.com"
@@ -86,6 +82,5 @@ jobs:
       runner-environment: sonar-xs
       release-process: "https://xtranet-sonarsource.atlassian.net/wiki/x/RADLAQE"
       verbose: ${{ inputs.verbose }}
-      sqaa-integration: ${{ inputs.sqaa-integration }}
       bump-version: true
       bump-version-exclusions: "its,sonar-kotlin-surefire"


### PR DESCRIPTION
## Summary

- Enables SQAA integration in the automated release workflow by adding `sqaa-integration: true` to the reusable workflow call, alongside the existing `plugin-artifacts-sqs` and `plugin-artifacts-sqc` inputs
- Relies on `release-automation-secret-name: sonar-kotlin-release-automation` (already set) and falls back to `plugin-name: kotlin` for the artifact key (`sonar-kotlin-plugin`)
- Vault permissions for `sonar-kotlin-release-automation` to access `sonar-analysis-as-a-service` were granted in SonarSource/re-terraform-aws-vault#9295

## Test plan

- [ ] Manually trigger `Automate release` with `dry-run: true` and verify a draft PR is created in `sonar-analysis-as-a-service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)