### PR TITLE
SONARKT-813 Fix ruling test commands and update docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
       - uses: ./.github/actions/cache-orchestrator
       - run: |
           ./gradlew \
-              :its:plugin:integrationTest --info -Pits
+              :its:plugin:integrationTest --info
         env:
           DEVELOCITY_ACCESS_KEY: develocity-public.sonar.build=${{ fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN }}
           ARTIFACTORY_PRIVATE_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }}
@@ -130,7 +130,7 @@ jobs:
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
       - run: |
           ./gradlew \
-              :its:ruling:integrationTest --info -Pruling
+              :its:ruling:integrationTest --info
         env:
           KOTLIN_COMPILER_IT_ENABLED: true
           DEVELOCITY_ACCESS_KEY: develocity-public.sonar.build=${{ fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN }}
@@ -157,7 +157,7 @@ jobs:
       - uses: ./.github/actions/cache-orchestrator
       - run: |
           ./gradlew \
-              :its:sq-integration:integrationTest --info -Pits -Dsonar.runtimeVersion=DEV
+              :its:sq-integration:integrationTest --info -Dsonar.runtimeVersion=DEV
         env:
           DEVELOCITY_ACCESS_KEY: develocity-public.sonar.build=${{ fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN }}
           ARTIFACTORY_PRIVATE_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,10 +45,16 @@ git submodule update --init its/sources
 ./gradlew :its:plugin:integrationTest --info --console=plain --no-daemon
 
 # Update ruling golden files after changing a rule:
-# The tests always write actual results to its/ruling/build/reports/ruling/ (even on failure).
-# After running, copy the updated file(s) for the affected rule(s):
-#   cp its/ruling/build/reports/ruling/<corpus>/kotlin-S<NNNN>.json \
-#      its/ruling/src/integrationTest/resources/expected/kotlin/<corpus>/kotlin-S<NNNN>.json
+# 1. Standard corpora — actual results go to its/ruling/build/reports/ruling/ (even on failure):
+#    cp its/ruling/build/reports/ruling/<corpus>/kotlin-S<NNNN>.json \
+#       its/ruling/src/integrationTest/resources/expected/kotlin/<corpus>/kotlin-S<NNNN>.json
+# 2. kotlin corpus (test_kotlin_compiler) — skipped by default, enable with:
+#    KOTLIN_COMPILER_IT_ENABLED=true ./gradlew :its:ruling:integrationTest ...
+#    Goldens are in the same its/ruling/.../expected/kotlin/ directory.
+# 3. kotlin-language-server corpus — run by :its:sq-integration:integrationTest;
+#    actual results go to its/sq-integration/build/tmp/actual/kotlin/kotlin-language-server/
+#    cp its/sq-integration/build/tmp/actual/kotlin/kotlin-language-server/kotlin-S<NNNN>.json \
+#       its/sq-integration/src/integrationTest/resources/expected/kotlin/kotlin-language-server/kotlin-S<NNNN>.json
 ```
 
 ## Implementing a New Rule

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,17 +38,17 @@ This updates `gradle/verification-metadata.xml`. The task is additive — it app
 # Integration and ruling tests both need the source projects submodule:
 git submodule update --init its/sources
 
-# Run integration tests
-./gradlew build -Pits --info --console=plain --no-daemon
+# Run ruling tests (uses SIT — no SonarQube server needed)
+./gradlew :its:ruling:integrationTest --info --console=plain --no-daemon
 
-# Run ruling tests only
-./gradlew build -Pruling --info --console=plain --no-daemon
-# A ruling "failure" that reads "Issues differences: 0" plus "Files listed in
-# Expected directory were not analyzed" means its/sources is missing/uninitialized,
-# not a rule regression. Non-zero "Issues differences" is the real signal.
+# Run plugin tests
+./gradlew :its:plugin:integrationTest --info --console=plain --no-daemon
 
-# Run plugin tests only
-./gradlew build -Pplugin --info --console=plain --no-daemon
+# Update ruling golden files after changing a rule:
+# The tests always write actual results to its/ruling/build/reports/ruling/ (even on failure).
+# After running, copy the updated file(s) for the affected rule(s):
+#   cp its/ruling/build/reports/ruling/<corpus>/kotlin-S<NNNN>.json \
+#      its/ruling/src/integrationTest/resources/expected/kotlin/<corpus>/kotlin-S<NNNN>.json
 ```
 
 ## Implementing a New Rule
@@ -61,10 +61,10 @@ git submodule update --init its/sources
 ./gradlew setupGradleRuleStubs -Prule=S6626 -PclassName=TaskDefinitionsCheck
 
 # Download/refresh rule metadata from RSPEC repository
-./gradlew generateRuleMetadata -Prule=S42
+./gradlew :sonar-kotlin-plugin:ruleApiGenerateRuleKotlin -Prule=S42
 
 # Update all rule metadata
-./gradlew updateRuleMetadata
+./gradlew :sonar-kotlin-plugin:ruleApiUpdateKotlin
 ```
 
 ## Architecture
@@ -127,3 +127,35 @@ After creating a check class, it must be added to `KotlinCheckList.kt` in `sonar
 ./gradlew sonar-kotlin-api:printAst --args="dot path/to/File.kt /tmp/ast.dot"
 dot -Tpng /tmp/ast.dot -o /tmp/ast.png
 ```
+
+<!-- sonar:begin:sonarqube-agentic-analysis-protocol -->
+# Vortex analysis protocol
+
+Vortex analysis is the final confirmation layer at the end of every turn in which you wrote to one or more files in the workspace (create, edit, patch, format — any tool call that changed file contents on disk).
+
+**Trigger:** the moment before you send your final reply for the turn.
+
+When the trigger fires, you **MUST** run Vortex analysis on the full set of files you modified this turn — **one command, not a per-file loop**.
+
+**Preferred:** pass every path you modified this turn in a single invocation (repeat `--file` for each path). Use paths **relative to the project root** (e.g. `src/foo.ts`). For end-of-turn analysis, **always** pass `--depth DEEP` — even when you changed only one file — so cross-file findings are included.
+
+```bash
+sonar analyze agentic --project SonarSource_sonar-kotlin --depth DEEP --file <path/to/file1> --file <path/to/file2>
+```
+
+**Fallback:** when you cannot reliably list every modified path (e.g. you did not track them, or git state is the only source of truth), use the git change set with DEEP analysis:
+
+```bash
+sonar analyze agentic --project SonarSource_sonar-kotlin --depth DEEP
+```
+
+Per-edit hooks run faster STANDARD analysis. End-of-turn analysis must always use `--depth DEEP` (including a single `--file`). Use `--depth STANDARD` only for optional faster passes — never for the mandatory end-of-turn run.
+
+Non-negotiable rules:
+
+1. Mid-turn edits do **not** need Vortex analysis — only the final on-disk state matters. Skipping Vortex analysis at end-of-turn is a protocol violation.
+2. Run Vortex analysis **before** sending your final reply, marking the task done, or handing control back to the user.
+3. If Vortex analysis reports issues on lines you touched in this turn, fix them, then re-run Vortex analysis on the same scope (change set or explicit file list). Repeat until clean (or only pre-existing findings on lines you did not touch remain). Pre-existing findings on untouched lines are out of scope — do not "fix" them unless the user asked.
+4. If Vortex analysis is skipped (no SonarQube Cloud connection, or no project configured), state the skip reason to the user once and continue — do not retry.
+5. Do not suppress, summarize away, or omit Vortex analysis findings from your reply. Surface them verbatim.
+<!-- sonar:end:sonarqube-agentic-analysis-protocol -->

--- a/README.md
+++ b/README.md
@@ -45,77 +45,50 @@ For more information see [README.md](https://github.com/SonarSource/cloud-native
 
 ## Integration Tests
 
-By default, Integration Tests (ITs) are skipped during the build. If you want to run them, you need first to retrieve the related projects
-which are used as input:
+Integration and ruling tests require the source projects submodule:
 
     git submodule update --init its/sources
 
-Then build and run the Integration Tests using the `its` property:
+Run ruling tests (uses SIT — no SonarQube server needed):
 
-    ./gradlew build -Pits --info --console=plain --no-daemon
+    ./gradlew :its:ruling:integrationTest --info --console=plain --no-daemon
 
-You can also build and run only Ruling Tests using the `ruling` property:
+Run plugin tests:
 
-    ./gradlew build -Pruling --info --console=plain --no-daemon
+    ./gradlew :its:plugin:integrationTest --info --console=plain --no-daemon
 
-You can also build and run only Plugin Tests using the `plugin` property:
+To run a single ruling test method, e.g.:
 
-    ./gradlew build -Pplugin --info --console=plain --no-daemon
+    ./gradlew :its:ruling:integrationTest --info --console=plain --no-daemon --tests "org.sonarsource.kotlin.its.KotlinRulingTest.test_kotlin_corda"
 
-To run e.g. the ruling tests in the IDE, create a new Run/Debug Configuration where you run the following:
+### Updating ruling golden files
 
-    :its:ruling:test --info --console=plain -Pruling
+The ruling tests diff actual scanner output against golden files under
+`its/ruling/src/integrationTest/resources/expected/`. After changing a rule, update the
+affected golden files:
 
-You can also run single ruling tests, e.g.:
+1. Run the ruling tests — actual results are always written to `its/ruling/build/reports/ruling/`
+   even when the tests fail.
+2. Copy the updated file(s) for the affected rule(s):
 
-    :its:ruling:test --info --console=plain -Pruling --tests "org.sonarsource.slang.SlangRulingTest.test_kotlin_corda"
+       cp its/ruling/build/reports/ruling/<corpus>/kotlin-S<NNNN>.json \
+          its/ruling/src/integrationTest/resources/expected/kotlin/<corpus>/kotlin-S<NNNN>.json
 
-**Additional ruling parameters**
-
-* By default, the SonarQube version used is LATEST_RELEASE, you can use the following property to set a different one:
-
-      -Dsonar.runtimeVersion=9.7.1.62043
-
-* By default, analyzed projects are built by gradle only if changed, but you can force a clean build by using:
-
-      -DcleanProjects=true
-
-* To keep SonarQube running at the end of the analysis:
-
-       -DkeepSonarqubeRunning=true
-
-* To see in SonarQube not only the issue differences but all the issues:
-
-       -DkeepSonarqubeRunning=true -DreportAll=true
-
-### Debugging ruling tests
-
-You can debug the scanner when running ruling tests. As a new JVM is spawned to run the analysis you can't simply click 'debug' on a ruling
-test, however. You need to tell the Sonar Scanner (which is being used to run the analysis in the background) to launch a debuggable JVM.
-Then you can attach to this JVM instance and debug as normal via your IDE.
-
-The ruling test already provides a convenient API where all you need to do is supply the port you want to debug on (e.g. 5005)
-to `sonar.rulingDebugPort`. So, for instance, if you start the ruling tests from the CLI, run:
-
-    ./gradlew :its:ruling:test -Pruling --info --console=plain --no-daemon -Dsonar.rulingDebugPort=5005
-
-You can obviously do the same in the IDE and/or only run a particular test:
-
-    :its:ruling:test -Pruling --info --console=plain --tests "org.sonarsource.slang.SlangRulingTest.test_kotlin_corda" -Dsonar.rulingDebugPort=5005
+3. Re-run the ruling tests to confirm they pass.
 
 ## Utilities and Developing
 
 ### Generating/downloading rule metadata
 
-The Gradle task `generateRuleMetadata` will download the rule metadata from the [RSPEC repository](https://github.com/SonarSource/rspec/).
+The Gradle task `ruleApiGenerateRuleKotlin` will download the rule metadata from the [RSPEC repository](https://github.com/SonarSource/rspec/).
 
 For example, execute the following in the project root to fetch the metadata for rule `S42`:
 
-    ./gradlew generateRuleMetadata -PruleKey=S42
+    ./gradlew :sonar-kotlin-plugin:ruleApiGenerateRuleKotlin -Prule=S42
 
 If fetching from a branch:
 
-    ./gradlew generateRuleMetadata -PruleKey=S4830 -Pbranch=a_branch
+    ./gradlew :sonar-kotlin-plugin:ruleApiGenerateRuleKotlin -Prule=S4830 -Pbranch=a_branch
 
 Alternatively, you can let the tool auto-detect the branch. If you do not provide a branch, it will look at the PRs
 open in the RSPEC repository that contain the rule key in their name. If it finds any, you will be presented with a
@@ -131,12 +104,12 @@ choice of which branch to fetch the metadata from. Points to note about this fea
 
 If you want to update all rules' metadata, you can use:
 
-    ./gradlew updateRuleMetadata
+    ./gradlew :sonar-kotlin-plugin:ruleApiUpdateKotlin
 
 ### Implementing a new rule
 
 The Gradle task `setupRuleStubs` will create the commonly required files for implementing a new rule, including usual boilerplate code. It
-will also put the rule into the list of checks and call `generateRuleMetadata` to download the rule's metadata.
+will also put the rule into the list of checks and call `ruleApiGenerateRuleKotlin` to download the rule's metadata.
 
 To use this task, you need to know the rule key and a fitting name for the check class. For instance, if you want to implement the new
 rule `S42` in the class `AnswersEverythingCheck`, you can call the following in the root of the project:

--- a/README.md
+++ b/README.md
@@ -63,18 +63,63 @@ To run a single ruling test method, e.g.:
 
 ### Updating ruling golden files
 
-The ruling tests diff actual scanner output against golden files under
-`its/ruling/src/integrationTest/resources/expected/`. After changing a rule, update the
-affected golden files:
+The ruling tests diff actual scanner output against golden files. After changing a rule,
+update the golden files for every corpus that exercises it.
 
-1. Run the ruling tests — actual results are always written to `its/ruling/build/reports/ruling/`
-   even when the tests fail.
+#### Standard corpora (corda, okio, intellij-rust, …)
+
+Golden files live under `its/ruling/src/integrationTest/resources/expected/`.
+Actual results are always written to `its/ruling/build/reports/ruling/` even when tests fail.
+
+1. Run the ruling tests:
+
+       ./gradlew :its:ruling:integrationTest --info --console=plain --no-daemon
+
 2. Copy the updated file(s) for the affected rule(s):
 
        cp its/ruling/build/reports/ruling/<corpus>/kotlin-S<NNNN>.json \
           its/ruling/src/integrationTest/resources/expected/kotlin/<corpus>/kotlin-S<NNNN>.json
 
-3. Re-run the ruling tests to confirm they pass.
+3. Re-run to confirm they pass.
+
+#### kotlin corpus (`test_kotlin_compiler`)
+
+This corpus is skipped by default because it requires heavy Kotlin compiler sources.
+Enable it with an environment variable:
+
+    KOTLIN_COMPILER_IT_ENABLED=true ./gradlew :its:ruling:integrationTest --info --console=plain --no-daemon
+
+Actual results land in the same `its/ruling/build/reports/ruling/kotlin/` directory.
+Update golden files the same way as for the standard corpora.
+
+#### kotlin-language-server corpus (`test_kotlin_language_server`)
+
+This corpus is run by the `qa_sq_integration` CI job, not the `qa_ruling` job.
+Golden files live under `its/sq-integration/src/integrationTest/resources/expected/kotlin/kotlin-language-server/`.
+Actual results are written to `its/sq-integration/build/tmp/actual/kotlin/kotlin-language-server/` during the run.
+
+1. Run the sq-integration tests:
+
+       ./gradlew :its:sq-integration:integrationTest --info --console=plain --no-daemon -Dsonar.runtimeVersion=DEV
+
+2. Copy the updated golden files:
+
+       cp its/sq-integration/build/tmp/actual/kotlin/kotlin-language-server/kotlin-S<NNNN>.json \
+          its/sq-integration/src/integrationTest/resources/expected/kotlin/kotlin-language-server/kotlin-S<NNNN>.json
+
+3. Re-run to confirm they pass.
+
+### Additional ruling parameters
+
+* `-DreportAll=true` — dump all actual issues instead of only the differences
+  (supported by `:its:ruling:integrationTest` and `:its:sq-integration:integrationTest`).
+
+The orchestrator-based `:its:sq-integration` tests additionally support:
+
+* `-Dsonar.runtimeVersion=<version>` — override the SonarQube version (default: `DEV`)
+* `-DcleanProjects=true` — force a clean build of the analysed projects
+* `-DkeepSonarqubeRunning=true` — leave the SonarQube instance running after the analysis
+* `-Dsonar.rulingDebugPort=5005` — attach a debugger to the spawned scanner JVM
 
 ## Utilities and Developing
 

--- a/README.md
+++ b/README.md
@@ -71,17 +71,6 @@ update the golden files for every corpus that exercises it.
 Golden files live under `its/ruling/src/integrationTest/resources/expected/`.
 Actual results are always written to `its/ruling/build/reports/ruling/` even when tests fail.
 
-1. Run the ruling tests:
-
-       ./gradlew :its:ruling:integrationTest --info --console=plain --no-daemon
-
-2. Copy the updated file(s) for the affected rule(s):
-
-       cp its/ruling/build/reports/ruling/<corpus>/kotlin-S<NNNN>.json \
-          its/ruling/src/integrationTest/resources/expected/kotlin/<corpus>/kotlin-S<NNNN>.json
-
-3. Re-run to confirm they pass.
-
 #### kotlin corpus (`test_kotlin_compiler`)
 
 This corpus is skipped by default because it requires heavy Kotlin compiler sources.
@@ -90,24 +79,12 @@ Enable it with an environment variable:
     KOTLIN_COMPILER_IT_ENABLED=true ./gradlew :its:ruling:integrationTest --info --console=plain --no-daemon
 
 Actual results land in the same `its/ruling/build/reports/ruling/kotlin/` directory.
-Update golden files the same way as for the standard corpora.
 
 #### kotlin-language-server corpus (`test_kotlin_language_server`)
 
 This corpus is run by the `qa_sq_integration` CI job, not the `qa_ruling` job.
 Golden files live under `its/sq-integration/src/integrationTest/resources/expected/kotlin/kotlin-language-server/`.
 Actual results are written to `its/sq-integration/build/tmp/actual/kotlin/kotlin-language-server/` during the run.
-
-1. Run the sq-integration tests:
-
-       ./gradlew :its:sq-integration:integrationTest --info --console=plain --no-daemon -Dsonar.runtimeVersion=DEV
-
-2. Copy the updated golden files:
-
-       cp its/sq-integration/build/tmp/actual/kotlin/kotlin-language-server/kotlin-S<NNNN>.json \
-          its/sq-integration/src/integrationTest/resources/expected/kotlin/kotlin-language-server/kotlin-S<NNNN>.json
-
-3. Re-run to confirm they pass.
 
 ### Additional ruling parameters
 


### PR DESCRIPTION
- Replace stale -Pits/-Pruling/-Pplugin flags (which are no-ops) with correct direct task invocations: :its:ruling:integrationTest and :its:plugin:integrationTest
- Fix generateRuleMetadata → :sonar-kotlin-plugin:ruleApiGenerateRuleKotlin and updateRuleMetadata → :sonar-kotlin-plugin:ruleApiUpdateKotlin
- Added Vortex analysis section in CLAUDE.md

