### PR TITLE
SONARKT-812 Fix FP on S1874: deprecated type references, declaration sites, and usage within deprecated scope

### DIFF
--- a/its/ruling/src/integrationTest/resources/expected/kotlin/corda/kotlin-S1874.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/corda/kotlin-S1874.json
@@ -102,7 +102,6 @@
 ],
 "kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt": [
 40,
-178,
 295
 ],
 "kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt": [

--- a/its/ruling/src/integrationTest/resources/expected/kotlin/corda/kotlin-S1874.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/corda/kotlin-S1874.json
@@ -83,25 +83,13 @@
 "kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/DataSourceFactory.kt": [
 41
 ],
-"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/BrokerJaasLoginModule.kt": [
-123,
-124,
-177
-],
 "kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/internal/artemis/CertificateChainCheckPolicy.kt": [
-12,
-20,
-31,
 34,
-45,
 48,
-59,
 61,
-76,
 78
 ],
 "kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt": [
-40,
 295
 ],
 "kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt": [
@@ -132,9 +120,6 @@
 168,
 170,
 171
-],
-"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt": [
-75
 ],
 "kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt": [
 44
@@ -172,8 +157,6 @@
 147
 ],
 "kotlin-corda-project:sources/kotlin/corda/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt": [
-42,
-50,
 52,
 52,
 61
@@ -232,8 +215,7 @@
 53
 ],
 "kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/model/SettingsModel.kt": [
-16,
-77
+16
 ],
 "kotlin-corda-project:sources/kotlin/corda/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt": [
 227

--- a/its/ruling/src/integrationTest/resources/expected/kotlin/kotlin/kotlin-S1874.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/kotlin/kotlin-S1874.json
@@ -53,14 +53,7 @@
 39
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-client/src/org/jetbrains/kotlin/daemon/client/KotlinCompilerClient.kt": [
-155,
-171,
 280
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompileService.kt": [
-114,
-127,
-157
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/JpsCompilerServicesFacade.kt": [
 19
@@ -69,54 +62,18 @@
 98,
 103,
 108,
-113,
-118,
-121
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/RemoteCompilationCanceledStatusClient.kt": [
-30
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/RemoteIncrementalCacheClient.kt": [
-26
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/RemoteIncrementalCompilationComponentsClient.kt": [
-26
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/RemoteLookupTrackerClient.kt": [
-29
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/AsyncDependencyResolverWrapper.kt": [
-31,
-37
+113
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/ScriptContentLoader.kt": [
 59
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.script/src/org/jetbrains/kotlin/script/scriptTemplate.kt": [
-32,
-62,
-62,
-62,
-62,
-70,
-73,
-74,
-74,
-81,
-83,
-84,
-89,
-96
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/frontend/di/injection.kt": [
-68
+62
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewResolutionOldInference.kt": [
 239,
 242,
-455,
-571,
-579
+455
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/OperationsMapGenerated.kt": [
 41,
@@ -206,34 +163,11 @@
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/CallGenerator.kt": [
 108
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt": [
-184,
-192,
-205,
-212
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/IrMemberFunctionBuilder.kt": [
-42
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/Scope.kt": [
-40
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrCallImpl.kt": [
 145
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrDelegatingConstructorCallImpl.kt": [
-76
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrEnumConstructorCallImpl.kt": [
-69
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeepCopyIrTree.kt": [
-32,
-145,
-427,
-450,
-463,
-482
+32
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/inference/components/SimpleConstraintSystemImpl.kt": [
 53
@@ -320,17 +254,6 @@
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt": [
 292
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDefinitionsManager.kt": [
-178,
-242
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptTemplatesProvider.kt": [
-57,
-58
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptTemplatesProviderAdapter.kt": [
-11
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/MultiplatformProjectImportingTest.kt": [
 37,
@@ -725,9 +648,6 @@
 16,
 26
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/junit/src/main/kotlin/Annotations.kt": [
-12
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/kotlin.test/jvm/src/test/kotlin/StackTraceJVMTest.kt": [
 15,
 22
@@ -882,9 +802,6 @@
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/test/utils/LazyJVMTest.kt": [
 127
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/samples/test/samples/_sampleUtils.kt": [
-21
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/org.jetbrains.kotlin.tools.tests/CasesPublicAPITest.kt": [
 27,
@@ -1233,7 +1150,6 @@
 135
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Plugin.kt": [
-95,
 170,
 186,
 186,

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
@@ -68,7 +68,7 @@ annotation class DeprecatedAnnotation
 typealias DeprecatedString = String
 
 @Deprecated("")
-private operator fun DeprecatedString.minus(s: String) = this + s // Noncompliant
+private operator fun DeprecatedString.minus(s: String) = this + s // Compliant - enclosing function is deprecated (cluster 6)
 
 class DeprecatedParameterUsedInFollowingParameter(
     @Deprecated("This is deprecated") val deprecatedParameter: String, // Compliant: not used, but declared
@@ -108,3 +108,30 @@ fun nestedFunctions() {
 
     oldFunction() // FN
 }
+
+// region nested usage of deprecated code within a deprecated scope
+
+@Deprecated("This whole class is deprecated")
+class DeprecatedClassUsingOtherDeprecated {
+    // field declaration in deprecated class references another deprecated type
+    val member: DeprecatedCode = DeprecatedCode() // Compliant - enclosing class is deprecated
+
+    // calling other deprecated APIs from within the deprecated class body
+    fun usesOtherDeprecatedApis() {
+        deprecatedFunction() // Compliant - enclosing class is deprecated
+        val x = DeprecatedCode() // Compliant - enclosing class is deprecated
+    }
+
+    companion object {
+        // factory method in companion object calling its own deprecated class constructor
+        fun create(): DeprecatedClassUsingOtherDeprecated = DeprecatedClassUsingOtherDeprecated() // Compliant - enclosing class is deprecated
+    }
+}
+
+@Deprecated("Use newWay instead")
+fun deprecatedFunctionCallingOtherDeprecated() {
+    deprecatedFunction() // Compliant - enclosing function is deprecated
+    DeprecatedCode() // Compliant - enclosing function is deprecated
+}
+
+// endregion

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
@@ -58,6 +58,9 @@ open class DeprecatedCode {
 }
 
 @Deprecated("")
+interface DeprecatedInterface
+
+@Deprecated("")
 fun deprecatedFunction() {}
 
 @Deprecated("")
@@ -117,7 +120,24 @@ class UsesDeprecatedInSignatures {
     fun withTypeArg(list: List<DeprecatedString>) {} // Compliant - type argument
 }
 
-class ExtendsDeprecatedWithoutConstructorCall : DeprecatedCode() // Noncompliant
+// actual usages of deprecated types must be reported
+
+// constructor call
+class ExtendsDeprecatedClass : DeprecatedCode() // Noncompliant
+
+// interface supertype
+class ImplementsDeprecatedInterface : DeprecatedInterface // Noncompliant
+
+// by-delegation
+class DelegatesViaDeprecatedInterface(d: DeprecatedInterface) : DeprecatedInterface by d // Noncompliant
+//                                                              ^^^^^^^^^^^^^^^^^^^
+
+fun typeChecks(x: Any) {
+    // is-check
+    if (x is DeprecatedCode) {} // Noncompliant
+    // cast
+    val y = x as DeprecatedCode // Noncompliant
+}
 
 //  annotation without parentheses must not be suppressed as type reference
 @DeprecatedAnnotation // Noncompliant

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
@@ -70,7 +70,7 @@ annotation class DeprecatedAnnotation
 typealias DeprecatedString = String
 
 @Deprecated("")
-private operator fun DeprecatedString.minus(s: String) = this + s // Compliant - enclosing function is deprecated (cluster 6)
+private operator fun DeprecatedString.minus(s: String) = this + s // Compliant - enclosing function is deprecated
 
 class DeprecatedParameterUsedInFollowingParameter(
     @Deprecated("This is deprecated") val deprecatedParameter: String, // Compliant: not used, but declared
@@ -144,7 +144,7 @@ fun typeChecks(x: Any) {
     }
 }
 
-//  annotation without parentheses must not be suppressed as type reference
+// annotation without parentheses must not be suppressed as type reference
 @DeprecatedAnnotation // Noncompliant
 class AnnotatedWithDeprecatedAnnotation
 

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
@@ -120,7 +120,7 @@ class UsesDeprecatedInSignatures {
     fun withTypeArg(list: List<DeprecatedString>) {} // Compliant - type argument
 }
 
-// actual usages of deprecated types must be reported
+// region actual usages of deprecated types must be reported
 
 // constructor call
 class ExtendsDeprecatedClass : DeprecatedCode() // Noncompliant
@@ -137,6 +137,11 @@ fun typeChecks(x: Any) {
     if (x is DeprecatedCode) {} // Noncompliant
     // cast
     val y = x as DeprecatedCode // Noncompliant
+    // when is-pattern
+    when (x) {
+        is DeprecatedCode -> {} // Noncompliant
+        else -> {}
+    }
 }
 
 //  annotation without parentheses must not be suppressed as type reference

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeUsedCheckSample.kt
@@ -12,8 +12,7 @@ class Example : DeprecatedCode() // Noncompliant {{Deprecated code should not be
 //   ^^^^^^^^^^^^^^^^^^^^
 class DeprecatedCodeUsedCheckSample {
 
-    fun usesDeprecated(kStr: DeprecatedString): String { // Noncompliant
-//                           ^^^^^^^^^^^^^^^^
+    fun usesDeprecated(kStr: DeprecatedString): String {
 
         DeprecatedConstructor("") // Noncompliant
 
@@ -108,6 +107,23 @@ fun nestedFunctions() {
 
     oldFunction() // FN
 }
+
+// deprecated type in structural (non-executable) positions should not be flagged
+
+fun returnsDeprecated(): DeprecatedCode? = null // Compliant - return type
+
+class UsesDeprecatedInSignatures {
+    val field: DeprecatedCode? = null // Compliant - field type
+    fun withTypeArg(list: List<DeprecatedString>) {} // Compliant - type argument
+}
+
+class ExtendsDeprecatedWithoutConstructorCall : DeprecatedCode() // Noncompliant
+
+//  annotation without parentheses must not be suppressed as type reference
+@DeprecatedAnnotation // Noncompliant
+class AnnotatedWithDeprecatedAnnotation
+
+// endregion
 
 // region nested usage of deprecated code within a deprecated scope
 

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheck.kt
@@ -19,10 +19,13 @@ package org.sonarsource.kotlin.checks
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
 import org.jetbrains.kotlin.psi.KtAnnotated
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtConstructorCalleeExpression
 import org.jetbrains.kotlin.psi.KtEnumEntrySuperclassReferenceExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
+import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.sonar.check.Rule
@@ -37,9 +40,15 @@ class DeprecatedCodeUsedCheck : AbstractCheck() {
         context.kaDiagnostics
             .filter { it.factoryName == FirErrors.DEPRECATION.name }
             .filterNot { it.psi.isInsideDeprecatedScope() }
+            .filterNot { it.psi.isTypeReferencePosition() }
             .forEach { context.reportIssue(it.psi.elementToReport(), "Deprecated code should not be used.") }
     }
 
+}
+
+private fun PsiElement.isTypeReferencePosition(): Boolean {
+    val typeRef = (sequenceOf(this) + parents).filterIsInstance<KtTypeReference>().firstOrNull() ?: return false
+    return typeRef.parent !is KtConstructorCalleeExpression && typeRef.parent !is KtAnnotationEntry
 }
 
 private fun PsiElement.isInsideDeprecatedScope(): Boolean =

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheck.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntrySuperclassReferenceExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtIsExpression
 import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
+import org.jetbrains.kotlin.psi.KtWhenConditionIsPattern
 import org.jetbrains.kotlin.psi.KtSuperTypeEntry
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
@@ -58,6 +59,7 @@ private fun PsiElement.isTypeReferencePosition(): Boolean {
         is KtSuperTypeEntry,                // class Foo : DeprecatedInterface
         is KtDelegatedSuperTypeEntry,       // class Foo : DeprecatedInterface by d
         is KtIsExpression,                  // x is DeprecatedCode
+        is KtWhenConditionIsPattern,        // when (x) { is DeprecatedCode -> ... }
         is KtBinaryExpressionWithTypeRHS -> // x as DeprecatedCode
             false
         // structural / signature positions — suppress

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheck.kt
@@ -19,12 +19,15 @@ package org.sonarsource.kotlin.checks
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
 import org.jetbrains.kotlin.psi.KtAnnotated
-import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtConstructorCalleeExpression
+import org.jetbrains.kotlin.psi.KtDelegatedSuperTypeEntry
 import org.jetbrains.kotlin.psi.KtEnumEntrySuperclassReferenceExpression
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtIsExpression
 import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
+import org.jetbrains.kotlin.psi.KtSuperTypeEntry
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.parents
@@ -41,6 +44,7 @@ class DeprecatedCodeUsedCheck : AbstractCheck() {
             .filter { it.factoryName == FirErrors.DEPRECATION.name }
             .filterNot { it.psi.isInsideDeprecatedScope() }
             .filterNot { it.psi.isTypeReferencePosition() }
+            .distinctBy { it.psi }
             .forEach { context.reportIssue(it.psi.elementToReport(), "Deprecated code should not be used.") }
     }
 
@@ -48,7 +52,17 @@ class DeprecatedCodeUsedCheck : AbstractCheck() {
 
 private fun PsiElement.isTypeReferencePosition(): Boolean {
     val typeRef = (sequenceOf(this) + parents).filterIsInstance<KtTypeReference>().firstOrNull() ?: return false
-    return typeRef.parent !is KtConstructorCalleeExpression && typeRef.parent !is KtAnnotationEntry
+    return when (typeRef.parent) {
+        // actual usages of the deprecated element — must be reported
+        is KtConstructorCalleeExpression,   // class Foo : DeprecatedClass() / @DeprecatedAnnotation[()]
+        is KtSuperTypeEntry,                // class Foo : DeprecatedInterface
+        is KtDelegatedSuperTypeEntry,       // class Foo : DeprecatedInterface by d
+        is KtIsExpression,                  // x is DeprecatedCode
+        is KtBinaryExpressionWithTypeRHS -> // x as DeprecatedCode
+            false
+        // structural / signature positions — suppress
+        else -> true
+    }
 }
 
 private fun PsiElement.isInsideDeprecatedScope(): Boolean =

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeUsedCheck.kt
@@ -18,11 +18,13 @@ package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
+import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtEnumEntrySuperclassReferenceExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.AbstractCheck
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
@@ -34,10 +36,15 @@ class DeprecatedCodeUsedCheck : AbstractCheck() {
     override fun visitKtFile(file: KtFile, context: KotlinFileContext) = withKaSession {
         context.kaDiagnostics
             .filter { it.factoryName == FirErrors.DEPRECATION.name }
+            .filterNot { it.psi.isInsideDeprecatedScope() }
             .forEach { context.reportIssue(it.psi.elementToReport(), "Deprecated code should not be used.") }
     }
 
 }
+
+private fun PsiElement.isInsideDeprecatedScope(): Boolean =
+    parents.filterIsInstance<KtAnnotated>()
+        .any { annotated -> annotated.annotationEntries.any { it.shortName?.asString() == "Deprecated" } }
 
 private fun PsiElement.elementToReport() = when (this) {
     is KtCallExpression -> calleeExpression

--- a/sonar-kotlin-plugin/src/main/resources/org/sonar/l10n/kotlin/rules/kotlin/S1874.html
+++ b/sonar-kotlin-plugin/src/main/resources/org/sonar/l10n/kotlin/rules/kotlin/S1874.html
@@ -8,8 +8,10 @@ possible.</p>
 <p>Deprecated classes, interfaces, and their members should not be used, inherited or extended because they will eventually be removed. The
 deprecation period allows you to make a smooth transition away from the aging, soon-to-be-retired technology.</p>
 <p>Check the documentation or the deprecation message to understand why the code was deprecated and what the recommended alternative is.</p>
-<pre>
-@Deprecated("This function is deprecated, use newFunction instead", ReplaceWith("newFunction()"))
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+@Deprecated("Use newFunction instead", ReplaceWith("newFunction()"))
 fun oldFunction() {
     println("This is the old function.")
 }
@@ -18,8 +20,55 @@ fun newFunction() {
     println("This is the new function.")
 }
 
-oldFunction() // Noncompliant: "oldFunction is deprecated"
+oldFunction() // Noncompliant
 </pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+@Deprecated("Use newFunction instead", ReplaceWith("newFunction()"))
+fun oldFunction() {
+    println("This is the old function.")
+}
+
+fun newFunction() {
+    println("This is the new function.")
+}
+
+newFunction() // Compliant
+</pre>
+<h3>Exceptions</h3>
+<p>The following usages are not reported:</p>
+<ul>
+  <li>References to deprecated types in non-executable, structural positions: parameter types, return types, field/property types, and type arguments.
+  These positions do not invoke the deprecated API at runtime.
+    <pre>
+@Deprecated("")
+open class DeprecatedClass
+
+fun returnsDeprecated(): DeprecatedClass? = null   // Compliant - return type
+fun takesDeprecated(arg: DeprecatedClass) {}       // Compliant - parameter type
+
+class Holder {
+    val field: DeprecatedClass? = null             // Compliant - field type
+    fun withTypeArg(list: List&lt;DeprecatedClass&gt;) {}// Compliant - type argument
+}
+</pre></li>
+  <li>Any usage inside a declaration that is itself marked <code>@Deprecated</code>. Deprecated code is expected to reference other deprecated APIs
+  during the migration period.
+    <pre>
+@Deprecated("")
+open class DeprecatedClass
+
+@Deprecated("Use NewClass instead")
+class OldClass {
+    val member: DeprecatedClass = DeprecatedClass() // Compliant - enclosing class is deprecated
+}
+
+@Deprecated("Use newFunction instead")
+fun oldFunction() {
+    DeprecatedClass() // Compliant - enclosing function is deprecated
+}
+</pre></li>
+</ul>
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>


### PR DESCRIPTION
----
## Summary by Gitar

- **Rule Updates (S1874):**
    - Fixed false positives on deprecated type references in structural positions like signatures and return types in `DeprecatedCodeUsedCheck.kt`
    - Suppressed deprecation warnings for usages of deprecated code within a deprecated scope
    - Fixed false negatives on interface supertypes, delegation, `is`, and `as` expressions

<sub>This will update automatically on new commits.</sub>