### PR TITLE
SONARKT-792 Run PVF job on Pull Request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,9 +73,19 @@ jobs:
       - name: Get project version
         id: project-version
         run: |
-          echo "project-version=$(./gradlew properties --no-scan --no-daemon --console plain \
+          set -euo pipefail
+          VERSION=$(./gradlew properties --no-scan --no-daemon --console plain \
             -DbuildNumber=${{ steps.build-number.outputs.BUILD_NUMBER }} \
-            | grep '^version:' | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+            | grep '^version:' | awk '{print $2}')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Failed to determine project version from './gradlew properties' output"
+            exit 1
+          fi
+          echo "project-version=$VERSION" >> "$GITHUB_OUTPUT"
+        env:
+          ARTIFACTORY_PRIVATE_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PRIVATE_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+
   qa_plugin:
     runs-on: github-ubuntu-latest-s
     timeout-minutes: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,7 @@ jobs:
       statuses: read
     uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
     with:
+      baseline-version: 'DEV'
       candidate-version: ${{ needs.build.outputs.project-version }}
 
   promote:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
       contents: write
       pages: write
       statuses: read
-    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@SONARKT-791
+    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
     with:
       baseline-version: 'DEV'
       candidate-version: ${{ needs.build.outputs.project-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
   build:
     runs-on: github-ubuntu-latest-s
     timeout-minutes: 30
+    outputs:
+      project-version: ${{ steps.project-version.outputs.project-version }}
     steps:
       - &configure_GITHUB_JOB_ID_environment_variable
         # https://github.com/actions/runner/issues/324#issuecomment-3324382354
@@ -68,6 +70,12 @@ jobs:
           ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
           ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
           ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
+      - name: Get project version
+        id: project-version
+        run: |
+          echo "project-version=$(./gradlew properties --no-scan --no-daemon --console plain \
+            -DbuildNumber=${{ steps.build-number.outputs.BUILD_NUMBER }} \
+            | grep '^version:' | awk '{print $2}')" >> "$GITHUB_OUTPUT"
   qa_plugin:
     runs-on: github-ubuntu-latest-s
     timeout-minutes: 30
@@ -121,6 +129,19 @@ jobs:
           ARTIFACTORY_PRIVATE_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+  performance_validation:
+    name: Performance Validation
+    needs: [build]
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && github.event_name == 'pull_request' }}
+    permissions:
+      id-token: write
+      contents: write
+      pages: write
+      statuses: read
+    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
+    with:
+      candidate-version: ${{ needs.build.outputs.project-version }}
+
   promote:
     needs:
       - build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
       contents: write
       pages: write
       statuses: read
-    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
+    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@SONARKT-791
     with:
       baseline-version: 'DEV'
       candidate-version: ${{ needs.build.outputs.project-version }}


### PR DESCRIPTION
## Summary
- Adds a `performance_validation` job to `build.yml` that invokes `sonar-kotlin-pvf`'s `performance-validation.yml` as a reusable workflow (cross-repo `workflow_call`) after the `build` job succeeds.
- Passes the just-built `project-version` (resolved via `./gradlew properties`) as `candidate-version`, so PVF benchmarks the actual PR artifact instead of always using `DEV`.
- Can be skipped on a PR via the `skip-pvf` label or `[skip pvf]` in the PR title (handled on the sonar-kotlin-pvf side).

Mirrors SONARGO-833, DART-410, and SONARSWIFT-943 for the other analyzers, and SonarSource/sonar-text-enterprise's shipped design (SONARTEXT-1050).

Jira: https://sonarsource.atlassian.net/browse/SONARKT-792

## Test plan
- [ ] Open this PR and confirm the `performance_validation` job triggers `sonar-kotlin-pvf`'s workflow with the resolved candidate version
- [ ] Confirm PVF run completes and reports results back on this PR