### PR TITLE
SONARKT-391 Do not report S6313 on functions annotated with `@VisibleForTesting`

### DIFF
--- a/kotlin-checks-test-sources/src/main/java/androidx/annotation/VisibleForTesting.java
+++ b/kotlin-checks-test-sources/src/main/java/androidx/annotation/VisibleForTesting.java
@@ -1,4 +1,13 @@
 package androidx.annotation;
 
+// Local stub of androidx.annotation.VisibleForTesting, mirroring its public API,
+// so sample files can compile without pulling in the real androidx dependency.
 public @interface VisibleForTesting {
+
+    int otherwise() default PRIVATE;
+
+    int PROTECTED = 4;
+    int PACKAGE_PRIVATE = 3;
+    int PRIVATE = 2;
+    int NONE = 5;
 }

--- a/kotlin-checks-test-sources/src/main/java/androidx/annotation/VisibleForTesting.java
+++ b/kotlin-checks-test-sources/src/main/java/androidx/annotation/VisibleForTesting.java
@@ -1,0 +1,4 @@
+package androidx.annotation;
+
+public @interface VisibleForTesting {
+}

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/ViewModelSuspendingFunctionsCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/ViewModelSuspendingFunctionsCheckSample.kt
@@ -1,11 +1,17 @@
 package checks
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.delay
 
 class ViewModelSuspendingFunctionsCheckSample: ViewModel() {
-    
+
     fun function() {}
+
+    @VisibleForTesting
+    suspend fun visibleForTestingSuspendingFunction() { // Compliant
+        delay(500L)
+    }
     
     suspend fun suspendingFunction() { // Noncompliant {{Classes extending "ViewModel" should not expose suspending functions.}}
 //  ^^^^^^^

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/ViewModelSuspendingFunctionsCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/ViewModelSuspendingFunctionsCheckSample.kt
@@ -12,7 +12,12 @@ class ViewModelSuspendingFunctionsCheckSample: ViewModel() {
     suspend fun visibleForTestingSuspendingFunction() { // Compliant
         delay(500L)
     }
-    
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    suspend fun visibleForTestingWithOtherwiseSuspendingFunction() { // Compliant
+        delay(500L)
+    }
+
     suspend fun suspendingFunction() { // Noncompliant {{Classes extending "ViewModel" should not expose suspending functions.}}
 //  ^^^^^^^
         privateSuspendingFunction()

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ViewModelSuspendingFunctionsCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/ViewModelSuspendingFunctionsCheck.kt
@@ -26,6 +26,8 @@ import org.sonarsource.kotlin.api.checks.suspendModifier
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
 import org.sonarsource.kotlin.api.visiting.withKaSession
 
+private const val VISIBLE_FOR_TESTING_ANNOTATION = "VisibleForTesting"
+
 @Rule(key = "S6313")
 class ViewModelSuspendingFunctionsCheck : AbstractCheck() {
     private val viewModelClassId = ClassId.fromString("androidx/lifecycle/ViewModel")
@@ -33,6 +35,7 @@ class ViewModelSuspendingFunctionsCheck : AbstractCheck() {
     override fun visitNamedFunction(function: KtNamedFunction, kotlinFileContext: KotlinFileContext) {
         function.suspendModifier()?.let {
             if (!function.isPrivate()
+                && !function.isVisibleForTesting()
                 && function.extendsViewModel()
             ) {
                 kotlinFileContext.reportIssue(it,
@@ -40,6 +43,9 @@ class ViewModelSuspendingFunctionsCheck : AbstractCheck() {
             }
         }
     }
+
+    private fun KtNamedFunction.isVisibleForTesting(): Boolean =
+        annotationEntries.any { it.shortName?.asString() == VISIBLE_FOR_TESTING_ANNOTATION }
 
     private fun KtNamedFunction.extendsViewModel(): Boolean = withKaSession {
         val containingSymbol = symbol.containingSymbol


### PR DESCRIPTION
## Summary
- Rule S6313 flagged non-private suspending functions in a `ViewModel` even when they were annotated with `` `@VisibleForTesting` `` (androidx.annotation.VisibleForTesting), which is a false positive since such functions are intentionally exposed only for tests.
- The check now also excludes functions annotated with `` `@VisibleForTesting` `` (matched by simple annotation name, consistent with how other checks in this codebase recognize annotations such as `` `@Test` ``).

## Test plan
- [x] Added a `` `@VisibleForTesting` `` suspending function case to `ViewModelSuspendingFunctionsCheckSample.kt` and verified it is not reported.
- [x] Added an `androidx.annotation.VisibleForTesting` stub under `kotlin-checks-test-sources` (mirroring existing `androidx.lifecycle.ViewModel` stub) so the sample compiles with semantics.
- [x] `./gradlew :sonar-kotlin-checks:test --tests "org.sonarsource.kotlin.checks.ViewModelSuspendingFunctionsCheckTest"` passes.
- [x] `./gradlew :sonar-kotlin-checks:test` (full module) passes.
- [x] `./gradlew spotlessCheck` passes.

Fixes SONARKT-391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)