### PR TITLE
SONARKT-784 Detect test files with a reusable TestFileClassifier and suppress S2068/S6418 on them

### DIFF
--- a/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S2068.json
+++ b/its/ruling/src/test/resources/expected/kotlin/corda/kotlin-S2068.json
@@ -5,24 +5,6 @@
 "kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt": [
 36
 ],
-"kotlin-corda-project:sources/kotlin/corda/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt": [
-184,
-185,
-220,
-221
-],
-"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt": [
-111,
-112
-],
-"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt": [
-251,
-252
-],
-"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt": [
-213,
-214
-],
 "kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt": [
 133,
 134

--- a/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S2068.json
+++ b/its/ruling/src/test/resources/expected/kotlin/test-resources-sources/kotlin-S2068.json
@@ -1,6 +1,2 @@
 {
-"kotlin-test-resources-sources-project:ruling/src/test/resources/sources/kotlin/S2068.kt": [
-7,
-39
-]
 }

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/HardcodedCredentialsInTestFileSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/HardcodedCredentialsInTestFileSample.kt
@@ -1,0 +1,11 @@
+package checks
+
+// No "Noncompliant" markers: these credentials would be reported in main code,
+// but the check is expected to stay silent when the file is classified as a test file.
+internal class HardcodedCredentialsInTestFileSample {
+    fun f() {
+        val params = "user=admin&password=Password123"
+        var passwd = "xxxx"
+        passwd = "yyyy"
+    }
+}

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/HardcodedCredentialsInTestFileSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/HardcodedCredentialsInTestFileSample.kt
@@ -1,11 +1,12 @@
 package checks
 
-// No "Noncompliant" markers: these credentials would be reported in main code,
-// but the check is expected to stay silent when the file is classified as a test file.
+// These values would trigger S2068 in main code but are suppressed when the file is a test file.
 internal class HardcodedCredentialsInTestFileSample {
     fun f() {
-        val params = "user=admin&password=Password123"
-        var passwd = "xxxx"
-        passwd = "yyyy"
+        println("login=a&password=Rb7kZpQ2")
+        var passwd = "Rb7kZpQ2"
+        println(passwd)
+        passwd = "Rb7kZpQ2"
+        println(passwd)
     }
 }

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/HardcodedSecretsInTestFileSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/HardcodedSecretsInTestFileSample.kt
@@ -1,0 +1,10 @@
+package checks
+
+// No "Noncompliant" markers: these secrets would be reported in main code,
+// but the check is expected to stay silent when the file is classified as a test file.
+internal class HardcodedSecretsInTestFileSample {
+    fun f() {
+        val mySecret = "abcdefghijklmnopqrs"
+        val params = "login=a&secret=abcdefghijklmnopqrs"
+    }
+}

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/HardcodedSecretsInTestFileSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/HardcodedSecretsInTestFileSample.kt
@@ -1,10 +1,10 @@
 package checks
 
-// No "Noncompliant" markers: these secrets would be reported in main code,
-// but the check is expected to stay silent when the file is classified as a test file.
+// These values would trigger S6418 in main code but are suppressed when the file is a test file.
 internal class HardcodedSecretsInTestFileSample {
     fun f() {
-        val mySecret = "abcdefghijklmnopqrs"
-        val params = "login=a&secret=abcdefghijklmnopqrs"
+        val mySecret = "Hj4pZ9wLdN2sKq7VtXy"
+        println("login=a&secret=Hj4pZ9wLdN2sKq7VtXy")
+        println(mySecret)
     }
 }

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/InputFileContext.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/InputFileContext.kt
@@ -28,6 +28,7 @@ interface InputFileContext {
     val inputFile: InputFile
     val sensorContext: SensorContext
     val isAndroid: Boolean
+    val isTestFile: Boolean get() = false
 
     fun reportIssue(
         ruleKey: RuleKey,

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/InputFileContextImpl.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/InputFileContextImpl.kt
@@ -41,6 +41,7 @@ class InputFileContextImpl(
     override val sensorContext: SensorContext,
     override val inputFile: InputFile,
     override val isAndroid: Boolean,
+    override val isTestFile: Boolean = false,
 ) : InputFileContext {
 
     override var filteredRules: Map<String, Set<TextRange>> = HashMap()

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/TestFileClassifier.java
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/TestFileClassifier.java
@@ -109,8 +109,6 @@ public final class TestFileClassifier {
 
   private static boolean isTestSourceConfigured(Configuration config) {
     return isSet(config, "sonar.tests")
-      || isSet(config, "sonar.test.inclusions")
-      || isSet(config, "sonar.test.exclusions")
       || config.getBoolean(HEURISTIC_DISABLED_KEY).orElse(false);
   }
 

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/TestFileClassifier.java
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/TestFileClassifier.java
@@ -1,0 +1,125 @@
+/*
+ * SonarSource Kotlin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.kotlin.api.checks;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.utils.WildcardPattern;
+
+/**
+ * Decides whether a file is a test file for rule-execution purposes only; it never influences metric
+ * computation, which always relies on the platform {@link org.sonar.api.batch.fs.InputFile#type()}.
+ *
+ * <p>An analyzer registers its language's test-file path patterns together with the project
+ * {@link Configuration} via {@link #of(Configuration, String...)}. The heuristic is a fallback for
+ * when the project has not declared its test sources: the config gate is evaluated once at
+ * registration (it is a per-project fact), so the per-file {@link #looksLikeTestFile(String)} takes
+ * only the path.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * // once per analysis, where Configuration is available (e.g. the sensor):
+ * var testFiles = TestFileClassifier.of(sensorContext.config(), "**​/test/**", "**​/*Test.kt");
+ * // per file:
+ * if (testFiles.looksLikeTestFile(inputFile.uri().getPath())) { ... }
+ * }</pre>
+ */
+public final class TestFileClassifier {
+
+  /** Generic opt-out: disables the test-file heuristic for every analyzer that uses this classifier. */
+  public static final String HEURISTIC_DISABLED_KEY = "sonar.testFileHeuristic.disabled";
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestFileClassifier.class);
+
+  private static final String HEURISTIC_APPLIED_WARNING =
+    "Test files were detected using a path heuristic because \"sonar.tests\" is not set. To improve the " +
+      "analysis accuracy, it is recommended to configure it, e.g.: \"sonar.tests=src/test\".";
+
+  private final List<WildcardPattern> patterns;
+  private final boolean testSourcesConfigured;
+  // Warn once, here, so the heuristic behaves the same for every analyzer using this classifier.
+  private boolean heuristicWarningEmitted = false;
+
+  private TestFileClassifier(List<WildcardPattern> patterns, boolean testSourcesConfigured) {
+    this.patterns = patterns;
+    this.testSourcesConfigured = testSourcesConfigured;
+  }
+
+  /**
+   * Registers the test-file scope: its path patterns (Ant globs) plus the project {@code configuration}
+   * that gates the heuristic. The gate is evaluated once here.
+   */
+  public static TestFileClassifier of(Configuration configuration, String... globs) {
+    return new TestFileClassifier(
+      Arrays.stream(globs).map(WildcardPattern::create).collect(Collectors.toUnmodifiableList()),
+      isTestSourceConfigured(configuration));
+  }
+
+  /** True when {@code path} matches a registered pattern and the project has not configured test sources. */
+  public boolean looksLikeTestFile(String path) {
+    return looksLikeTestFile(path, Context.empty());
+  }
+
+  /**
+   * True when {@code path} matches a registered pattern and the project has not configured test sources.
+   * Emits a one-time warning the first time the heuristic classifies a file, so users are nudged to set
+   * {@code sonar.tests}. {@code context} is unused today; it is the stable extension point for future
+   * context-aware logic.
+   */
+  @SuppressWarnings("java:S1172")
+  public boolean looksLikeTestFile(String path, Context context) {
+    boolean detected = !testSourcesConfigured && patterns.stream().anyMatch(pattern -> pattern.match(path));
+    if (detected && !heuristicWarningEmitted) {
+      heuristicWarningEmitted = true;
+      LOG.warn(HEURISTIC_APPLIED_WARNING);
+    }
+    return detected;
+  }
+
+  private static boolean isTestSourceConfigured(Configuration config) {
+    return isSet(config, "sonar.tests")
+      || isSet(config, "sonar.test.inclusions")
+      || isSet(config, "sonar.test.exclusions")
+      || config.getBoolean(HEURISTIC_DISABLED_KEY).orElse(false);
+  }
+
+  private static boolean isSet(Configuration config, String key) {
+    return config.get(key).filter(value -> !value.isBlank()).isPresent();
+  }
+
+  /**
+   * Surrounding information passed alongside the path to {@link #looksLikeTestFile(String, Context)}.
+   *
+   * <p>Intentionally empty for now: a stable extension point so future accessors (e.g. file content or
+   * the analyzed language) can be added without changing the classification signature.
+   */
+  public interface Context {
+
+    Context EMPTY = new Context() {
+    };
+
+    /** Returns a context that carries no additional information. */
+    static Context empty() {
+      return EMPTY;
+    }
+  }
+}

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/TestFileClassifier.java
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/TestFileClassifier.java
@@ -19,9 +19,9 @@ package org.sonarsource.kotlin.api.checks;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.utils.WildcardPattern;
 
@@ -29,18 +29,16 @@ import org.sonar.api.utils.WildcardPattern;
  * Decides whether a file is a test file for rule-execution purposes only; it never influences metric
  * computation, which always relies on the platform {@link org.sonar.api.batch.fs.InputFile#type()}.
  *
- * <p>An analyzer registers its language's test-file path patterns together with the project
- * {@link Configuration} via {@link #of(Configuration, String...)}. The heuristic is a fallback for
- * when the project has not declared its test sources: the config gate is evaluated once at
- * registration (it is a per-project fact), so the per-file {@link #looksLikeTestFile(String)} takes
- * only the path.
+ * <p>An analyzer registers its test-file path patterns together with the project {@link Configuration}
+ * that gates the heuristic (evaluated once at registration, as it is a per-project fact). The
+ * heuristic is a fallback for when the project has not declared its test sources.
  *
  * <p>Usage:
  * <pre>{@code
  * // once per analysis, where Configuration is available (e.g. the sensor):
  * var testFiles = TestFileClassifier.of(sensorContext.config(), "**​/test/**", "**​/*Test.kt");
- * // per file:
- * if (testFiles.looksLikeTestFile(inputFile.uri().getPath())) { ... }
+ * // per file (matched on the project-relative path, so workspace directories are not matched):
+ * if (testFiles.looksLikeTestFile(inputFile)) { ... }
  * }</pre>
  */
 public final class TestFileClassifier {
@@ -54,6 +52,10 @@ public final class TestFileClassifier {
     "Test files were detected using a path heuristic because \"sonar.tests\" is not set. To improve the " +
       "analysis accuracy, it is recommended to configure it, e.g.: \"sonar.tests=src/test\".";
 
+  // Single shared empty context; held on the outer class so the interface exposes only empty().
+  private static final Context EMPTY_CONTEXT = new Context() {
+  };
+
   private final List<WildcardPattern> patterns;
   private final boolean testSourcesConfigured;
   // Warn once, here, so the heuristic behaves the same for every analyzer using this classifier.
@@ -65,8 +67,8 @@ public final class TestFileClassifier {
   }
 
   /**
-   * Registers the test-file scope: its path patterns (Ant globs) plus the project {@code configuration}
-   * that gates the heuristic. The gate is evaluated once here.
+   * Registers the test-file scope: {@code globs} (Ant path patterns) are matched against the file path.
+   * The {@code configuration} gates the heuristic; the gate is evaluated once here.
    */
   public static TestFileClassifier of(Configuration configuration, String... globs) {
     return new TestFileClassifier(
@@ -74,19 +76,24 @@ public final class TestFileClassifier {
       isTestSourceConfigured(configuration));
   }
 
-  /** True when {@code path} matches a registered pattern and the project has not configured test sources. */
-  public boolean looksLikeTestFile(String path) {
-    return looksLikeTestFile(path, Context.empty());
+  /**
+   * True when the file is recognized as a test file and the project has not configured test sources.
+   * Convenience overload with an empty {@link Context}.
+   */
+  public boolean looksLikeTestFile(InputFile inputFile) {
+    return looksLikeTestFile(inputFile, Context.empty());
   }
 
   /**
-   * True when {@code path} matches a registered pattern and the project has not configured test sources.
-   * Emits a one-time warning the first time the heuristic classifies a file, so users are nudged to set
-   * {@code sonar.tests}. {@code context} is unused today; it is the stable extension point for future
-   * context-aware logic.
+   * True when the file's project-relative path matches a registered glob and the project has not
+   * configured test sources. Emits a one-time warning the first time the heuristic classifies a file,
+   * so users are nudged to set {@code sonar.tests}. {@code context} is unused today; it is the stable
+   * per-file extension point.
    */
-  @SuppressWarnings("java:S1172")
-  public boolean looksLikeTestFile(String path, Context context) {
+  @SuppressWarnings("deprecation") // relativePath() is the only project-relative accessor; matching it
+  // avoids the false hits a workspace directory in the absolute path would produce.
+  public boolean looksLikeTestFile(InputFile inputFile, Context context) {
+    String path = inputFile.relativePath();
     boolean detected = !testSourcesConfigured && patterns.stream().anyMatch(pattern -> pattern.match(path));
     if (detected && !heuristicWarningEmitted) {
       heuristicWarningEmitted = true;
@@ -107,19 +114,14 @@ public final class TestFileClassifier {
   }
 
   /**
-   * Surrounding information passed alongside the path to {@link #looksLikeTestFile(String, Context)}.
-   *
-   * <p>Intentionally empty for now: a stable extension point so future accessors (e.g. file content or
-   * the analyzed language) can be added without changing the classification signature.
+   * Per-file information a future classifier may inspect (e.g. the parsed tree, annotations, imports).
+   * Unused today; it stays a stable per-file extension point.
    */
   public interface Context {
 
-    Context EMPTY = new Context() {
-    };
-
     /** Returns a context that carries no additional information. */
     static Context empty() {
-      return EMPTY;
+      return EMPTY_CONTEXT;
     }
   }
 }

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/TestFileClassifier.java
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/TestFileClassifier.java
@@ -47,9 +47,10 @@ public final class TestFileClassifier {
     "Test files were detected using a path heuristic because \"sonar.tests\" is not set. To improve the " +
       "analysis accuracy, it is recommended to configure it, e.g.: \"sonar.tests=src/test\".";
 
+  private static final class EmptyContext implements Context {}
+
   // Single shared empty context; held on the outer class so the interface exposes only empty().
-  private static final Context EMPTY_CONTEXT = new Context() {
-  };
+  private static final Context EMPTY_CONTEXT = new EmptyContext();
 
   // Fallback when no patterns are registered: test directories only, to minimize false positives.
   private static final List<WildcardPattern> DEFAULT_PATTERNS =
@@ -93,7 +94,8 @@ public final class TestFileClassifier {
    * True when test sources are not configured and either a glob matches the project-relative path or the
    * detector accepts {@code context}. Warns once when the heuristic first classifies a file.
    */
-  @SuppressWarnings("deprecation") // relativePath() is the only project-relative accessor
+  // relativePath() is the only project-relative accessor
+  @SuppressWarnings("deprecation")
   public boolean looksLikeTestFile(InputFile inputFile, Context context) {
     String path = inputFile.relativePath();
     boolean detected = !testSourcesConfigured

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/TestFileClassifier.java
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/TestFileClassifier.java
@@ -19,6 +19,7 @@ package org.sonarsource.kotlin.api.checks;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.InputFile;
@@ -56,6 +57,12 @@ public final class TestFileClassifier {
   private static final Context EMPTY_CONTEXT = new Context() {
   };
 
+  // Fallback when no patterns are registered: test directories only, to minimize false positives.
+  private static final List<WildcardPattern> DEFAULT_PATTERNS =
+    Stream.of("**/test/**", "**/tests/**", "**/__tests__/**")
+      .map(WildcardPattern::create)
+      .collect(Collectors.toUnmodifiableList());
+
   private final List<WildcardPattern> patterns;
   private final boolean testSourcesConfigured;
   // Warn once, here, so the heuristic behaves the same for every analyzer using this classifier.
@@ -68,12 +75,14 @@ public final class TestFileClassifier {
 
   /**
    * Registers the test-file scope: {@code globs} (Ant path patterns) are matched against the file path.
+   * When no globs are given, a generic set of test directories is used as a fallback.
    * The {@code configuration} gates the heuristic; the gate is evaluated once here.
    */
   public static TestFileClassifier of(Configuration configuration, String... globs) {
-    return new TestFileClassifier(
-      Arrays.stream(globs).map(WildcardPattern::create).collect(Collectors.toUnmodifiableList()),
-      isTestSourceConfigured(configuration));
+    List<WildcardPattern> patterns = globs.length == 0
+      ? DEFAULT_PATTERNS
+      : Arrays.stream(globs).map(WildcardPattern::create).collect(Collectors.toUnmodifiableList());
+    return new TestFileClassifier(patterns, isTestSourceConfigured(configuration));
   }
 
   /**
@@ -90,8 +99,7 @@ public final class TestFileClassifier {
    * so users are nudged to set {@code sonar.tests}. {@code context} is unused today; it is the stable
    * per-file extension point.
    */
-  @SuppressWarnings("deprecation") // relativePath() is the only project-relative accessor; matching it
-  // avoids the false hits a workspace directory in the absolute path would produce.
+  @SuppressWarnings("deprecation") // relativePath() is the only project-relative accessor
   public boolean looksLikeTestFile(InputFile inputFile, Context context) {
     String path = inputFile.relativePath();
     boolean detected = !testSourcesConfigured && patterns.stream().anyMatch(pattern -> pattern.match(path));

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/TestFileClassifier.java
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/checks/TestFileClassifier.java
@@ -18,6 +18,7 @@ package org.sonarsource.kotlin.api.checks;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -27,20 +28,13 @@ import org.sonar.api.config.Configuration;
 import org.sonar.api.utils.WildcardPattern;
 
 /**
- * Decides whether a file is a test file for rule-execution purposes only; it never influences metric
- * computation, which always relies on the platform {@link org.sonar.api.batch.fs.InputFile#type()}.
+ * Test-file heuristic for rule execution only; it never affects metrics, which use the platform
+ * {@link org.sonar.api.batch.fs.InputFile#type()}. Applies only when the project has not declared its
+ * test sources.
  *
- * <p>An analyzer registers its test-file path patterns together with the project {@link Configuration}
- * that gates the heuristic (evaluated once at registration, as it is a per-project fact). The
- * heuristic is a fallback for when the project has not declared its test sources.
- *
- * <p>Usage:
- * <pre>{@code
- * // once per analysis, where Configuration is available (e.g. the sensor):
- * var testFiles = TestFileClassifier.of(sensorContext.config(), "**​/test/**", "**​/*Test.kt");
- * // per file (matched on the project-relative path, so workspace directories are not matched):
- * if (testFiles.looksLikeTestFile(inputFile)) { ... }
- * }</pre>
+ * <p>Registered once with the project {@link Configuration} (which gates the heuristic) plus path
+ * globs and, optionally, a {@code detector} for richer checks that reads a caller-supplied
+ * {@link Context}. Per file, {@link #looksLikeTestFile(InputFile)} returns the classification.
  */
 public final class TestFileClassifier {
 
@@ -63,46 +57,47 @@ public final class TestFileClassifier {
       .map(WildcardPattern::create)
       .collect(Collectors.toUnmodifiableList());
 
+  private static final Predicate<Context> NO_DETECTOR = context -> false;
+
   private final List<WildcardPattern> patterns;
+  private final Predicate<Context> detector;
   private final boolean testSourcesConfigured;
   // Warn once, here, so the heuristic behaves the same for every analyzer using this classifier.
   private boolean heuristicWarningEmitted = false;
 
-  private TestFileClassifier(List<WildcardPattern> patterns, boolean testSourcesConfigured) {
+  private TestFileClassifier(List<WildcardPattern> patterns, Predicate<Context> detector, boolean testSourcesConfigured) {
     this.patterns = patterns;
+    this.detector = detector;
     this.testSourcesConfigured = testSourcesConfigured;
   }
 
-  /**
-   * Registers the test-file scope: {@code globs} (Ant path patterns) are matched against the file path.
-   * When no globs are given, a generic set of test directories is used as a fallback.
-   * The {@code configuration} gates the heuristic; the gate is evaluated once here.
-   */
+  /** Registers path {@code globs} (Ant patterns); with none, a generic set of test directories is used. */
   public static TestFileClassifier of(Configuration configuration, String... globs) {
+    return of(configuration, NO_DETECTOR, globs);
+  }
+
+  /** As {@link #of(Configuration, String...)}, plus a {@code detector} matched when no glob does. */
+  public static TestFileClassifier of(Configuration configuration, Predicate<Context> detector, String... globs) {
     List<WildcardPattern> patterns = globs.length == 0
       ? DEFAULT_PATTERNS
       : Arrays.stream(globs).map(WildcardPattern::create).collect(Collectors.toUnmodifiableList());
-    return new TestFileClassifier(patterns, isTestSourceConfigured(configuration));
+    return new TestFileClassifier(patterns, detector, isTestSourceConfigured(configuration));
   }
 
-  /**
-   * True when the file is recognized as a test file and the project has not configured test sources.
-   * Convenience overload with an empty {@link Context}.
-   */
+  /** Path-only classification; convenience overload with an empty {@link Context}. */
   public boolean looksLikeTestFile(InputFile inputFile) {
     return looksLikeTestFile(inputFile, Context.empty());
   }
 
   /**
-   * True when the file's project-relative path matches a registered glob and the project has not
-   * configured test sources. Emits a one-time warning the first time the heuristic classifies a file,
-   * so users are nudged to set {@code sonar.tests}. {@code context} is unused today; it is the stable
-   * per-file extension point.
+   * True when test sources are not configured and either a glob matches the project-relative path or the
+   * detector accepts {@code context}. Warns once when the heuristic first classifies a file.
    */
   @SuppressWarnings("deprecation") // relativePath() is the only project-relative accessor
   public boolean looksLikeTestFile(InputFile inputFile, Context context) {
     String path = inputFile.relativePath();
-    boolean detected = !testSourcesConfigured && patterns.stream().anyMatch(pattern -> pattern.match(path));
+    boolean detected = !testSourcesConfigured
+      && (patterns.stream().anyMatch(pattern -> pattern.match(path)) || detector.test(context));
     if (detected && !heuristicWarningEmitted) {
       heuristicWarningEmitted = true;
       LOG.warn(HEURISTIC_APPLIED_WARNING);
@@ -122,12 +117,12 @@ public final class TestFileClassifier {
   }
 
   /**
-   * Per-file information a future classifier may inspect (e.g. the parsed tree, annotations, imports).
-   * Unused today; it stays a stable per-file extension point.
+   * Per-file input a detector inspects. An analyzer implements it to carry what its detector needs
+   * (e.g. the parsed tree) and downcasts to that implementation.
    */
   public interface Context {
 
-    /** Returns a context that carries no additional information. */
+    /** A context carrying no information; detectors needing more return false. */
     static Context empty() {
       return EMPTY_CONTEXT;
     }

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
@@ -28,6 +28,7 @@ import org.sonar.api.batch.sensor.SensorContext
 import org.sonarsource.analyzer.commons.ProgressReport
 import org.sonarsource.kotlin.api.checks.InputFileContext
 import org.sonarsource.kotlin.api.checks.InputFileContextImpl
+import org.sonarsource.kotlin.api.checks.TestFileClassifier
 import org.sonarsource.kotlin.api.common.DEFAULT_KOTLIN_LANGUAGE_VERSION
 import org.sonarsource.kotlin.api.common.FAIL_FAST_PROPERTY_NAME
 import org.sonarsource.kotlin.api.common.KOTLIN_LANGUAGE_VERSION
@@ -57,6 +58,15 @@ abstract class AbstractKotlinSensorExecuteContext(
     private val isInAndroidContext: Boolean by lazy {
         sensorContext.config().getBoolean(SONAR_ANDROID_DETECTED).orElse(false)
     }
+    private val testFiles: TestFileClassifier by lazy {
+        TestFileClassifier.of(
+            sensorContext.config(),
+            "**/test/**", "**/tests/**",
+            "**/*Test.kt", "**/*Tests.kt", "**/*Spec.kt", "**/*IT.kt")
+    }
+
+    private fun isTestFile(inputFile: InputFile): Boolean =
+        inputFile.type() == InputFile.Type.TEST || testFiles.looksLikeTestFile(inputFile.uri().path)
 
     private val inputFileToVirtualFile: Map<InputFile, KotlinVirtualFile> by lazy {
         val virtualFileSystem = KotlinFileSystem()
@@ -109,7 +119,7 @@ abstract class AbstractKotlinSensorExecuteContext(
     val kotlinFiles: List<KotlinSyntaxStructure> by lazy {
         inputFiles.mapNotNull {
             onFileRead()
-            val inputFileContext = InputFileContextImpl(sensorContext, it, isInAndroidContext)
+            val inputFileContext = InputFileContextImpl(sensorContext, it, isInAndroidContext, isTestFile(it))
             try {
                 // The current logic relies on eager loading of all files before the analysis starts.
                 // To trigger potential IO exceptions and report them, we need to do this call.
@@ -138,7 +148,7 @@ abstract class AbstractKotlinSensorExecuteContext(
                 !EMPTY_FILE_CONTENT_PATTERN.matches(it.inputFile.contents())
             }.forEach { (ktFile, doc, inputFile) ->
                 if (sensorContext.isCancelled) return false
-                val inputFileContext = InputFileContextImpl(sensorContext, inputFile, isInAndroidContext)
+                val inputFileContext = InputFileContextImpl(sensorContext, inputFile, isInAndroidContext, isTestFile(inputFile))
                 val tree = KotlinTree(ktFile, doc)
 
                 measureDuration(inputFile.filename()) {

--- a/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
+++ b/sonar-kotlin-api/src/main/java/org/sonarsource/kotlin/api/sensors/AbstractKotlinSensorExecuteContext.kt
@@ -66,7 +66,7 @@ abstract class AbstractKotlinSensorExecuteContext(
     }
 
     private fun isTestFile(inputFile: InputFile): Boolean =
-        inputFile.type() == InputFile.Type.TEST || testFiles.looksLikeTestFile(inputFile.uri().path)
+        inputFile.type() == InputFile.Type.TEST || testFiles.looksLikeTestFile(inputFile)
 
     private val inputFileToVirtualFile: Map<InputFile, KotlinVirtualFile> by lazy {
         val virtualFileSystem = KotlinFileSystem()

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/TestFileClassifierTest.java
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/TestFileClassifierTest.java
@@ -1,0 +1,114 @@
+/*
+ * SonarSource Kotlin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.kotlin.api.checks;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.event.Level;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.config.internal.MapSettings;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestFileClassifierTest {
+
+  @RegisterExtension
+  LogTesterJUnit5 logTester = new LogTesterJUnit5();
+
+  private static final String[] GLOBS = {
+    "**/test/**", "**/tests/**",
+    "**/*Test.kt", "**/*Tests.kt", "**/*Spec.kt", "**/*IT.kt"
+  };
+
+  private static Configuration config(String... keyValues) {
+    var settings = new MapSettings();
+    for (int i = 0; i < keyValues.length; i += 2) {
+      settings.setProperty(keyValues[i], keyValues[i + 1]);
+    }
+    return settings.asConfig();
+  }
+
+  private static TestFileClassifier classifier(Configuration config) {
+    return TestFileClassifier.of(config, GLOBS);
+  }
+
+  @Test
+  void matches_test_paths_when_test_sources_not_configured() {
+    var classifier = classifier(config());
+    assertThat(classifier.looksLikeTestFile("src/main/kotlin/FooTest.kt")).isTrue();
+    assertThat(classifier.looksLikeTestFile("a/FooTests.kt")).isTrue();
+    assertThat(classifier.looksLikeTestFile("a/FooSpec.kt")).isTrue();
+    assertThat(classifier.looksLikeTestFile("a/FooIT.kt")).isTrue();
+    assertThat(classifier.looksLikeTestFile("src/test/kotlin/Foo.kt")).isTrue();
+    assertThat(classifier.looksLikeTestFile("module/tests/Foo.kt")).isTrue();
+  }
+
+  @Test
+  void does_not_match_non_test_paths() {
+    var classifier = classifier(config());
+    assertThat(classifier.looksLikeTestFile("src/main/kotlin/Foo.kt")).isFalse();
+    // case-sensitive suffix: "audit.kt" must not match "*IT.kt"
+    assertThat(classifier.looksLikeTestFile("src/main/kotlin/audit.kt")).isFalse();
+    assertThat(classifier.looksLikeTestFile("")).isFalse();
+  }
+
+  @Test
+  void gate_disables_heuristic_when_test_sources_configured() {
+    var testPath = "src/main/kotlin/FooTest.kt";
+    assertThat(classifier(config("sonar.tests", "src/test")).looksLikeTestFile(testPath)).isFalse();
+    assertThat(classifier(config("sonar.test.inclusions", "**/*Test.kt")).looksLikeTestFile(testPath)).isFalse();
+    assertThat(classifier(config("sonar.test.exclusions", "**/generated/**")).looksLikeTestFile(testPath)).isFalse();
+  }
+
+  @Test
+  void gate_ignores_blank_property() {
+    assertThat(classifier(config("sonar.tests", "  ")).looksLikeTestFile("a/FooTest.kt")).isTrue();
+  }
+
+  @Test
+  void opt_out_property_disables_heuristic() {
+    var classifier = classifier(config(TestFileClassifier.HEURISTIC_DISABLED_KEY, "true"));
+    assertThat(classifier.looksLikeTestFile("a/FooTest.kt")).isFalse();
+  }
+
+  @Test
+  void context_overload_matches_convenience_overload() {
+    var classifier = classifier(config());
+    assertThat(classifier.looksLikeTestFile("a/FooTest.kt", TestFileClassifier.Context.empty()))
+      .isEqualTo(classifier.looksLikeTestFile("a/FooTest.kt"));
+  }
+
+  @Test
+  void warns_once_when_the_heuristic_first_classifies_a_test_file() {
+    var classifier = classifier(config());
+    classifier.looksLikeTestFile("a/FooTest.kt");
+    classifier.looksLikeTestFile("b/BarTest.kt");
+    classifier.looksLikeTestFile("c/Main.kt"); // no match, no extra warning
+
+    assertThat(logTester.logs(Level.WARN)).hasSize(1);
+    assertThat(logTester.logs(Level.WARN).get(0)).contains("sonar.tests");
+  }
+
+  @Test
+  void does_not_warn_when_test_sources_are_configured() {
+    var classifier = classifier(config("sonar.tests", "src/test"));
+    classifier.looksLikeTestFile("a/FooTest.kt");
+
+    assertThat(logTester.logs(Level.WARN)).isEmpty();
+  }
+}

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/TestFileClassifierTest.java
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/TestFileClassifierTest.java
@@ -96,11 +96,17 @@ class TestFileClassifierTest {
   }
 
   @Test
-  void gate_disables_heuristic_when_test_sources_configured() {
+  void gate_disables_heuristic_when_sonar_tests_configured() {
     var testFile = file("src/main/kotlin/FooTest.kt");
     assertThat(classifier(config("sonar.tests", "src/test")).looksLikeTestFile(testFile)).isFalse();
-    assertThat(classifier(config("sonar.test.inclusions", "**/*Test.kt")).looksLikeTestFile(testFile)).isFalse();
-    assertThat(classifier(config("sonar.test.exclusions", "**/generated/**")).looksLikeTestFile(testFile)).isFalse();
+  }
+
+  @Test
+  void gate_stays_active_when_only_inclusions_or_exclusions_configured() {
+    // sonar.test.inclusions/exclusions only refine an existing test-source set; they do not declare one
+    var testFile = file("src/main/kotlin/FooTest.kt");
+    assertThat(classifier(config("sonar.test.inclusions", "**/*Test.kt")).looksLikeTestFile(testFile)).isTrue();
+    assertThat(classifier(config("sonar.test.exclusions", "**/generated/**")).looksLikeTestFile(testFile)).isTrue();
   }
 
   @Test

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/TestFileClassifierTest.java
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/TestFileClassifierTest.java
@@ -65,6 +65,16 @@ class TestFileClassifierTest {
   }
 
   @Test
+  void falls_back_to_generic_test_directories_when_no_patterns_registered() {
+    var classifier = TestFileClassifier.of(config()); // no globs registered
+    assertThat(classifier.looksLikeTestFile(file("src/test/kotlin/Foo.kt"))).isTrue();
+    assertThat(classifier.looksLikeTestFile(file("a/tests/Foo.kt"))).isTrue();
+    assertThat(classifier.looksLikeTestFile(file("a/__tests__/Foo.js"))).isTrue();
+    // fallback matches directories only, not test-named files
+    assertThat(classifier.looksLikeTestFile(file("src/main/kotlin/FooTest.kt"))).isFalse();
+  }
+
+  @Test
   void does_not_match_non_test_paths() {
     var classifier = classifier(config());
     assertThat(classifier.looksLikeTestFile(file("src/main/kotlin/Foo.kt"))).isFalse();

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/TestFileClassifierTest.java
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/TestFileClassifierTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.kotlin.api.checks;
 
+import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
@@ -52,6 +53,18 @@ class TestFileClassifierTest {
   private static InputFile file(String relativePath) {
     return new TestInputFileBuilder("module", relativePath).build();
   }
+
+  // A context flavour an analyzer would supply, carrying structural info its detector reads.
+  private static final class AnnotatedContext implements TestFileClassifier.Context {
+    final boolean hasTestImport;
+
+    AnnotatedContext(boolean hasTestImport) {
+      this.hasTestImport = hasTestImport;
+    }
+  }
+
+  private static final Predicate<TestFileClassifier.Context> IMPORTS_TEST_FRAMEWORK =
+    context -> context instanceof AnnotatedContext && ((AnnotatedContext) context).hasTestImport;
 
   @Test
   void matches_test_paths_when_test_sources_not_configured() {
@@ -107,6 +120,31 @@ class TestFileClassifierTest {
     var testFile = file("a/FooTest.kt");
     assertThat(classifier.looksLikeTestFile(testFile, TestFileClassifier.Context.empty()))
       .isEqualTo(classifier.looksLikeTestFile(testFile));
+  }
+
+  @Test
+  void detector_classifies_from_the_context_when_no_path_matches() {
+    var classifier = TestFileClassifier.of(config(), IMPORTS_TEST_FRAMEWORK);
+    var mainFile = file("src/main/kotlin/Foo.kt");
+    assertThat(classifier.looksLikeTestFile(mainFile, new AnnotatedContext(true))).isTrue();
+    assertThat(classifier.looksLikeTestFile(mainFile, new AnnotatedContext(false))).isFalse();
+    // empty context (e.g. a path-only call): the detector cannot classify
+    assertThat(classifier.looksLikeTestFile(mainFile)).isFalse();
+  }
+
+  @Test
+  void detector_and_patterns_are_combined() {
+    var classifier = TestFileClassifier.of(config(), IMPORTS_TEST_FRAMEWORK, GLOBS);
+    // path pattern hit, no structural info needed
+    assertThat(classifier.looksLikeTestFile(file("a/FooTest.kt"))).isTrue();
+    // no path hit, detector hit
+    assertThat(classifier.looksLikeTestFile(file("src/main/kotlin/Foo.kt"), new AnnotatedContext(true))).isTrue();
+  }
+
+  @Test
+  void detector_is_gated_by_configured_test_sources() {
+    var classifier = TestFileClassifier.of(config("sonar.tests", "src/test"), IMPORTS_TEST_FRAMEWORK, GLOBS);
+    assertThat(classifier.looksLikeTestFile(file("src/main/kotlin/Foo.kt"), new AnnotatedContext(true))).isFalse();
   }
 
   @Test

--- a/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/TestFileClassifierTest.java
+++ b/sonar-kotlin-api/src/test/java/org/sonarsource/kotlin/api/checks/TestFileClassifierTest.java
@@ -19,6 +19,8 @@ package org.sonarsource.kotlin.api.checks;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
@@ -47,58 +49,62 @@ class TestFileClassifierTest {
     return TestFileClassifier.of(config, GLOBS);
   }
 
+  private static InputFile file(String relativePath) {
+    return new TestInputFileBuilder("module", relativePath).build();
+  }
+
   @Test
   void matches_test_paths_when_test_sources_not_configured() {
     var classifier = classifier(config());
-    assertThat(classifier.looksLikeTestFile("src/main/kotlin/FooTest.kt")).isTrue();
-    assertThat(classifier.looksLikeTestFile("a/FooTests.kt")).isTrue();
-    assertThat(classifier.looksLikeTestFile("a/FooSpec.kt")).isTrue();
-    assertThat(classifier.looksLikeTestFile("a/FooIT.kt")).isTrue();
-    assertThat(classifier.looksLikeTestFile("src/test/kotlin/Foo.kt")).isTrue();
-    assertThat(classifier.looksLikeTestFile("module/tests/Foo.kt")).isTrue();
+    assertThat(classifier.looksLikeTestFile(file("src/main/kotlin/FooTest.kt"))).isTrue();
+    assertThat(classifier.looksLikeTestFile(file("a/FooTests.kt"))).isTrue();
+    assertThat(classifier.looksLikeTestFile(file("a/FooSpec.kt"))).isTrue();
+    assertThat(classifier.looksLikeTestFile(file("a/FooIT.kt"))).isTrue();
+    assertThat(classifier.looksLikeTestFile(file("src/test/kotlin/Foo.kt"))).isTrue();
+    assertThat(classifier.looksLikeTestFile(file("module/tests/Foo.kt"))).isTrue();
   }
 
   @Test
   void does_not_match_non_test_paths() {
     var classifier = classifier(config());
-    assertThat(classifier.looksLikeTestFile("src/main/kotlin/Foo.kt")).isFalse();
+    assertThat(classifier.looksLikeTestFile(file("src/main/kotlin/Foo.kt"))).isFalse();
     // case-sensitive suffix: "audit.kt" must not match "*IT.kt"
-    assertThat(classifier.looksLikeTestFile("src/main/kotlin/audit.kt")).isFalse();
-    assertThat(classifier.looksLikeTestFile("")).isFalse();
+    assertThat(classifier.looksLikeTestFile(file("src/main/kotlin/audit.kt"))).isFalse();
   }
 
   @Test
   void gate_disables_heuristic_when_test_sources_configured() {
-    var testPath = "src/main/kotlin/FooTest.kt";
-    assertThat(classifier(config("sonar.tests", "src/test")).looksLikeTestFile(testPath)).isFalse();
-    assertThat(classifier(config("sonar.test.inclusions", "**/*Test.kt")).looksLikeTestFile(testPath)).isFalse();
-    assertThat(classifier(config("sonar.test.exclusions", "**/generated/**")).looksLikeTestFile(testPath)).isFalse();
+    var testFile = file("src/main/kotlin/FooTest.kt");
+    assertThat(classifier(config("sonar.tests", "src/test")).looksLikeTestFile(testFile)).isFalse();
+    assertThat(classifier(config("sonar.test.inclusions", "**/*Test.kt")).looksLikeTestFile(testFile)).isFalse();
+    assertThat(classifier(config("sonar.test.exclusions", "**/generated/**")).looksLikeTestFile(testFile)).isFalse();
   }
 
   @Test
   void gate_ignores_blank_property() {
-    assertThat(classifier(config("sonar.tests", "  ")).looksLikeTestFile("a/FooTest.kt")).isTrue();
+    assertThat(classifier(config("sonar.tests", "  ")).looksLikeTestFile(file("a/FooTest.kt"))).isTrue();
   }
 
   @Test
   void opt_out_property_disables_heuristic() {
     var classifier = classifier(config(TestFileClassifier.HEURISTIC_DISABLED_KEY, "true"));
-    assertThat(classifier.looksLikeTestFile("a/FooTest.kt")).isFalse();
+    assertThat(classifier.looksLikeTestFile(file("a/FooTest.kt"))).isFalse();
   }
 
   @Test
   void context_overload_matches_convenience_overload() {
     var classifier = classifier(config());
-    assertThat(classifier.looksLikeTestFile("a/FooTest.kt", TestFileClassifier.Context.empty()))
-      .isEqualTo(classifier.looksLikeTestFile("a/FooTest.kt"));
+    var testFile = file("a/FooTest.kt");
+    assertThat(classifier.looksLikeTestFile(testFile, TestFileClassifier.Context.empty()))
+      .isEqualTo(classifier.looksLikeTestFile(testFile));
   }
 
   @Test
   void warns_once_when_the_heuristic_first_classifies_a_test_file() {
     var classifier = classifier(config());
-    classifier.looksLikeTestFile("a/FooTest.kt");
-    classifier.looksLikeTestFile("b/BarTest.kt");
-    classifier.looksLikeTestFile("c/Main.kt"); // no match, no extra warning
+    classifier.looksLikeTestFile(file("a/FooTest.kt"));
+    classifier.looksLikeTestFile(file("b/BarTest.kt"));
+    classifier.looksLikeTestFile(file("c/Main.kt")); // no match, no extra warning
 
     assertThat(logTester.logs(Level.WARN)).hasSize(1);
     assertThat(logTester.logs(Level.WARN).get(0)).contains("sonar.tests");
@@ -107,7 +113,7 @@ class TestFileClassifierTest {
   @Test
   void does_not_warn_when_test_sources_are_configured() {
     var classifier = classifier(config("sonar.tests", "src/test"));
-    classifier.looksLikeTestFile("a/FooTest.kt");
+    classifier.looksLikeTestFile(file("a/FooTest.kt"));
 
     assertThat(logTester.logs(Level.WARN)).isEmpty();
   }

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AbstractHardcodedVisitor.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/AbstractHardcodedVisitor.kt
@@ -51,6 +51,7 @@ abstract class AbstractHardcodedVisitor : AbstractCheck() {
     }
 
     override fun visitBinaryExpression(expression: KtBinaryExpression, context: KotlinFileContext) {
+        if (context.inputFileContext.isTestFile) return
         if (expression.operationToken == KtTokens.EQ || expression.operationToken == KtTokens.PLUSEQ) {
             val left = expression.left
             left?.identifier()?.let { checkVariable(context, left, it, expression.right!!) }
@@ -58,12 +59,14 @@ abstract class AbstractHardcodedVisitor : AbstractCheck() {
     }
 
     override fun visitProperty(property: KtProperty, context: KotlinFileContext) {
+        if (context.inputFileContext.isTestFile) return
         property.initializer?.let {
             checkVariable(context, property.nameIdentifier!!, property.name!!, it)
         }
     }
 
     override fun visitStringTemplateExpression(expression: KtStringTemplateExpression, context: KotlinFileContext) {
+        if (context.inputFileContext.isTestFile) return
         val content = if (!expression.hasInterpolation()) expression.asConstant() else ""
         literalPatterns()
             .mapNotNull { regex -> regex.find(content) }

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/HardcodedCredentialsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/HardcodedCredentialsCheck.kt
@@ -55,6 +55,7 @@ class HardcodedCredentialsCheck : AbstractHardcodedVisitor() {
     }
 
     override fun visitStringTemplateExpression(expression: KtStringTemplateExpression, context: KotlinFileContext) {
+        if (context.inputFileContext.isTestFile) return
         val content = if (!expression.hasInterpolation()) expression.asConstant() else ""
         if (isURIWithCredentials(content)) {
             context.reportIssue(expression, "Review this hard-coded URL, which may contain a credential.")

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/HardcodedCredentialsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/HardcodedCredentialsCheckTest.kt
@@ -16,4 +16,16 @@
  */
 package org.sonarsource.kotlin.checks
 
-class HardcodedCredentialsCheckTest : CheckTest(HardcodedCredentialsCheck())
+import org.junit.jupiter.api.Test
+import org.sonarsource.kotlin.testapi.KotlinVerifier
+
+class HardcodedCredentialsCheckTest : CheckTest(HardcodedCredentialsCheck()) {
+
+    @Test
+    fun `no issues are raised in test files`() {
+        KotlinVerifier(HardcodedCredentialsCheck()) {
+            this.fileName = "HardcodedCredentialsInTestFileSample.kt"
+            this.isTestFile = true
+        }.verifyNoIssue()
+    }
+}

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/HardcodedSecretsCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/HardcodedSecretsCheckTest.kt
@@ -16,4 +16,16 @@
  */
 package org.sonarsource.kotlin.checks
 
-internal class HardcodedSecretsCheckTest : CheckTest(HardcodedSecretsCheck())
+import org.junit.jupiter.api.Test
+import org.sonarsource.kotlin.testapi.KotlinVerifier
+
+internal class HardcodedSecretsCheckTest : CheckTest(HardcodedSecretsCheck()) {
+
+    @Test
+    fun `no issues are raised in test files`() {
+        KotlinVerifier(HardcodedSecretsCheck()) {
+            this.fileName = "HardcodedSecretsInTestFileSample.kt"
+            this.isTestFile = true
+        }.verifyNoIssue()
+    }
+}

--- a/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/KotlinVerifier.kt
+++ b/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/KotlinVerifier.kt
@@ -52,6 +52,7 @@ class KotlinVerifier(private val check: AbstractCheck) {
     var deps: List<String> = getClassPath(DEFAULT_TEST_JARS_DIRECTORY)
     var isAndroid = false
     var fileType: InputFile.Type = InputFile.Type.MAIN
+    var isTestFile = false
 
     fun verify() {
         verifyFile {
@@ -99,7 +100,7 @@ class KotlinVerifier(private val check: AbstractCheck) {
                 val start = comment.range.start()
                 verifier.addComment(start.line(), start.lineOffset() + 1, comment.text, 2, 0)
             }
-        val ctx = TestContext(verifier, check, inputFile = DummyInputFile(path, fileType), isAndroid = isAndroid)
+        val ctx = TestContext(verifier, check, inputFile = DummyInputFile(path, fileType), isAndroid = isAndroid, isTestFile = isTestFile)
         ctx.scan(root)
         return verifier
     }

--- a/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/TestContext.kt
+++ b/sonar-kotlin-test-api/src/main/java/org/sonarsource/kotlin/testapi/TestContext.kt
@@ -37,6 +37,7 @@ class TestContext(
     vararg furtherChecks: AbstractCheck,
     override val inputFile: InputFile = DummyInputFile(),
     override val isAndroid: Boolean = false,
+    override val isTestFile: Boolean = false,
 ) : InputFileContext {
     private val visitor: KtTestChecksVisitor = KtTestChecksVisitor(listOf(check) + furtherChecks)
     override var filteredRules: Map<String, Set<TextRange>> = emptyMap()


### PR DESCRIPTION
## What

Introduces `TestFileClassifier` — a reusable, registration-based classifier for
detecting test/fixture files — and uses it to stop the hardcoded-secret rules
S2068 and S6418 from raising on test files.

When a project does not set `sonar.tests`, the scanner labels test files as MAIN,
so these rules fire on test fixtures containing placeholder credentials — a
common source of false positives.

## How

- `TestFileClassifier` (Java, in `sonar-kotlin-api`): `of(configuration, globs…)`
  registers a language's test-file path globs and evaluates the gate once —
  `sonar.tests` / `sonar.test.inclusions` / `sonar.test.exclusions`, plus a
  generic opt-out `sonar.testFileHeuristic.disabled`. When no globs are
  registered, it falls back to a generic set of test directories (`**/test/**`,
  `**/tests/**`, `**/__tests__/**`). The per-file `looksLikeTestFile(InputFile)`
  emits a one-time "set sonar.tests" warning on first hit. An
  `of(configuration, detector, globs…)` overload takes a caller-supplied
  detector (`Predicate<Context>`) for checks richer than path matching (e.g. a
  parsed tree that imports a test framework); `Context` is a caller-defined
  per-file input the detector downcasts to. Written in Java so it can later be
  lifted verbatim to `sonar-analyzer-commons`.
- The Kotlin sensor registers the scope and computes a per-file `isTestFile`
  (platform `InputFile.Type.TEST` or the heuristic), exposed on
  `InputFileContext`; S2068 and S6418 consult it and skip test files.
- Classification affects rule execution only, never metrics.
- Kotlin patterns: `**/test/**`, `**/tests/**`, `**/*Test.kt`, `**/*Tests.kt`,
  `**/*Spec.kt`, `**/*IT.kt`.
