### PR TITLE
SONARKT-814 S6518 Fix FPs for Java overloads and `set()` return values

### DIFF
--- a/its/ruling/src/integrationTest/resources/expected/kotlin/corda/kotlin-S6518.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/corda/kotlin-S6518.json
@@ -12,17 +12,9 @@
 146
 ],
 "kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt": [
-218,
-227,
-257
+218
 ],
 "kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt": [
 143
-],
-"kotlin-corda-project:sources/kotlin/corda/serialization/src/main/kotlin/net/corda/serialization/internal/ByteBufferStreams.kt": [
-41
-],
-"kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationOutputTests.kt": [
-1158
 ]
 }

--- a/its/ruling/src/integrationTest/resources/expected/kotlin/kotlin/kotlin-S6518.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/kotlin/kotlin-S6518.json
@@ -64,8 +64,5 @@
 152,
 156,
 452
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/source-sections/source-sections-compiler/src/org/jetbrains/kotlin/sourceSections/FilteredSectionsVirtualFile.kt": [
-68
 ]
 }

--- a/its/ruling/src/integrationTest/resources/expected/kotlin/okio/kotlin-S6518.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/okio/kotlin-S6518.json
@@ -1,5 +1,1 @@
-{
-"kotlin-okio-project:sources/kotlin/okio/okio/jvm/src/main/java/okio/Buffer.kt": [
-1045
-]
-}
+{}

--- a/kotlin-checks-test-sources/src/main/java/android/util/LongSparseArray.java
+++ b/kotlin-checks-test-sources/src/main/java/android/util/LongSparseArray.java
@@ -1,0 +1,7 @@
+package android.util;
+
+public class LongSparseArray<E> {
+  public E get(long key) { return null; }
+  public E get(long key, E defaultValue) { return defaultValue; }
+  public void set(long key, E value) { }
+}

--- a/kotlin-checks-test-sources/src/main/java/android/util/SparseArray.java
+++ b/kotlin-checks-test-sources/src/main/java/android/util/SparseArray.java
@@ -1,0 +1,7 @@
+package android.util;
+
+public class SparseArray<E> {
+  public E get(int key) { return null; }
+  public E get(int key, E defaultValue) { return defaultValue; }
+  public void set(int key, E value) { }
+}

--- a/kotlin-checks-test-sources/src/main/java/android/util/SparseBooleanArray.java
+++ b/kotlin-checks-test-sources/src/main/java/android/util/SparseBooleanArray.java
@@ -1,0 +1,7 @@
+package android.util;
+
+public class SparseBooleanArray {
+  public boolean get(int key) { return false; }
+  public boolean get(int key, boolean defaultValue) { return defaultValue; }
+  public void set(int key, boolean value) { }
+}

--- a/kotlin-checks-test-sources/src/main/java/android/util/SparseIntArray.java
+++ b/kotlin-checks-test-sources/src/main/java/android/util/SparseIntArray.java
@@ -1,0 +1,7 @@
+package android.util;
+
+public class SparseIntArray {
+  public int get(int key) { return 0; }
+  public int get(int key, int defaultValue) { return defaultValue; }
+  public void set(int key, int value) { }
+}

--- a/kotlin-checks-test-sources/src/main/java/android/util/SparseLongArray.java
+++ b/kotlin-checks-test-sources/src/main/java/android/util/SparseLongArray.java
@@ -1,0 +1,7 @@
+package android.util;
+
+public class SparseLongArray {
+  public long get(int key) { return 0L; }
+  public long get(int key, long defaultValue) { return defaultValue; }
+  public void set(int key, long value) { }
+}

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/IndexedAccessCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/IndexedAccessCheckSample.kt
@@ -1,9 +1,15 @@
 package checks
 
+import android.util.LongSparseArray
+import android.util.SparseArray
+import android.util.SparseBooleanArray
+import android.util.SparseIntArray
+import android.util.SparseLongArray
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.RangeMap
 import com.google.common.collect.Table
 import java.nio.ByteBuffer
+import java.nio.CharBuffer
 import java.util.BitSet
 import java.util.Calendar
 import java.util.Stack
@@ -11,6 +17,8 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicIntegerArray
+import java.util.concurrent.atomic.AtomicLongArray
+import java.util.concurrent.atomic.AtomicReferenceArray
 import okhttp3.Headers
 import otherpackage.KotlinLibContainer
 import otherpackage.get
@@ -25,6 +33,8 @@ class IndexedAccessCheckSample {
         buffer: ByteBuffer,
         stack: Stack<String>,
         atomicArray: AtomicIntegerArray,
+        atomicLongArray: AtomicLongArray,
+        atomicReferenceArray: AtomicReferenceArray<String>,
         bitSet: BitSet,
         arrayList: ArrayList<Int>,
         hashMap: HashMap<String, Int>,
@@ -44,6 +54,10 @@ class IndexedAccessCheckSample {
         stack.get(0) // Noncompliant {{Replace function call with indexed accessor.}}
         atomicArray.get(0) // Noncompliant {{Replace function call with indexed accessor.}}
         atomicArray.set(0, 42) // Noncompliant {{Replace function call with indexed accessor.}}
+        atomicLongArray.get(0) // Noncompliant {{Replace function call with indexed accessor.}}
+        atomicLongArray.set(0, 42L) // Noncompliant {{Replace function call with indexed accessor.}}
+        atomicReferenceArray.get(0) // Noncompliant {{Replace function call with indexed accessor.}}
+        atomicReferenceArray.set(0, "value") // Noncompliant {{Replace function call with indexed accessor.}}
         bitSet.get(5) // Noncompliant {{Replace function call with indexed accessor.}}
         bitSet.set(5, true) // Noncompliant {{Replace function call with indexed accessor.}}
         // Concrete Java collection implementations - caught via List/Map supertype check
@@ -58,6 +72,46 @@ class IndexedAccessCheckSample {
         cal.get(Calendar.YEAR) // Compliant - Java interop operator, not in allowed types
         cal.set(Calendar.YEAR, 2024) // Compliant - Java interop operator, not in allowed types
         future.get(1L, TimeUnit.SECONDS) // Compliant - Java interop operator, not in allowed types
+    }
+
+    fun bufferBulkReads(byteBuffer: ByteBuffer, charBuffer: CharBuffer, bytes: ByteArray, chars: CharArray) {
+        byteBuffer.get(bytes) // Compliant - copies into the destination instead of selecting an element
+        byteBuffer.get(bytes, 0, bytes.size) // Compliant - relative bulk read
+        byteBuffer.get(0, bytes) // Compliant - absolute bulk read
+        byteBuffer.get(0, bytes, 0, bytes.size) // Compliant - absolute bulk read with destination range
+        charBuffer.get(chars) // Compliant - all Buffer specializations follow the same signature rules
+        charBuffer.get(0) // Noncompliant {{Replace function call with indexed accessor.}}
+    }
+
+    fun bitSetRanges(bitSet: BitSet) {
+        bitSet.get(1, 4) // Compliant - returns a range, not the element at two indexes
+        bitSet.set(1) // Compliant - cannot be expressed as indexed assignment
+        bitSet.set(1, 4) // Compliant - sets a range to true
+        bitSet.set(1, 4, false) // Compliant - sets a range to a value
+    }
+
+    fun androidSparseArrays(
+        sparseArray: SparseArray<String>,
+        sparseIntArray: SparseIntArray,
+        sparseBooleanArray: SparseBooleanArray,
+        sparseLongArray: SparseLongArray,
+        longSparseArray: LongSparseArray<String>,
+    ) {
+        sparseArray.get(1) // Noncompliant {{Replace function call with indexed accessor.}}
+        sparseArray.get(1, "default") // Compliant - the second argument is a default value
+        sparseArray.set(1, "value") // Noncompliant {{Replace function call with indexed accessor.}}
+        sparseIntArray.get(1) // Noncompliant {{Replace function call with indexed accessor.}}
+        sparseIntArray.get(1, 42) // Compliant - the second argument is a default value
+        sparseIntArray.set(1, 42) // Noncompliant {{Replace function call with indexed accessor.}}
+        sparseBooleanArray.get(1) // Noncompliant {{Replace function call with indexed accessor.}}
+        sparseBooleanArray.get(1, false) // Compliant - the second argument is a default value
+        sparseBooleanArray.set(1, true) // Noncompliant {{Replace function call with indexed accessor.}}
+        sparseLongArray.get(1) // Noncompliant {{Replace function call with indexed accessor.}}
+        sparseLongArray.get(1, 42L) // Compliant - the second argument is a default value
+        sparseLongArray.set(1, 42L) // Noncompliant {{Replace function call with indexed accessor.}}
+        longSparseArray.get(1L) // Noncompliant {{Replace function call with indexed accessor.}}
+        longSparseArray.get(1L, "default") // Compliant - the second argument is a default value
+        longSparseArray.set(1L, "value") // Noncompliant {{Replace function call with indexed accessor.}}
     }
 
     fun kotlinLibraryTypes(container: KotlinLibContainer<String>, headers: Headers) {
@@ -192,16 +246,29 @@ class ChainableMap {
     fun size(): Int = 0
 }
 
-fun chainedSetters(builder: ChainableBuilder, chainableMap: ChainableMap) {
-    builder.set("a", "1").set("b", "2").set("c", "3") // Noncompliant {{Replace function call with indexed accessor.}}
-    //                                  ^^^
-    builder.set("a", "1").set("b", "2") // Noncompliant {{Replace function call with indexed accessor.}}
-    //                    ^^^
+fun setCallUsages(builder: ChainableBuilder, chainableMap: ChainableMap, list: MutableList<Int>) {
+    builder.set("standalone", "value") // Noncompliant {{Replace function call with indexed accessor.}}
+    builder.set("a", "1").set("b", "2").set("c", "3") // Compliant - every set belongs to the same fluent chain
+    builder.set("a", "1").set("b", "2") // Compliant - terminal set is preceded by another set
+    (builder.set("a", "1")).set("b", "2") // Compliant - parentheses do not break the setter chain
+    (builder.`set`("a", "1") as ChainableBuilder).set("b", "2") // Compliant - casts and backticks do not break the setter chain
+    builder.set("a", "1")!!.set("b", "2") // Compliant - non-null assertions do not break the setter chain
     builder.set("a", "1").build() // Compliant - set result used in chain
+    val setResult = builder.set("a", "1") // Compliant - set result is assigned
+    consumeBuilder(builder.set("a", "1")) // Compliant - set result is passed as an argument
+    val previousValue = list.set(0, 42) // Compliant - indexed assignment would discard the returned old value
+    consumeInt(previousValue)
 
     builder.get("a").length // Noncompliant {{Replace function call with indexed accessor.}}
 
-    chainableMap.set("a", 1).set("b", 2) // Noncompliant {{Replace function call with indexed accessor.}}
+    chainableMap.set("a", 1).set("b", 2) // Compliant - terminal set is preceded by another set
     chainableMap.set("a", 1).size() // Compliant - set result used in chain
+
+    createBuilder().set("a", "1") // Noncompliant {{Replace function call with indexed accessor.}}
 }
 
+fun consumeBuilder(builder: ChainableBuilder) = Unit
+
+fun createBuilder() = ChainableBuilder()
+
+fun consumeInt(value: Int) = Unit

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/IndexedAccessCheckSampleNoSemantics.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/IndexedAccessCheckSampleNoSemantics.kt
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList
 import com.google.common.collect.RangeMap
 import com.google.common.collect.Table
 import java.nio.ByteBuffer
+import java.nio.CharBuffer
 import java.util.BitSet
 import java.util.Calendar
 import java.util.Stack
@@ -11,6 +12,8 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicIntegerArray
+import java.util.concurrent.atomic.AtomicLongArray
+import java.util.concurrent.atomic.AtomicReferenceArray
 import okhttp3.Headers
 import otherpackage.KotlinLibContainer
 import otherpackage.get
@@ -25,6 +28,8 @@ class IndexedAccessCheckSampleNoSemantics {
         buffer: ByteBuffer,
         stack: Stack<String>,
         atomicArray: AtomicIntegerArray,
+        atomicLongArray: AtomicLongArray,
+        atomicReferenceArray: AtomicReferenceArray<String>,
         bitSet: BitSet,
         arrayList: ArrayList<Int>,
         hashMap: HashMap<String, Int>,
@@ -43,6 +48,10 @@ class IndexedAccessCheckSampleNoSemantics {
         stack.get(0) // Noncompliant {{Replace function call with indexed accessor.}}
         atomicArray.get(0) // Noncompliant {{Replace function call with indexed accessor.}}
         atomicArray.set(0, 42) // Noncompliant {{Replace function call with indexed accessor.}}
+        atomicLongArray.get(0) // Noncompliant {{Replace function call with indexed accessor.}}
+        atomicLongArray.set(0, 42L) // Noncompliant {{Replace function call with indexed accessor.}}
+        atomicReferenceArray.get(0) // Noncompliant {{Replace function call with indexed accessor.}}
+        atomicReferenceArray.set(0, "value") // Noncompliant {{Replace function call with indexed accessor.}}
         bitSet.get(5) // Noncompliant {{Replace function call with indexed accessor.}}
         bitSet.set(5, true) // Noncompliant {{Replace function call with indexed accessor.}}
         // Concrete Java collection implementations - caught via List/Map supertype check with semantics
@@ -56,6 +65,22 @@ class IndexedAccessCheckSampleNoSemantics {
         cal.get(Calendar.YEAR) // Compliant - Java interop operator, not in allowed types
         cal.set(Calendar.YEAR, 2024) // Compliant - Java interop operator, not in allowed types
         future.get(1L, TimeUnit.SECONDS) // Compliant - Java interop operator, not in allowed types
+    }
+
+    fun bufferBulkReads(byteBuffer: ByteBuffer, charBuffer: CharBuffer, bytes: ByteArray, chars: CharArray) {
+        byteBuffer.get(bytes) // Compliant - copies into the destination instead of selecting an element
+        byteBuffer.get(bytes, 0, bytes.size) // Compliant - relative bulk read
+        byteBuffer.get(0, bytes) // Compliant - absolute bulk read
+        byteBuffer.get(0, bytes, 0, bytes.size) // Compliant - absolute bulk read with destination range
+        charBuffer.get(chars) // Compliant - all Buffer specializations follow the same signature rules
+        charBuffer.get(0) // Noncompliant {{Replace function call with indexed accessor.}}
+    }
+
+    fun bitSetRanges(bitSet: BitSet) {
+        bitSet.get(1, 4) // Compliant - returns a range, not the element at two indexes
+        bitSet.set(1) // Compliant - cannot be expressed as indexed assignment
+        bitSet.set(1, 4) // Compliant - sets a range to true
+        bitSet.set(1, 4, false) // Compliant - sets a range to a value
     }
 
     fun kotlinLibraryTypes(container: KotlinLibContainer<String>, headers: Headers) {
@@ -194,15 +219,29 @@ class ChainableMap2 {
     fun size(): Int = 0
 }
 
-fun chainedSetters2(builder: ChainableBuilder2, chainableMap: ChainableMap2) {
-    builder.set("a", "1").set("b", "2").set("c", "3") // Noncompliant {{Replace function call with indexed accessor.}}
-    //                                  ^^^
-    builder.set("a", "1").set("b", "2") // Noncompliant {{Replace function call with indexed accessor.}}
-    //                    ^^^
+fun setCallUsages2(builder: ChainableBuilder2, chainableMap: ChainableMap2, list: MutableList<Int>) {
+    builder.set("standalone", "value") // Noncompliant {{Replace function call with indexed accessor.}}
+    builder.set("a", "1").set("b", "2").set("c", "3") // Compliant - every set belongs to the same fluent chain
+    builder.set("a", "1").set("b", "2") // Compliant - terminal set is preceded by another set
+    (builder.set("a", "1")).set("b", "2") // Compliant - parentheses do not break the setter chain
+    (builder.`set`("a", "1") as ChainableBuilder2).set("b", "2") // Compliant - casts and backticks do not break the setter chain
+    builder.set("a", "1")!!.set("b", "2") // Compliant - non-null assertions do not break the setter chain
     builder.set("a", "1").build() // Compliant - set result used in chain
+    val setResult = builder.set("a", "1") // Compliant - set result is assigned
+    consumeBuilder2(builder.set("a", "1")) // Compliant - set result is passed as an argument
+    val previousValue = list.set(0, 42) // Compliant - indexed assignment would discard the returned old value
+    consumeInt2(previousValue)
 
     builder.get("a").length // Noncompliant {{Replace function call with indexed accessor.}}
 
-    chainableMap.set("a", 1).set("b", 2) // Noncompliant {{Replace function call with indexed accessor.}}
+    chainableMap.set("a", 1).set("b", 2) // Compliant - terminal set is preceded by another set
     chainableMap.set("a", 1).size() // Compliant - set result used in chain
+
+    createBuilder2().set("a", "1") // Noncompliant {{Replace function call with indexed accessor.}}
 }
+
+fun consumeBuilder2(builder: ChainableBuilder2) = Unit
+
+fun createBuilder2() = ChainableBuilder2()
+
+fun consumeInt2(value: Int) = Unit

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IndexedAccessCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/IndexedAccessCheck.kt
@@ -19,9 +19,16 @@ package org.sonarsource.kotlin.checks
 import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
+import org.jetbrains.kotlin.analysis.api.symbols.name
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtPostfixExpression
+import org.jetbrains.kotlin.psi.KtPsiUtil.deparenthesize
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 import org.jetbrains.kotlin.psi.KtSuperExpression
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.CallAbstractCheck
@@ -37,36 +44,82 @@ class IndexedAccessCheck : CallAbstractCheck() {
     companion object {
         private val LIST_CLASS_ID = ClassId.fromString("kotlin/collections/List")
         private val MAP_CLASS_ID = ClassId.fromString("kotlin/collections/Map")
+        private val ANY_PARAMETER_TYPE: String? = null
 
-        /**
-         * Java classes where indexed access operator syntax is idiomatic in Kotlin.
-         * For these types, we still raise even though the operator comes from Java interop.
-         *
-         * Note: concrete List/Map implementations (ArrayList, HashMap, Vector, etc.) are handled
-         * separately via a supertype check against kotlin.collections.List and kotlin.collections.Map.
-         */
-        private val JAVA_INTEROP_ALLOWED_TYPES = setOf(
-            // NIO Buffer types - get(index) is natural indexed access
-            "java.nio.ByteBuffer",
-            "java.nio.CharBuffer",
-            "java.nio.ShortBuffer",
-            "java.nio.IntBuffer",
-            "java.nio.LongBuffer",
-            "java.nio.FloatBuffer",
-            "java.nio.DoubleBuffer",
-            // BitSet - get(index)/set(index, value) is natural indexed access
-            "java.util.BitSet",
-            // Atomic arrays - get/set by index is natural
-            "java.util.concurrent.atomic.AtomicIntegerArray",
-            "java.util.concurrent.atomic.AtomicLongArray",
-            "java.util.concurrent.atomic.AtomicReferenceArray",
-            // Android sparse arrays - get/set by key is natural
-            "android.util.SparseArray",
-            "android.util.SparseIntArray",
-            "android.util.SparseBooleanArray",
-            "android.util.SparseLongArray",
-            "android.util.LongSparseArray",
+        private data class JavaInteropMethodSignature(
+            val name: String,
+            val parameterTypes: List<String?>,
+        ) {
+            fun matches(name: String, parameterTypes: List<String?>): Boolean =
+                this.name == name &&
+                    this.parameterTypes.size == parameterTypes.size &&
+                    this.parameterTypes.zip(parameterTypes).all { (expected, actual) -> expected == null || expected == actual }
+        }
+
+        private data class JavaInteropMethodGroup(
+            val receiverTypes: Set<String>,
+            val signatures: Set<JavaInteropMethodSignature>,
+        ) {
+            fun allows(receiverType: String?, name: String, parameterTypes: List<String?>): Boolean =
+                receiverType in receiverTypes && signatures.any { it.matches(name, parameterTypes) }
+        }
+
+        private fun signature(name: String, vararg parameterTypes: String?) =
+            JavaInteropMethodSignature(name, parameterTypes.toList())
+
+        /** Java receiver types and the exact operator-shaped methods that are idiomatic indexed access in Kotlin. */
+        private val JAVA_INTEROP_METHOD_ALLOW_LIST = listOf(
+            JavaInteropMethodGroup(
+                receiverTypes = setOf(
+                    "java.nio.ByteBuffer",
+                    "java.nio.CharBuffer",
+                    "java.nio.ShortBuffer",
+                    "java.nio.IntBuffer",
+                    "java.nio.LongBuffer",
+                    "java.nio.FloatBuffer",
+                    "java.nio.DoubleBuffer",
+                ),
+                signatures = setOf(signature("get", "kotlin.Int")),
+            ),
+            JavaInteropMethodGroup(
+                receiverTypes = setOf("java.util.BitSet"),
+                signatures = setOf(
+                    signature("get", "kotlin.Int"),
+                    signature("set", "kotlin.Int", "kotlin.Boolean"),
+                ),
+            ),
+            JavaInteropMethodGroup(
+                receiverTypes = setOf(
+                    "java.util.concurrent.atomic.AtomicIntegerArray",
+                    "java.util.concurrent.atomic.AtomicLongArray",
+                    "java.util.concurrent.atomic.AtomicReferenceArray",
+                ),
+                signatures = setOf(
+                    signature("get", "kotlin.Int"),
+                    signature("set", "kotlin.Int", ANY_PARAMETER_TYPE),
+                ),
+            ),
+            JavaInteropMethodGroup(
+                receiverTypes = setOf(
+                    "android.util.SparseArray",
+                    "android.util.SparseIntArray",
+                    "android.util.SparseBooleanArray",
+                    "android.util.SparseLongArray",
+                ),
+                signatures = setOf(
+                    signature("get", "kotlin.Int"),
+                    signature("set", "kotlin.Int", ANY_PARAMETER_TYPE),
+                ),
+            ),
+            JavaInteropMethodGroup(
+                receiverTypes = setOf("android.util.LongSparseArray"),
+                signatures = setOf(
+                    signature("get", "kotlin.Long"),
+                    signature("set", "kotlin.Long", ANY_PARAMETER_TYPE),
+                ),
+            ),
         )
+
     }
 
     override val functionsToVisit = listOf(
@@ -84,22 +137,36 @@ class IndexedAccessCheck : CallAbstractCheck() {
         val dotExpression = callExpression.parent as? KtDotQualifiedExpression ?: return
         if (dotExpression.receiverExpression is KtSuperExpression) return
         if (callExpression.typeArgumentList != null) return
-        if(callExpression.valueArguments.any {  it.isNamed() }) return
-        if (isChainedSetCall(callExpression, dotExpression)) return
-        if (isJavaInteropOperator(resolvedCall) && !isAllowedJavaInteropType(resolvedCall)) return
+        if (callExpression.valueArguments.any { it.isNamed() }) return
+        if (isSetCallWhoseResultMustBePreserved(callExpression, dotExpression, resolvedCall)) return
+        if (isJavaInteropOperator(resolvedCall) && !isAllowedJavaInteropMethod(resolvedCall)) return
         kotlinFileContext.reportIssue(callExpression.calleeExpression!!, "Replace function call with indexed accessor.")
     }
 
     /**
-     * Checks whether a `set` call is part of a method chain, meaning its return value is used
-     * for further chaining. For example, in `builder.set("a", "1").set("b", "2")`, the inner
-     * `builder.set("a", "1")` is the receiver of the outer dot-qualified expression. Replacing
-     * such calls with indexed access operators would break the chain.
+     * Indexed assignment evaluates to Unit, so a `set` call cannot be replaced when its return
+     * value is used. The terminal call in a setter chain is suppressed as well: reporting only
+     * that call would suggest a misleading mixture of fluent and indexed syntax.
      */
-    private fun isChainedSetCall(callExpression: KtCallExpression, dotExpression: KtDotQualifiedExpression): Boolean {
-        if (callExpression.calleeExpression?.text != "set") return false
-        val parent = dotExpression.parent as? KtDotQualifiedExpression ?: return false
-        return parent.receiverExpression == dotExpression
+    private fun isSetCallWhoseResultMustBePreserved(
+        callExpression: KtCallExpression,
+        dotExpression: KtDotQualifiedExpression,
+        resolvedCall: KaFunctionCall<*>,
+    ): Boolean = withKaSession {
+        if (resolvedCall.symbol.name?.asString() != "set") return false
+        return callExpression.isUsedAsExpression || dotExpression.receiverExpression.containsSetCall()
+    }
+
+    private fun KtExpression.containsSetCall(): Boolean = when (val expression = deparenthesize(this)) {
+        is KtBinaryExpressionWithTypeRHS -> expression.left.containsSetCall()
+        is KtPostfixExpression ->
+            expression.operationToken == KtTokens.EXCLEXCL && expression.baseExpression?.containsSetCall() == true
+        is KtDotQualifiedExpression -> {
+            val selectorCall = expression.selectorExpression as? KtCallExpression
+            val selectorName = (selectorCall?.calleeExpression as? KtSimpleNameExpression)?.getReferencedName()
+            selectorName == "set" || expression.receiverExpression.containsSetCall()
+        }
+        else -> false
     }
 
     /**
@@ -113,13 +180,18 @@ class IndexedAccessCheck : CallAbstractCheck() {
     }
 
     /**
-     * Checks whether the receiver type of the resolved function is in the allow-list
-     * of Java types where indexed access operator syntax is idiomatic.
+     * Kotlin treats every suitably named Java `get` or `set` method as operator-shaped. Accept the
+     * explicitly allow-listed element-access signatures, as well as any operator-shaped overload
+     * on a List or Map subtype.
      */
-    private fun isAllowedJavaInteropType(resolvedCall: KaFunctionCall<*>): Boolean = withKaSession {
+    private fun isAllowedJavaInteropMethod(resolvedCall: KaFunctionCall<*>): Boolean = withKaSession {
         val type = (resolvedCall.dispatchReceiver ?: resolvedCall.extensionReceiver)?.type ?: return false
-        if (type.asFqNameString() in JAVA_INTEROP_ALLOWED_TYPES) return true
-        // Any List or Map implementation supports idiomatic indexed access
-        return type.isSubtypeOf(LIST_CLASS_ID) || type.isSubtypeOf(MAP_CLASS_ID)
+        val receiverType = type.asFqNameString()
+        val name = resolvedCall.symbol.name?.asString() ?: return false
+        val parameterTypes = resolvedCall.signature.valueParameters.map { it.returnType.asFqNameString() }
+
+        return JAVA_INTEROP_METHOD_ALLOW_LIST.any { it.allows(receiverType, name, parameterTypes) } ||
+            // Any List or Map implementation supports idiomatic indexed access
+            type.isSubtypeOf(LIST_CLASS_ID) || type.isSubtypeOf(MAP_CLASS_ID)
     }
 }


### PR DESCRIPTION
Fix false positives in S6518 when explicit `get`/`set` calls cannot
safely or meaningfully be replaced with indexed access syntax.

1. Filter Java interoperability methods by resolved signature:
   - Ignore NIO Buffer bulk reads.
   - Ignore BitSet range operations.
   - Ignore Android sparse-array getters with default values.
   - Preserve support for atomic arrays and genuine indexed operations.

2. Preserve return-value-using and chained `set()` calls:
   - Ignore `set()` calls whose return value is assigned, returned, passed as an argument, or used for further calls.
   - Ignore terminal setters preceded by another setter in the same chain, because reporting only the terminal call would suggest rewrites such as `builder.set(first, value).set(second, otherValue)` -> `builder.set(first, value)[second] = otherValue`. Arguably the set chain looks better (is more consistent).

Part of AT-82
