### PR TITLE
GHA-355 Add statuses: write permission for release-lock feature

### DIFF
--- a/.github/workflows/AutomateRelease.yml
+++ b/.github/workflows/AutomateRelease.yml
@@ -54,7 +54,7 @@ jobs:
     name: Release
     uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@v1
     permissions:
-      statuses: read
+      statuses: write
       id-token: write
       contents: write
       actions: write


### PR DESCRIPTION
## Context

This PR is part of the release-lock gate rollout ([GHA-368](https://sonarsource.atlassian.net/browse/GHA-368), epic [GHA-358](https://sonarsource.atlassian.net/browse/GHA-358)).

The `automated-release.yml` reusable workflow in `release-github-actions` will soon activate Phase 0 of the release-lock gate: at release start and abort, it posts a `release-lock` commit status on all open PRs. This requires `statuses: write` on the caller job's `GITHUB_TOKEN`.

**This PR grants that permission ahead of time** — while the sweep steps are still no-ops — so that activating the feature later requires no further per-repo changes and doesn't risk disrupting ongoing releases.

## Change

Add `statuses: write` to the `permissions:` block of the automated-release caller job.

## Impact

None on current releases. The permission is additive; the sweep steps in `automated-release.yml` are currently stubbed out.

[GHA-368]: https://sonarsource.atlassian.net/browse/GHA-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GHA-358]: https://sonarsource.atlassian.net/browse/GHA-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ