### PR TITLE
SONARKT-803 Pin org.sonarqube plugin version in the kotlin-language-server ruling build

### DIFF
--- a/its/sq-integration/src/integrationTest/java/org/sonarsource/slang/SlangRulingTest.java
+++ b/its/sq-integration/src/integrationTest/java/org/sonarsource/slang/SlangRulingTest.java
@@ -161,11 +161,16 @@ class SlangRulingTest {
     return moduleDirectory().resolve(Path.of("build", projectKey(project) + "-differences"));
   }
 
+  private static Path pinSonarqubePluginScript() throws IOException {
+    return moduleDirectory().resolve(Path.of("src", "integrationTest", "resources", "pin-sonarqube-plugin.gradle"));
+  }
+
   private static GradleBuild gradleBuild(String project, Map<String, String> properties) throws IOException {
     return GradleBuild.create(projectDirectory(project).toFile())
       .setProperties(properties)
       .setEnvironmentVariable("GRADLE_OPTS", "-Xmx1024m")
       .addArguments("--stacktrace", "--info", "--console=plain", "-x", "test")
+      .addArguments("--init-script", pinSonarqubePluginScript().toString())
       .setTimeoutSeconds(600);
   }
 

--- a/its/sq-integration/src/integrationTest/resources/pin-sonarqube-plugin.gradle
+++ b/its/sq-integration/src/integrationTest/resources/pin-sonarqube-plugin.gradle
@@ -1,0 +1,27 @@
+/*
+ * SonarSource Kotlin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+
+// The ruling project declares `id("org.sonarqube") version "+"`. See SCANGRADLE-440.
+def sonarqubePluginVersion = '7.3.1.8318'
+
+settingsEvaluated { settings ->
+    settings.pluginManagement.resolutionStrategy.eachPlugin { details ->
+        if (details.requested.id.id == 'org.sonarqube') {
+            details.useVersion(sonarqubePluginVersion)
+        }
+    }
+}


### PR DESCRIPTION
`its/sources/kotlin/kotlin-language-server` declares `id("org.sonarqube") version "+"`, so every run resolves whatever is newest on the Gradle Plugin Portal. `7.4.0.8496`, published 2026-08-06, declares classpath inputs without task-dependency provenance, so Gradle now fails `:<subproject>:sonarResolver` with an implicit-dependency error against `processResources`. `qa_sq_integration` has been red every night since, on an unchanged commit, blocking all PRs via `promote`.

Pin to `7.3.1.8318` — what the last green run used, and what `build-logic/common` already pins — via a Gradle init script. This also makes the ruling classpath, and therefore the issues asserted here, reproducible rather than dependent on an external release.

Pinned here rather than in the `its/sources` submodule, which is owned by another squad. Drop it once the scanner fix in [SCANGRADLE-440](https://sonarsource.atlassian.net/browse/SCANGRADLE-440) ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SCANGRADLE-440]: https://sonarsource.atlassian.net/browse/SCANGRADLE-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ