### PR TITLE
SONARKT-788 Document that bumping kotlinVersion requires a SonarSecurity update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,10 @@ group=org.sonarsource.kotlin
 version=3.8-SNAPSHOT
 description=Code Analyzer for Kotlin
 projectTitle=Kotlin
+# IMPORTANT: When bumping kotlinVersion, the Kotlin compiler version MUST also be updated in
+# SonarSecurity, which compiles its Kotlin frontend against this exact version (provided at
+# runtime by SonarKotlin). Update SonarSecurity's `kotlin.version` and `sonarkotlin.version`
+# properties together, plus any required migration of its Kotlin frontend to the new API.
 kotlinVersion=2.4.0
 
 org.gradle.jvmargs=-Xmx4096M


### PR DESCRIPTION
Adds a note next to `kotlinVersion` in `gradle.properties` documenting the cross-repo coupling with SonarSecurity: SonarSecurity's Kotlin frontend is compiled against the exact Kotlin compiler version that SonarKotlin provides at runtime, so any bump here must be mirrored in SonarSecurity (`kotlin.version` / `sonarkotlin.version`, plus any required Kotlin Analysis API migration).

Context: the recent Kotlin 2.4.0 bump required a coordinated update and Analysis API migration in SonarSecurity (SONARSEC-8626). This comment makes the coupling discoverable at the point of change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
