### PR TITLE
SONARKT-792 Trigger PVF via repository_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           ./gradlew \
               build \
               sonar -Dsonar.host.url=https://next.sonarqube.com/sonarqube \
-              ${{ github.event_name != 'pull_request' && 'artifactoryPublish' || '' }} \
+              artifactoryPublish \
               -DbuildNumber=${{ steps.build-number.outputs.BUILD_NUMBER }}
         env:
           DEVELOCITY_ACCESS_KEY: develocity-public.sonar.build=${{ fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
       contents: write
       pages: write
       statuses: read
-    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@SONARKT-791
+    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
     with:
       baseline-version: 'DEV'
       candidate-version: ${{ needs.build.outputs.project-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,7 @@ jobs:
     # Wait for `promote`, not just `build`: the candidate artifact is only copied into a
     # publicly-readable Artifactory repo during promotion. Dispatching right after `build`
     # races PVF against promotion and PVF loses (artifact not found yet).
-    needs: [build, qa_plugin, qa_ruling, promote]
+    needs: [build, qa_plugin, qa_ruling, qa_sq_integration, promote]
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,9 +73,19 @@ jobs:
       - name: Get project version
         id: project-version
         run: |
-          echo "project-version=$(./gradlew properties --no-scan --no-daemon --console plain \
+          set -euo pipefail
+          VERSION=$(./gradlew properties --no-scan --no-daemon --console plain \
             -DbuildNumber=${{ steps.build-number.outputs.BUILD_NUMBER }} \
-            | grep '^version:' | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+            | grep '^version:' | awk '{print $2}')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Failed to determine project version from './gradlew properties' output"
+            exit 1
+          fi
+          echo "project-version=$VERSION" >> "$GITHUB_OUTPUT"
+        env:
+          ARTIFACTORY_PRIVATE_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PRIVATE_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+
   qa_plugin:
     runs-on: github-ubuntu-latest-s
     timeout-minutes: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
   build:
     runs-on: github-ubuntu-latest-s
     timeout-minutes: 30
+    outputs:
+      project-version: ${{ steps.project-version.outputs.project-version }}
     steps:
       - &configure_GITHUB_JOB_ID_environment_variable
         # https://github.com/actions/runner/issues/324#issuecomment-3324382354
@@ -68,6 +70,12 @@ jobs:
           ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
           ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
           ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
+      - name: Get project version
+        id: project-version
+        run: |
+          echo "project-version=$(./gradlew properties --no-scan --no-daemon --console plain \
+            -DbuildNumber=${{ steps.build-number.outputs.BUILD_NUMBER }} \
+            | grep '^version:' | awk '{print $2}')" >> "$GITHUB_OUTPUT"
   qa_plugin:
     runs-on: github-ubuntu-latest-s
     timeout-minutes: 30
@@ -91,6 +99,7 @@ jobs:
           ARTIFACTORY_PRIVATE_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PRIVATE_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
   qa_ruling:
     runs-on: github-ubuntu-latest-m
     timeout-minutes: 60
@@ -143,6 +152,19 @@ jobs:
           ARTIFACTORY_PRIVATE_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+  performance_validation:
+    name: Performance Validation
+    needs: [build]
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && github.event_name == 'pull_request' }}
+    permissions:
+      id-token: write
+      contents: write
+      pages: write
+      statuses: read
+    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
+    with:
+      candidate-version: ${{ needs.build.outputs.project-version }}
+
   promote:
     needs:
       - build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,10 @@ jobs:
   # reported back as the `performance-validation` commit status.
   trigger_performance_validation:
     name: Trigger Performance Validation
-    needs: [build]
+    # Wait for `promote`, not just `build`: the candidate artifact is only copied into a
+    # publicly-readable Artifactory repo during promotion. Dispatching right after `build`
+    # races PVF against promotion and PVF loses (artifact not found yet).
+    needs: [build, qa_plugin, qa_ruling, promote]
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,7 @@ jobs:
       statuses: read
     uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
     with:
+      baseline-version: 'DEV'
       candidate-version: ${{ needs.build.outputs.project-version }}
 
   promote:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,8 @@ jobs:
             development/kv/data/develocity token | DEVELOCITY_TOKEN;
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username | ARTIFACTORY_USERNAME;
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
+            development/github/token/licenses-ro token | GITHUB_TOKEN;
+      - uses: ./.github/actions/cache-orchestrator
       - run: |
           ./gradlew \
               :its:plugin:integrationTest --info -Pits
@@ -162,19 +164,66 @@ jobs:
           ARTIFACTORY_PRIVATE_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
-  performance_validation:
-    name: Performance Validation
+  # Public repos cannot call private reusable workflows (GitHub limitation).
+  # Trigger PVF in private sonar-kotlin-pvf via repository_dispatch; results are
+  # reported back as the `performance-validation` commit status.
+  trigger_performance_validation:
+    name: Trigger Performance Validation
     needs: [build]
-    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && github.event_name == 'pull_request' }}
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !cancelled() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-pvf') &&
+      !contains(github.event.pull_request.title, '[skip pvf]')
+    runs-on: github-ubuntu-latest-s
+    timeout-minutes: 10
     permissions:
       id-token: write
-      contents: write
-      pages: write
-      statuses: read
-    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
-    with:
-      baseline-version: 'DEV'
-      candidate-version: ${{ needs.build.outputs.project-version }}
+      statuses: write
+    steps:
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-pvf-trigger token | GITHUB_TOKEN;
+      - name: Set pending status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f state=pending \
+            -f context=performance-validation \
+            -f description="PVF triggered" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - name: Dispatch PVF on sonar-kotlin-pvf
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+          CANDIDATE: ${{ needs.build.outputs.project-version }}
+        run: |
+          set -euo pipefail
+          gh api repos/SonarSource/sonar-kotlin-pvf/dispatches \
+            --method POST \
+            -f event_type=sonar-kotlin-pr-pvf \
+            -f "client_payload[baseline-version]=DEV" \
+            -f "client_payload[candidate-version]=${CANDIDATE}" \
+            -f "client_payload[commit-sha]=${{ github.event.pull_request.head.sha }}" \
+            -f "client_payload[pr-number]=${{ github.event.pull_request.number }}" \
+            -f "client_payload[source-repo]=${{ github.repository }}"
+      - name: Mark status error if dispatch failed
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f state=error \
+            -f context=performance-validation \
+            -f description="Failed to trigger PVF" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   promote:
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
       contents: write
       pages: write
       statuses: read
-    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@SONARKT-791
+    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
     with:
       baseline-version: 'DEV'
       candidate-version: ${{ needs.build.outputs.project-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
   build:
     runs-on: github-ubuntu-latest-s
     timeout-minutes: 30
+    outputs:
+      project-version: ${{ steps.project-version.outputs.project-version }}
     steps:
       - &configure_GITHUB_JOB_ID_environment_variable
         # https://github.com/actions/runner/issues/324#issuecomment-3324382354
@@ -68,6 +70,12 @@ jobs:
           ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
           ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
           ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
+      - name: Get project version
+        id: project-version
+        run: |
+          echo "project-version=$(./gradlew properties --no-scan --no-daemon --console plain \
+            -DbuildNumber=${{ steps.build-number.outputs.BUILD_NUMBER }} \
+            | grep '^version:' | awk '{print $2}')" >> "$GITHUB_OUTPUT"
   qa_plugin:
     runs-on: github-ubuntu-latest-s
     timeout-minutes: 30
@@ -121,6 +129,19 @@ jobs:
           ARTIFACTORY_PRIVATE_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+  performance_validation:
+    name: Performance Validation
+    needs: [build]
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && github.event_name == 'pull_request' }}
+    permissions:
+      id-token: write
+      contents: write
+      pages: write
+      statuses: read
+    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
+    with:
+      candidate-version: ${{ needs.build.outputs.project-version }}
+
   promote:
     needs:
       - build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
       contents: write
       pages: write
       statuses: read
-    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
+    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@SONARKT-791
     with:
       baseline-version: 'DEV'
       candidate-version: ${{ needs.build.outputs.project-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
       contents: write
       pages: write
       statuses: read
-    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
+    uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@SONARKT-791
     with:
       baseline-version: 'DEV'
       candidate-version: ${{ needs.build.outputs.project-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,7 @@ jobs:
       statuses: read
     uses: SonarSource/sonar-kotlin-pvf/.github/workflows/performance-validation.yml@master
     with:
+      baseline-version: 'DEV'
       candidate-version: ${{ needs.build.outputs.project-version }}
 
   promote:


### PR DESCRIPTION
## Summary
- Replace the broken private `workflow_call` to `sonar-kotlin-pvf` with a `repository_dispatch` trigger (public repos cannot call private reusable workflows).
- After a successful same-repo PR build, set a pending `performance-validation` status and dispatch `sonar-kotlin-pr-pvf` with the built candidate version + commit SHA.
- Honor `skip-pvf` label / `[skip pvf]` in the PR title; skip fork PRs (no Vault cross-repo token).
- Keep the `project-version` build output from the earlier approach.

Supersedes the approach in #750. Merge **after**:
1. Vault token PR (`re-terraform-aws-vault`)
2. Receiver PR (`sonar-kotlin-pvf`)

Jira: https://sonarsource.atlassian.net/browse/SONARKT-792

## Test plan
- [ ] On this PR (after Vault + pvf PRs are merged), confirm `Trigger Performance Validation` succeeds
- [ ] Confirm a PVF run starts in `sonar-kotlin-pvf` and updates the `performance-validation` status
- [ ] Confirm `skip-pvf` / `[skip pvf]` skips the trigger job