### PR TITLE
SONARKT-816 S6619 Fix FP on nullable projections and FP on expression with safe-call operators

### DIFF
--- a/its/ruling/src/integrationTest/resources/expected/kotlin/kotlin/kotlin-S6619.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/kotlin/kotlin-S6619.json
@@ -5,9 +5,6 @@
 "kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/render.kt": [
 201
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt": [
-361
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt": [
 164
 ],
@@ -16,22 +13,6 @@
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt": [
 143
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/CapturedVarsOptimizationMethodTransformer.kt": [
-157,
-183
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/DeadCodeEliminationMethodTransformer.kt": [
-65,
-83
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/PopBackwardPropagationTransformer.kt": [
-90
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/RedundantBoxingMethodTransformer.kt": [
-70,
-159,
-167
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/JvmRuntimeVersionsConsistencyChecker.kt": [
 338
@@ -116,9 +97,6 @@
 "kotlin-kotlin-project:sources/kotlin/kotlin/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/ClassDeserializer.kt": [
 44
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/eval4j/src/org/jetbrains/eval4j/interpreterLoop.kt": [
-97
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt": [
 609,
 625
@@ -141,9 +119,6 @@
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/project/Platform.kt": [
 165
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/referenceUtil.kt": [
-273
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/search/usagesSearch/operators/InvokeOperatorReferenceSearcher.kt": [
 54
 ],
@@ -156,17 +131,7 @@
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt": [
 157,
-160,
-245,
-268,
-356,
-746
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionSession.kt": [
-372
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/FromUnresolvedNamesCompletion.kt": [
-44
+160
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KeywordValues.kt": [
 97
@@ -355,10 +320,6 @@
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/kotlin-jsr223-local-example/src/test/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223ScriptEngineIT.kt": [
 137
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/common/src/generated/_Arrays.kt": [
-1250,
-1780
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jdk8/test/collections/MapTest.kt": [
 139,

--- a/its/sq-integration/src/integrationTest/resources/expected/kotlin/kotlin-language-server/kotlin-S6619.json
+++ b/its/sq-integration/src/integrationTest/resources/expected/kotlin/kotlin-language-server/kotlin-S6619.json
@@ -1,5 +1,1 @@
-{
-"kotlin-kotlin-language-server-project:shared/src/main/kotlin/org/javacs/kt/Logger.kt": [
-153
-]
-}
+{}

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/UselessNullCheckCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/UselessNullCheckCheckSample.kt
@@ -147,3 +147,14 @@ class NullableGeneric {
     infix fun contract(block: () -> Unit) { }
     infix fun <T> T.implies(value: Boolean) { }
 }
+
+private class CapturedNullableTypeRegressionTests {
+    private fun nullableVararg(vararg values: String?): String =
+        values[0] ?: "fallback" // Compliant: regression test
+
+    private fun nullableVarargRequireNotNull(vararg values: String?): String =
+        requireNotNull(values[0]) // Compliant: regression test
+
+    private fun projectedNullableArray(values: Array<out String?>): String =
+        values[0] ?: "fallback" // Compliant: regression test
+}

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/UselessNullCheckCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/UselessNullCheckCheckSample.kt
@@ -157,6 +157,9 @@ private class CapturedNullableTypeRegressionTests {
 
     private fun projectedNullableArray(values: Array<out String?>): String =
         values[0] ?: "fallback" // Compliant: regression test
+
+    private fun projectedNullableArrayRequireNotNull(values: Array<out String?>): String =
+        requireNotNull(values[0]) // Compliant: regression test
 }
 
 private class SafeCallConventionOperatorRegressionTests {
@@ -179,4 +182,8 @@ private class SafeCallConventionOperatorRegressionTests {
 
     private fun increment(container: Container?): Int =
         container?.number++ ?: -1 // Compliant: regression test
+
+    private fun nestedElvis(nonNullValue: String, container: Container?): String =
+        nonNullValue ?: container?.list[0] ?: "fallback" // Noncompliant {{Remove this useless elvis operation `?:`, it always succeeds.}}
+//                   ^^
 }

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/UselessNullCheckCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/UselessNullCheckCheckSample.kt
@@ -158,3 +158,25 @@ private class CapturedNullableTypeRegressionTests {
     private fun projectedNullableArray(values: Array<out String?>): String =
         values[0] ?: "fallback" // Compliant: regression test
 }
+
+private class SafeCallConventionOperatorRegressionTests {
+    private interface Container {
+        val list: List<String>
+        var number: Int
+    }
+
+    private fun elvis(container: Container?): String =
+        container?.list[0] ?: "fallback" // Compliant: regression test
+
+    private fun assertion(container: Container?): String =
+        container?.list[0]!! // Compliant: regression test
+
+    private fun safeAccess(container: Container?): Int? =
+        container?.list[0]?.length // Compliant: regression test
+
+    private fun comparison(container: Container?): Boolean =
+        container?.list[0] != null // Compliant: regression test
+
+    private fun increment(container: Container?): Int =
+        container?.number++ ?: -1 // Compliant: regression test
+}

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.analysis.api.symbols.name
 import org.jetbrains.kotlin.analysis.api.types.KaErrorType
 import org.jetbrains.kotlin.analysis.api.types.KaTypeParameterType
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -50,13 +51,25 @@ class UselessNullCheckCheck : AbstractCheck() {
     override fun visitBinaryExpression(binaryExpression: KtBinaryExpression, kotlinFileContext: KotlinFileContext) {
         when (binaryExpression.operationToken) {
             KtTokens.EQEQ -> binaryExpression.operandComparedToNull()?.let {
-                raiseIssueIfUselessCheck(kotlinFileContext, it, binaryExpression, comparesToNull = true) {
+                raiseIssueIfUselessCheck(
+                    kotlinFileContext,
+                    it,
+                    binaryExpression,
+                    comparesToNull = true,
+                    requiredCompilerDiagnosticName = FirErrors.SENSELESS_COMPARISON.name,
+                ) {
                     +"null check"
                 }
             }
 
             KtTokens.EXCLEQ -> binaryExpression.operandComparedToNull()?.let {
-                raiseIssueIfUselessCheck(kotlinFileContext, it, binaryExpression, comparesToNull = false) {
+                raiseIssueIfUselessCheck(
+                    kotlinFileContext,
+                    it,
+                    binaryExpression,
+                    comparesToNull = false,
+                    requiredCompilerDiagnosticName = FirErrors.SENSELESS_COMPARISON.name,
+                ) {
                     +"non-null check"
                 }
             }
@@ -66,6 +79,7 @@ class UselessNullCheckCheck : AbstractCheck() {
                 binaryExpression.left!!,
                 binaryExpression.operationReference,
                 comparesToNull = false,
+                requiredCompilerDiagnosticName = FirErrors.USELESS_ELVIS.name,
             ) {
                 +"elvis operation "
                 code("?:")
@@ -80,6 +94,7 @@ class UselessNullCheckCheck : AbstractCheck() {
             safeDotExpression.receiverExpression,
             safeDotExpression.operationTokenNode.psi,
             comparesToNull = false,
+            requiredCompilerDiagnosticName = FirErrors.UNNECESSARY_SAFE_CALL.name,
         ) {
             +"null-safe access "
             code("?.")
@@ -93,6 +108,7 @@ class UselessNullCheckCheck : AbstractCheck() {
                 unaryExpression.baseExpression!!,
                 unaryExpression.operationReference,
                 comparesToNull = false,
+                requiredCompilerDiagnosticName = FirErrors.UNNECESSARY_NOT_NULL_ASSERTION.name,
             ) {
                 +"non-null assertion "
                 code("!!")
@@ -133,7 +149,8 @@ class UselessNullCheckCheck : AbstractCheck() {
         expression: KtExpression,
         issueLocation: PsiElement,
         comparesToNull: Boolean,
-        nullCheckTypeForMessage: Message.() -> Unit
+        requiredCompilerDiagnosticName: String? = null,
+        nullCheckTypeForMessage: Message.() -> Unit,
     ) {
         val resolvedExpression = expression.predictRuntimeValueExpression()
 
@@ -141,7 +158,10 @@ class UselessNullCheckCheck : AbstractCheck() {
             if (comparesToNull) "succeeds" else "fails"
         } else if (
         // We are not using the resolvedExpression on purpose here, as it can cause FPs. See SONARKT-373.
-            expression.isNotNullable()
+            expression.isNotNullable() && (
+                requiredCompilerDiagnosticName == null ||
+                    kfc.hasCompilerDiagnostic(requiredCompilerDiagnosticName, issueLocation)
+            )
         ) {
             if (comparesToNull) "fails" else "succeeds"
         } else {
@@ -155,6 +175,11 @@ class UselessNullCheckCheck : AbstractCheck() {
         }
     }
 }
+
+private fun KotlinFileContext.hasCompilerDiagnostic(factoryName: String, issueLocation: PsiElement): Boolean =
+    kaDiagnostics.any { diagnostic ->
+        diagnostic.factoryName == factoryName && diagnostic.psi.textRange.contains(issueLocation.textRange)
+    }
 
 private fun KtExpression.isNotNullable(): Boolean =
     when (this) {

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
@@ -57,6 +57,7 @@ class UselessNullCheckCheck : AbstractCheck() {
                     binaryExpression,
                     comparesToNull = true,
                     requiredCompilerDiagnosticName = FirErrors.SENSELESS_COMPARISON.name,
+                    diagnosticScope = binaryExpression,
                 ) {
                     +"null check"
                 }
@@ -69,6 +70,7 @@ class UselessNullCheckCheck : AbstractCheck() {
                     binaryExpression,
                     comparesToNull = false,
                     requiredCompilerDiagnosticName = FirErrors.SENSELESS_COMPARISON.name,
+                    diagnosticScope = binaryExpression,
                 ) {
                     +"non-null check"
                 }
@@ -80,6 +82,7 @@ class UselessNullCheckCheck : AbstractCheck() {
                 binaryExpression.operationReference,
                 comparesToNull = false,
                 requiredCompilerDiagnosticName = FirErrors.USELESS_ELVIS.name,
+                diagnosticScope = binaryExpression,
             ) {
                 +"elvis operation "
                 code("?:")
@@ -95,6 +98,7 @@ class UselessNullCheckCheck : AbstractCheck() {
             safeDotExpression.operationTokenNode.psi,
             comparesToNull = false,
             requiredCompilerDiagnosticName = FirErrors.UNNECESSARY_SAFE_CALL.name,
+            diagnosticScope = safeDotExpression,
         ) {
             +"null-safe access "
             code("?.")
@@ -109,6 +113,7 @@ class UselessNullCheckCheck : AbstractCheck() {
                 unaryExpression.operationReference,
                 comparesToNull = false,
                 requiredCompilerDiagnosticName = FirErrors.UNNECESSARY_NOT_NULL_ASSERTION.name,
+                diagnosticScope = unaryExpression,
             ) {
                 +"non-null assertion "
                 code("!!")
@@ -150,6 +155,7 @@ class UselessNullCheckCheck : AbstractCheck() {
         issueLocation: PsiElement,
         comparesToNull: Boolean,
         requiredCompilerDiagnosticName: String? = null,
+        diagnosticScope: PsiElement = issueLocation,
         nullCheckTypeForMessage: Message.() -> Unit,
     ) {
         val resolvedExpression = expression.predictRuntimeValueExpression()
@@ -160,7 +166,7 @@ class UselessNullCheckCheck : AbstractCheck() {
         // We are not using the resolvedExpression on purpose here, as it can cause FPs. See SONARKT-373.
             expression.isNotNullable() && (
                 requiredCompilerDiagnosticName == null ||
-                    kfc.hasCompilerDiagnostic(requiredCompilerDiagnosticName, issueLocation)
+                    kfc.hasCompilerDiagnostic(requiredCompilerDiagnosticName, diagnosticScope, issueLocation)
             )
         ) {
             if (comparesToNull) "fails" else "succeeds"
@@ -176,9 +182,16 @@ class UselessNullCheckCheck : AbstractCheck() {
     }
 }
 
-private fun KotlinFileContext.hasCompilerDiagnostic(factoryName: String, issueLocation: PsiElement): Boolean =
+private fun KotlinFileContext.hasCompilerDiagnostic(
+    factoryName: String,
+    scope: PsiElement,
+    issueLocation: PsiElement,
+): Boolean =
     kaDiagnostics.any { diagnostic ->
-        diagnostic.factoryName == factoryName && diagnostic.psi.textRange.contains(issueLocation.textRange)
+        // A diagnostic on an enclosing expression may also cover the issue location, so constrain it to this operation.
+        diagnostic.factoryName == factoryName &&
+                diagnostic.psi.textRange.contains(issueLocation.textRange) &&
+                scope.textRange.contains(diagnostic.psi.textRange)
     }
 
 private fun KtExpression.isNotNullable(): Boolean =

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UselessNullCheckCheck.kt
@@ -165,7 +165,7 @@ private fun KtExpression.isNotNullable(): Boolean =
             this@isNotNullable.expressionType?.let { resolvedType ->
                 resolvedType !is KaErrorType &&
                         resolvedType !is KaTypeParameterType &&
-                        !resolvedType.isMarkedNullable && !resolvedType.hasFlexibleNullability
+                        !resolvedType.isNullable && !resolvedType.hasFlexibleNullability
             }
         } == true
     }


### PR DESCRIPTION
This PR fixes two FPs:

### FP on nullable projections

The Analysis API represents elements read from out-projected arrays, including nullable `varargs`, as captured types. For `CapturedType(out T?)`, `isMarkedNullable` is false because the captured type itself is not marked with `?`, even though its upper bound allows `null`. S6619 consequently treated nullable elements as non-null and reported their null checks as useless.

Use `KaType.isNullable` so nullability is evaluated semantically, including type bounds. Add regression cases for nullable `varargs`, `requireNotNull`, and explicit out projections.

### FP on expressions with safe-call operators

Due to the upstream Kotlin Analysis API bug KT-66472 (https://youtrack.jetbrains.com/issue/KT-66472), `expressionType` returns the non-null selector type for convention operators pulled into a safe call. For example, it reports `String` for `container?.list[0]` and `Int` for `container?.number++`, although both complete expressions are nullable when container is null. S6619 trusted those types and incorrectly reported subsequent null checks as useless.

As a workaround, we require the corresponding Kotlin compiler diagnostic before reporting comparisons, Elvis operators, safe calls, or non-null assertions. These compiler diagnostics assert that the null check or null-safety operation is useless under the compiler's complete semantics, so S6619 treats them as the source of truth instead of relying on the incorrect Analysis API type. Add regression cases for indexed access and increment operators.

Part of AT-82

----
## Summary by Gitar

- **Bug fixes:**
    - Fixed false positives in `UselessNullCheckCheck` by validating required compiler diagnostics and fixing nullable type checks


<sub>This will update automatically on new commits.</sub>