### PR TITLE
SONARKT-809 Move Telemetry logging behind internal flag

### DIFF
--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/plugin/KotlinProjectSensor.kt
@@ -31,6 +31,7 @@ class KotlinProjectSensor(internal val telemetryData: TelemetryData) : ProjectSe
     companion object {
         private const val PLUGIN_VERSION_RESOURCE = "org/sonar/plugins/kotlin/pluginVersion.properties"
         private const val UNKNOWN_VERSION = "unknown"
+        const val EXTENDED_LOGGING_PROPERTY_NAME = "sonar.internal.kotlin.extendedLogging"
 
         fun resolvePluginVersion(): String = resolvePluginVersion(PLUGIN_VERSION_RESOURCE)
 
@@ -53,23 +54,25 @@ class KotlinProjectSensor(internal val telemetryData: TelemetryData) : ProjectSe
         descriptor.onlyOnLanguage(KOTLIN_LANGUAGE_KEY).name("KotlinProjectSensor")
     }
 
-    fun addAndLogTelemetryProperty(context: SensorContext, propertyName: String, propertyValue: Any) {
+    fun addAndLogTelemetryProperty(context: SensorContext, extendedLogging: Boolean, propertyName: String, propertyValue: Any) {
         val stringValue = propertyValue.toString()
         context.addTelemetryProperty(propertyName, stringValue)
-        LOG.debug("TELEMETRY: $propertyName=$stringValue")
+        if (extendedLogging) {
+            LOG.debug("TELEMETRY: $propertyName=$stringValue")
+        }
     }
 
-    fun fileProcessingTelemetry(context: SensorContext) = with(telemetryData) {
+    fun fileProcessingTelemetry(context: SensorContext, extendedLogging: Boolean) = with(telemetryData) {
         // files - .kt and .kts counters
-        addAndLogTelemetryProperty(context, "kotlin.files.processed", filesProcessed)
-        addAndLogTelemetryProperty(context, "kotlin.files.read.failures", readFailures)
-        addAndLogTelemetryProperty(context, "kotlin.files.parse.failures", parseFailures)
-        addAndLogTelemetryProperty(context, "kotlin.files.analysis.crashes", analysisCrashes)
+        addAndLogTelemetryProperty(context, extendedLogging, "kotlin.files.processed", filesProcessed)
+        addAndLogTelemetryProperty(context, extendedLogging, "kotlin.files.read.failures", readFailures)
+        addAndLogTelemetryProperty(context, extendedLogging, "kotlin.files.parse.failures", parseFailures)
+        addAndLogTelemetryProperty(context, extendedLogging, "kotlin.files.analysis.crashes", analysisCrashes)
         // scripts - .kts only
-        addAndLogTelemetryProperty(context, "kotlin.scripts.processed", scriptsProcessed)
-        addAndLogTelemetryProperty(context, "kotlin.scripts.read.failures", scriptReadFailures)
-        addAndLogTelemetryProperty(context, "kotlin.scripts.parse.failures", scriptParseFailures)
-        addAndLogTelemetryProperty(context, "kotlin.scripts.analysis.crashes", scriptAnalysisCrashes)
+        addAndLogTelemetryProperty(context, extendedLogging, "kotlin.scripts.processed", scriptsProcessed)
+        addAndLogTelemetryProperty(context, extendedLogging, "kotlin.scripts.read.failures", scriptReadFailures)
+        addAndLogTelemetryProperty(context, extendedLogging, "kotlin.scripts.parse.failures", scriptParseFailures)
+        addAndLogTelemetryProperty(context, extendedLogging, "kotlin.scripts.analysis.crashes", scriptAnalysisCrashes)
     }
 
     /**
@@ -77,16 +80,17 @@ class KotlinProjectSensor(internal val telemetryData: TelemetryData) : ProjectSe
      */
     override fun execute(context: SensorContext) {
         if (context.runtime().apiVersion.isGreaterThanOrEqual(Version.create(10, 9))) {
-            addAndLogTelemetryProperty(context, "kotlin.pluginVersion", resolvePluginVersion())
+            val extendedLogging = context.config().getBoolean(EXTENDED_LOGGING_PROPERTY_NAME).orElse(false)
+            addAndLogTelemetryProperty(context, extendedLogging, "kotlin.pluginVersion", resolvePluginVersion())
             with(telemetryData) {
-                addAndLogTelemetryProperty(context, "kotlin.android", if (hasAndroidImports) "1" else "0")
-                addAndLogTelemetryProperty(context, "kotlin.reports.surefire.classes.imported", surefireClassesImported)
-                addAndLogTelemetryProperty(context, "kotlin.reports.surefire.classes.failed", surefireClassesFailed)
-                addAndLogTelemetryProperty(context, "kotlin.reports.surefire.classes.duplicated", surefireClassesDuplicated)
-                addAndLogTelemetryProperty(context, "kotlin.reports.surefire.classes.overlapping", surefireClassesOverlapping)
+                addAndLogTelemetryProperty(context, extendedLogging, "kotlin.android", if (hasAndroidImports) "1" else "0")
+                addAndLogTelemetryProperty(context, extendedLogging, "kotlin.reports.surefire.classes.imported", surefireClassesImported)
+                addAndLogTelemetryProperty(context, extendedLogging, "kotlin.reports.surefire.classes.failed", surefireClassesFailed)
+                addAndLogTelemetryProperty(context, extendedLogging, "kotlin.reports.surefire.classes.duplicated", surefireClassesDuplicated)
+                addAndLogTelemetryProperty(context, extendedLogging, "kotlin.reports.surefire.classes.overlapping", surefireClassesOverlapping)
             }
 
-            fileProcessingTelemetry(context)
+            fileProcessingTelemetry(context, extendedLogging)
         }
     }
 }

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
@@ -29,9 +29,9 @@ import org.sonar.api.testfixtures.log.LogTesterJUnit5
 import org.sonar.scanner.plugin.api.impl.config.MapSettings
 import org.sonarsource.kotlin.metrics.TelemetryData
 
-class KotlinProjectSensorTest {
+private const val PLUGIN_VERSION = "1.2.3-TEST"
 
-    private val pluginVersion = "1.2.3-TEST"
+class KotlinProjectSensorTest {
 
     @RegisterExtension
     val logTester = LogTesterJUnit5().setLevel(Level.DEBUG)
@@ -50,7 +50,7 @@ class KotlinProjectSensorTest {
         assertThat(telemetry)
             .containsExactlyInAnyOrderEntriesOf(
                 mapOf(
-                    "kotlin.pluginVersion" to pluginVersion,
+                    "kotlin.pluginVersion" to PLUGIN_VERSION,
                     "kotlin.android" to "0",
                     "kotlin.reports.surefire.classes.failed" to "0",
                     "kotlin.reports.surefire.classes.imported" to "0",
@@ -70,7 +70,7 @@ class KotlinProjectSensorTest {
         sensor.telemetryData.hasAndroidImports = true
         sensor.execute(context)
         assertThat(telemetry).containsExactlyInAnyOrderEntriesOf(mapOf(
-            "kotlin.pluginVersion" to pluginVersion,
+            "kotlin.pluginVersion" to PLUGIN_VERSION,
             "kotlin.android" to "1",
             "kotlin.reports.surefire.classes.failed" to "0",
             "kotlin.reports.surefire.classes.imported" to "0",
@@ -108,7 +108,7 @@ class KotlinProjectSensorTest {
 
         assertThat(logTester.logs(Level.DEBUG))
             .contains(
-                "TELEMETRY: kotlin.pluginVersion=$pluginVersion",
+                "TELEMETRY: kotlin.pluginVersion=$PLUGIN_VERSION",
                 "TELEMETRY: kotlin.android=0",
                 "TELEMETRY: kotlin.files.processed=0",
                 "TELEMETRY: kotlin.scripts.analysis.crashes=0",
@@ -117,7 +117,7 @@ class KotlinProjectSensorTest {
 
     @Test
     fun `resolvePluginVersion reads version from resource`() {
-        assertThat(KotlinProjectSensor.resolvePluginVersion()).isEqualTo(pluginVersion)
+        assertThat(KotlinProjectSensor.resolvePluginVersion()).isEqualTo(PLUGIN_VERSION)
     }
 
     @Test

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
@@ -21,11 +21,17 @@ import io.mockk.slot
 import io.mockk.spyk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester
 import java.nio.file.Path
+import org.slf4j.event.Level
+import org.sonar.api.testfixtures.log.LogTesterJUnit5
 import org.sonarsource.kotlin.metrics.TelemetryData
 
 class KotlinProjectSensorTest {
+
+    @RegisterExtension
+    val logTester = LogTesterJUnit5().setLevel(Level.DEBUG)
 
     @Test
     fun `execute reports telemetry`() {

--- a/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
+++ b/sonar-kotlin-plugin/src/test/java/org/sonarsource/kotlin/plugin/KotlinProjectSensorTest.kt
@@ -26,9 +26,12 @@ import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester
 import java.nio.file.Path
 import org.slf4j.event.Level
 import org.sonar.api.testfixtures.log.LogTesterJUnit5
+import org.sonar.scanner.plugin.api.impl.config.MapSettings
 import org.sonarsource.kotlin.metrics.TelemetryData
 
 class KotlinProjectSensorTest {
+
+    private val pluginVersion = "1.2.3-TEST"
 
     @RegisterExtension
     val logTester = LogTesterJUnit5().setLevel(Level.DEBUG)
@@ -47,7 +50,7 @@ class KotlinProjectSensorTest {
         assertThat(telemetry)
             .containsExactlyInAnyOrderEntriesOf(
                 mapOf(
-                    "kotlin.pluginVersion" to "1.2.3-TEST",
+                    "kotlin.pluginVersion" to pluginVersion,
                     "kotlin.android" to "0",
                     "kotlin.reports.surefire.classes.failed" to "0",
                     "kotlin.reports.surefire.classes.imported" to "0",
@@ -67,7 +70,7 @@ class KotlinProjectSensorTest {
         sensor.telemetryData.hasAndroidImports = true
         sensor.execute(context)
         assertThat(telemetry).containsExactlyInAnyOrderEntriesOf(mapOf(
-            "kotlin.pluginVersion" to "1.2.3-TEST",
+            "kotlin.pluginVersion" to pluginVersion,
             "kotlin.android" to "1",
             "kotlin.reports.surefire.classes.failed" to "0",
             "kotlin.reports.surefire.classes.imported" to "0",
@@ -85,8 +88,36 @@ class KotlinProjectSensorTest {
     }
 
     @Test
+    fun `execute does not log telemetry by default`() {
+        val context = SensorContextTester.create(Path.of("."))
+
+        KotlinProjectSensor(TelemetryData()).execute(context)
+
+        assertThat(context.telemetryProperties).isNotEmpty()
+        assertThat(logTester.logs(Level.DEBUG)).noneMatch { it.startsWith("TELEMETRY:") }
+    }
+
+    @Test
+    fun `execute logs telemetry when extended logging is enabled`() {
+        val context = SensorContextTester.create(Path.of("."))
+        context.setSettings(MapSettings().apply {
+            setProperty(KotlinProjectSensor.EXTENDED_LOGGING_PROPERTY_NAME, true)
+        })
+
+        KotlinProjectSensor(TelemetryData()).execute(context)
+
+        assertThat(logTester.logs(Level.DEBUG))
+            .contains(
+                "TELEMETRY: kotlin.pluginVersion=$pluginVersion",
+                "TELEMETRY: kotlin.android=0",
+                "TELEMETRY: kotlin.files.processed=0",
+                "TELEMETRY: kotlin.scripts.analysis.crashes=0",
+            )
+    }
+
+    @Test
     fun `resolvePluginVersion reads version from resource`() {
-        assertThat(KotlinProjectSensor.resolvePluginVersion()).isEqualTo("1.2.3-TEST")
+        assertThat(KotlinProjectSensor.resolvePluginVersion()).isEqualTo(pluginVersion)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Gate DEBUG-level telemetry logging behind a new internal property `sonar.internal.kotlin.extendedLogging`, matching the pattern already used in sonar-dart, sonar-iac-enterprise, and sonar-text-enterprise. The `context.addTelemetryProperty(...)` calls remain unconditional — only the `LOG.debug(...)` calls are now gated. The flag is read once per `execute()` call and threaded as a boolean parameter through the telemetry logging methods.

## Changes

- **KotlinProjectSensor.kt**: Added read of `sonar.internal.kotlin.extendedLogging` property; gated DEBUG logging calls with the boolean flag
- **KotlinProjectSensorTest.kt**: Added test pair (enabled/disabled) using `LogTesterJUnit5` to verify logging behavior

## Testing

- `./gradlew :sonar-kotlin-plugin:test --tests '*KotlinProjectSensorTest*'` — BUILD SUCCESSFUL
- Vortex static analysis on both touched files — clean (no new findings on modified lines)