### PR TITLE
SONARKT-807 Run PVF after build and before promote

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,6 +177,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       !cancelled() &&
+      needs.build.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(github.event.pull_request.labels.*.name, 'skip-pvf') &&
       !contains(github.event.pull_request.title, '[skip pvf]')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,9 +169,6 @@ jobs:
   # reported back as the `performance-validation` commit status.
   trigger_performance_validation:
     name: Trigger Performance Validation
-    # Wait for `promote`, not just `build`: the candidate artifact is only copied into a
-    # publicly-readable Artifactory repo during promotion. Dispatching right after `build`
-    # races PVF against promotion and PVF loses (artifact not found yet).
     needs: [build]
     if: >-
       github.event_name == 'pull_request' &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,7 @@ jobs:
     # Wait for `promote`, not just `build`: the candidate artifact is only copied into a
     # publicly-readable Artifactory repo during promotion. Dispatching right after `build`
     # races PVF against promotion and PVF loses (artifact not found yet).
-    needs: [build, qa_plugin, qa_ruling, qa_sq_integration, promote]
+    needs: [build]
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **CI/CD Configuration:**
    - Updated workflow dependencies in `.github/workflows/build.yml` to run PVF after `build` instead of waiting for `promote`.

<sub>This will update automatically on new commits.</sub>