### PR TITLE
SONARKT-808 Add KTLO jira project to release automation

### DIFF
--- a/.github/workflows/AutomateRelease.yml
+++ b/.github/workflows/AutomateRelease.yml
@@ -84,3 +84,4 @@ jobs:
       verbose: ${{ inputs.verbose }}
       bump-version: true
       bump-version-exclusions: "its,sonar-kotlin-surefire"
+      ktlo-jira-project-key: "CLOUDSEC"


### PR DESCRIPTION
## Summary
Adds `ktlo-jira-project-key: "CLOUDSEC"` to the release automation workflow so KTLO tickets generated during release are filed in the CLOUDSEC Jira project.

## Changes
- Added `ktlo-jira-project-key: "CLOUDSEC"` input to `.github/workflows/AutomateRelease.yml`

## Testing
- No functional analyzer change; verified by the shared release workflow on next release run.