### PR TITLE
Pin org.sonarqube Gradle plugin to 7.3.1.8318 in kotlin-language-server ruling test

### DIFF
--- a/its/sq-integration/src/integrationTest/java/org/sonarsource/slang/SlangRulingTest.java
+++ b/its/sq-integration/src/integrationTest/java/org/sonarsource/slang/SlangRulingTest.java
@@ -162,10 +162,11 @@ class SlangRulingTest {
   }
 
   private static GradleBuild gradleBuild(String project, Map<String, String> properties) throws IOException {
+    Path initScript = moduleDirectory().resolve(Path.of("src", "integrationTest", "resources", "pin-sonarqube-plugin.init.gradle.kts"));
     return GradleBuild.create(projectDirectory(project).toFile())
       .setProperties(properties)
       .setEnvironmentVariable("GRADLE_OPTS", "-Xmx1024m")
-      .addArguments("--stacktrace", "--info", "--console=plain", "-x", "test")
+      .addArguments("--stacktrace", "--info", "--console=plain", "-x", "test", "--init-script", initScript.toString())
       .setTimeoutSeconds(600);
   }
 

--- a/its/sq-integration/src/integrationTest/resources/pin-sonarqube-plugin.init.gradle.kts
+++ b/its/sq-integration/src/integrationTest/resources/pin-sonarqube-plugin.init.gradle.kts
@@ -1,0 +1,12 @@
+// Pins org.sonarqube to a version without the sonarResolver bug SCANGRADLE-293.
+beforeSettings {
+    pluginManagement {
+        resolutionStrategy {
+            eachPlugin {
+                if (requested.id.id == "org.sonarqube") {
+                    useVersion("7.3.1.8318")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `its/sq-integration` ruling test `SlangRulingTest.test_kotlin_language_server()` has been failing on master since 2026-08-07.
- The sample project `its/sources/kotlin/kotlin-language-server/build.gradle.kts` resolves the `org.sonarqube` Gradle plugin via `version("+")`. Release 7.4.0.8496 regressed a known bug (SCANGRADLE-293: `sonarResolver` task creates a bad implicit dependency link, e.g. with `:shared:processResources`) that 7.1.0.6387 had previously fixed.
- Pin the plugin to the last known-good version, 7.3.1.8318, via a Gradle init script (`its/sq-integration/src/integrationTest/resources/pin-sonarqube-plugin.init.gradle.kts`) passed to the nested Gradle build with `--init-script` in `SlangRulingTest.gradleBuild()`. This is entirely within our own repo and does not touch the `its/sources` submodule.

## Test plan
- [x] Ran `./gradlew --init-script .../pin-sonarqube-plugin.init.gradle.kts build sonar -x test --stacktrace --console=plain -Dsonar.host.url=http://127.0.0.1:9999 -Dsonar.token=dummy -Dsonar.projectKey=test -Dsonar.scanner.skipJreProvisioning=true` directly against `its/sources/kotlin/kotlin-language-server`.
- [x] Confirmed `:sonarResolver`, `:platform:sonarResolver`, `:server:sonarResolver`, `:shared:sonarResolver` all succeed (no "A problem was found with the configuration of task" error).
- [x] Confirmed the build only fails afterwards at `:sonar`, with the expected scanner-bootstrapping error against the dummy server URL.