### PR TITLE
SONARKT-817 Fix FPs on S1133: override functions and DeprecationLevel HIDDEN/ERROR

### DIFF
--- a/its/ruling/src/integrationTest/resources/expected/kotlin/corda/kotlin-S1133.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/corda/kotlin-S1133.json
@@ -31,10 +31,6 @@
 131,
 135
 ],
-"kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/crypto/CompositeSignature.kt": [
-32,
-52
-],
 "kotlin-corda-project:sources/kotlin/corda/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt": [
 151,
 167,
@@ -118,11 +114,7 @@
 "kotlin-corda-project:sources/kotlin/corda/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/User.kt": [
 10
 ],
-"kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/CordaClock.kt": [
-24
-],
 "kotlin-corda-project:sources/kotlin/corda/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt": [
-178,
 343
 ],
 "kotlin-corda-project:sources/kotlin/corda/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt": [

--- a/its/ruling/src/integrationTest/resources/expected/kotlin/kotlin/kotlin-S1133.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/kotlin/kotlin-S1133.json
@@ -21,8 +21,6 @@
 121
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/fileClasses/Deprecated.kt": [
-24,
-28,
 32
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/kotlin/VirtualFileKotlinClass.kt": [
@@ -133,12 +131,6 @@
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeepCopyIrTree.kt": [
 35
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtElement.kt": [
-28
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/psi/KtFile.kt": [
-161
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/psi/src/org/jetbrains/kotlin/script/KotlinScriptDefinition.kt": [
 53
 ],
@@ -195,9 +187,6 @@
 "kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/ModuleDescriptorImpl.kt": [
 64
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors/src/org/jetbrains/kotlin/resolve/constants/constantValues.kt": [
-123
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/core/reflection.jvm/src/kotlin/reflect/full/KClasses.kt": [
 72
 ],
@@ -213,11 +202,6 @@
 159,
 178
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/resolve/ModuleTestSourceInfo.kt": [
-20,
-28,
-36
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/IntentionBasedInspection.kt": [
 58
 ],
@@ -230,9 +214,6 @@
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptTemplatesProvider.kt": [
 25,
 33
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/debugger/KotlinPositionManager.kt": [
-349
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-maven/src/org/jetbrains/kotlin/idea/maven/PomFile.kt": [
 563
@@ -294,7 +275,6 @@
 37
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/annotations.kt": [
-12,
 16,
 20,
 24
@@ -302,12 +282,6 @@
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/concurrent.kt": [
 10,
 13
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/coreDeprecated.kt": [
-9,
-12,
-15,
-18
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/js.math.kt": [
 12,
@@ -340,41 +314,14 @@
 23,
 26
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/regex.kt": [
-174,
-179
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/src/kotlin/string.kt": [
-63
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/runtime/kotlin/jvm/JvmClassMapping.kt": [
-91
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/collections/MutableCollectionsJVM.kt": [
-15,
-20
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/jvm/src/kotlin/util/BigDecimals.kt": [
 47
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/MapAccessors.kt": [
 42
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/collections/MutableCollections.kt": [
-51
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/src/kotlin/text/Strings.kt": [
 315
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/test/kotlin/cases/special/hidden.kt": [
-4,
-6,
-9,
-12,
-15,
-19,
-21,
-25
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-annotations-jvm/src/kotlin/annotations/jvm/Annotations.kt": [
 26

--- a/its/ruling/src/integrationTest/resources/expected/kotlin/kotlin/kotlin-S1133.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/kotlin/kotlin-S1133.json
@@ -20,9 +20,6 @@
 118,
 121
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/fileClasses/Deprecated.kt": [
-32
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/load/kotlin/VirtualFileKotlinClass.kt": [
 59
 ],
@@ -199,8 +196,7 @@
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/ide-common/src/org/jetbrains/kotlin/idea/caches/resolve/resolutionApi.kt": [
 46,
-159,
-178
+159
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/IntentionBasedInspection.kt": [
 58

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeCheckSample.kt
@@ -40,15 +40,64 @@ typealias KtString = String // Noncompliant
 private operator fun KtString.minus(s: String) = this + s // Noncompliant
 
 class DeprecatedPrimaryConstructor @Deprecated("") constructor() { // Noncompliant
-//                                                 ^^^^^^^^^^^  
+//                                                 ^^^^^^^^^^^
 }
 
 var anonymousFunction = @Deprecated("") fun() { // Noncompliant
-//                      ^^^^^^^^^^^^^^^ 
+//                      ^^^^^^^^^^^^^^^
 }
 
 
 var anonymousClass = @Deprecated("") object : Any() { // Noncompliant
-//                   ^^^^^^^^^^^^^^^ 
+//                   ^^^^^^^^^^^^^^^
 
 }
+
+// region override functions implementing external/parent APIs should not be flagged
+
+open class BaseClass {
+    open fun legacyMethod(): Unit = Unit
+    open val legacyProp: String get() = ""
+}
+
+class DerivedClass : BaseClass() {
+    @Deprecated("Deprecated in parent class")
+    override fun legacyMethod(): Unit = Unit // Compliant - override, removal is not unilateral
+
+    @Deprecated("Deprecated in Java")
+    override val legacyProp: String get() = "" // Compliant - override property
+}
+
+fun interface LegacyInterface {
+    @Deprecated("")
+    fun interfaceMethod() // Noncompliant
+//      ^^^^^^^^^^^^^^^
+}
+
+class InterfaceImpl : LegacyInterface {
+    @Deprecated("Deprecated in Java")
+    override fun interfaceMethod() {} // Compliant - override
+}
+
+// endregion
+
+// region DeprecationLevel.HIDDEN and ERROR signals deliberate binary-compat lifecycle management
+
+@Deprecated("Hidden for binary compat", level = DeprecationLevel.HIDDEN)
+fun hiddenDeprecated() {} // Compliant
+
+@Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+class HiddenDeprecatedClass // Compliant
+
+@Deprecated("DO NOT CALL - compile-time guard", level = DeprecationLevel.ERROR)
+fun errorGuard() {} // Compliant
+
+@Deprecated("Error", level = DeprecationLevel.ERROR)
+class ErrorDeprecatedClass // Compliant
+
+// Explicit DeprecationLevel.WARNING still reports
+@Deprecated("Please migrate", level = DeprecationLevel.WARNING)
+fun explicitWarningFunction() {} // Noncompliant
+//  ^^^^^^^^^^^^^^^^^^^^^^^
+
+//endregion

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/DeprecatedCodeCheckSample.kt
@@ -56,16 +56,21 @@ var anonymousClass = @Deprecated("") object : Any() { // Noncompliant
 // region override functions implementing external/parent APIs should not be flagged
 
 open class BaseClass {
-    open fun legacyMethod(): Unit = Unit
+    @Deprecated("")
+    open fun legacyMethod(): Unit = Unit // Noncompliant
     open val legacyProp: String get() = ""
+    open var legacyVar: String = ""
 }
 
 class DerivedClass : BaseClass() {
     @Deprecated("Deprecated in parent class")
-    override fun legacyMethod(): Unit = Unit // Compliant - override, removal is not unilateral
+    override fun legacyMethod(): Unit = Unit // Compliant - override method
 
     @Deprecated("Deprecated in Java")
     override val legacyProp: String get() = "" // Compliant - override property
+
+    override var legacyVar: String = ""
+        @Deprecated("Deprecated in Java") get // Compliant - accessor of an override property
 }
 
 fun interface LegacyInterface {
@@ -99,5 +104,15 @@ class ErrorDeprecatedClass // Compliant
 @Deprecated("Please migrate", level = DeprecationLevel.WARNING)
 fun explicitWarningFunction() {} // Noncompliant
 //  ^^^^^^^^^^^^^^^^^^^^^^^
+
+@Deprecated("Hidden positional", ReplaceWith(""), DeprecationLevel.HIDDEN)
+fun hiddenPositional() {} // Compliant
+
+@Deprecated("Error positional", ReplaceWith(""), DeprecationLevel.ERROR)
+fun errorPositional() {} // Compliant
+
+@Deprecated("Warning positional", ReplaceWith(""), DeprecationLevel.WARNING)
+fun warningPositional() {} // Noncompliant
+//  ^^^^^^^^^^^^^^^^^
 
 //endregion

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeCheck.kt
@@ -46,11 +46,14 @@ class DeprecatedCodeCheck : AbstractCheck() {
 
 private fun KtAnnotationEntry.isOnOverriddenElement(): Boolean {
     val owner = annotatedElement()
-    return owner is KtModifierListOwner && owner.hasModifier(KtTokens.OVERRIDE_KEYWORD)
+    val declaration = if (owner is KtPropertyAccessor) owner.property else owner
+    return (declaration as? KtModifierListOwner)?.hasModifier(KtTokens.OVERRIDE_KEYWORD) == true
 }
 
 private fun KtAnnotationEntry.hasNonWarningDeprecationLevel(): Boolean {
+    // Deprecated(message, replaceWith, level): `level` may be passed by name or as 3rd positional arg
     val levelArg = valueArguments.find { it.getArgumentName()?.asName?.asString() == "level" }
+        ?: valueArguments.filter { it.getArgumentName() == null }.getOrNull(2)
         ?: return false
     val text = levelArg.getArgumentExpression()?.text ?: return false
     return text.endsWith("HIDDEN") || text.endsWith("ERROR")

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/DeprecatedCodeCheck.kt
@@ -17,8 +17,10 @@
 package org.sonarsource.kotlin.checks
 
 import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.StandardClassIds
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
@@ -33,15 +35,30 @@ import org.sonarsource.kotlin.api.visiting.withKaSession
 class DeprecatedCodeCheck : AbstractCheck() {
 
     override fun visitAnnotationEntry(annotationEntry: KtAnnotationEntry, context: KotlinFileContext) = withKaSession {
-        if (annotationEntry.typeReference?.type?.isClassType(StandardClassIds.Annotations.Deprecated) == true) {
+        if (annotationEntry.typeReference?.type?.isClassType(StandardClassIds.Annotations.Deprecated) == true
+            && !annotationEntry.isOnOverriddenElement()
+            && !annotationEntry.hasNonWarningDeprecationLevel()
+        ) {
             context.reportIssue(annotationEntry.elementToReport(), "Do not forget to remove this deprecated code someday.")
         }
     }
 }
 
+private fun KtAnnotationEntry.isOnOverriddenElement(): Boolean {
+    val owner = annotatedElement()
+    return owner is KtModifierListOwner && owner.hasModifier(KtTokens.OVERRIDE_KEYWORD)
+}
+
+private fun KtAnnotationEntry.hasNonWarningDeprecationLevel(): Boolean {
+    val levelArg = valueArguments.find { it.getArgumentName()?.asName?.asString() == "level" }
+        ?: return false
+    val text = levelArg.getArgumentExpression()?.text ?: return false
+    return text.endsWith("HIDDEN") || text.endsWith("ERROR")
+}
+
 private fun KtAnnotationEntry.elementToReport(): PsiElement =
     when (val annotated = annotatedElement()) {
-        // Deprecated Primary constructor should always have a "constructor" keyword 
+        // Deprecated Primary constructor should always have a "constructor" keyword
         is KtPrimaryConstructor -> annotated.getConstructorKeyword()!!
         is KtSecondaryConstructor -> annotated.getConstructorKeyword()
         is KtPropertyAccessor -> annotated.namePlaceholder

--- a/sonar-kotlin-plugin/src/main/resources/org/sonar/l10n/kotlin/rules/kotlin/S1133.html
+++ b/sonar-kotlin-plugin/src/main/resources/org/sonar/l10n/kotlin/rules/kotlin/S1133.html
@@ -5,4 +5,32 @@
 @Deprecated("") // Noncompliant
 class Example
 </pre>
+<h3>Exceptions</h3>
+<p>The following usages are not reported:</p>
+<ul>
+  <li><code>override</code> functions and properties. These implement an external API contract and cannot be removed unilaterally — the decision
+  belongs to the owner of the parent class or interface.
+    <pre>
+open class Base {
+    open fun legacyMethod() {}
+}
+
+class Derived : Base() {
+    @Deprecated("Deprecated in parent class")
+    override fun legacyMethod() {} // Compliant - removal depends on the parent API
+}
+</pre></li>
+  <li><code>@Deprecated</code> with <code>level = DeprecationLevel.HIDDEN</code>. This is the Kotlin-provided mechanism for controlled
+  binary-compatible removal and signals intentional lifecycle management beyond a plain warning.
+    <pre>
+@Deprecated("Hidden for binary compatibility", level = DeprecationLevel.HIDDEN)
+fun hiddenFunction() {} // Compliant
+</pre></li>
+  <li><code>@Deprecated</code> with <code>level = DeprecationLevel.ERROR</code>. This is used as a deliberate compile-time guard to prevent misuse,
+  not as forgotten code awaiting cleanup.
+    <pre>
+@Deprecated("DO NOT CALL - compile-time guard", level = DeprecationLevel.ERROR)
+fun errorGuard() {} // Compliant
+</pre></li>
+</ul>
 

--- a/sonar-kotlin-plugin/src/main/resources/org/sonar/l10n/kotlin/rules/kotlin/S1133.html
+++ b/sonar-kotlin-plugin/src/main/resources/org/sonar/l10n/kotlin/rules/kotlin/S1133.html
@@ -12,6 +12,7 @@ class Example
   belongs to the owner of the parent class or interface.
     <pre>
 open class Base {
+    @Deprecated("Will be removed in the next major release")
     open fun legacyMethod() {}
 }
 
@@ -20,14 +21,17 @@ class Derived : Base() {
     override fun legacyMethod() {} // Compliant - removal depends on the parent API
 }
 </pre></li>
-  <li><code>@Deprecated</code> with <code>level = DeprecationLevel.HIDDEN</code>. This is the Kotlin-provided mechanism for controlled
-  binary-compatible removal and signals intentional lifecycle management beyond a plain warning.
+  <li><code>@Deprecated</code> with <code>level = DeprecationLevel.HIDDEN</code>. <code>HIDDEN</code> is Kotlin’s language-provided mechanism for
+  controlled, binary-compatible removal: the declaration is invisible to source-level callers but still present in compiled bytecode for existing
+  consumers. Raising a "do not forget to remove this" warning here would be redundant noise — the developer has already taken a more deliberate step
+  than a plain <code>@Deprecated</code>, and the removal process is explicitly underway.
     <pre>
 @Deprecated("Hidden for binary compatibility", level = DeprecationLevel.HIDDEN)
 fun hiddenFunction() {} // Compliant
 </pre></li>
-  <li><code>@Deprecated</code> with <code>level = DeprecationLevel.ERROR</code>. This is used as a deliberate compile-time guard to prevent misuse,
-  not as forgotten code awaiting cleanup.
+  <li><code>@Deprecated</code> with <code>level = DeprecationLevel.ERROR</code>. <code>ERROR</code>-level deprecations are intentional compile-time
+  guards that prevent callers from using a declaration (for example, <code>DO NOT CALL</code> sentinels or deliberate overload-resolution blockers).
+  They are not legacy code awaiting cleanup — they are active API-design decisions, and removing them would change the public contract.
     <pre>
 @Deprecated("DO NOT CALL - compile-time guard", level = DeprecationLevel.ERROR)
 fun errorGuard() {} // Compliant


### PR DESCRIPTION
S1133 no longer flags:
- Deprecated `override` functions/properties — they implement an external API contract and cannot be removed unilaterally by the consumer.
- `@Deprecated` with `level = DeprecationLevel.HIDDEN` — the Kotlin mechanism for controlled binary-compatible removal.
- `@Deprecated` with `level = DeprecationLevel.ERROR` — a deliberate compile-time guard, not forgotten code.
