### PR TITLE
SONARKT-819 Authenticate git clones for build-logic/common submodule fetches

### DIFF
--- a/.github/actions/authenticate-git-clones/action.yml
+++ b/.github/actions/authenticate-git-clones/action.yml
@@ -1,0 +1,18 @@
+name: Authenticate git clones
+description: Configure git and gh to authenticate clone/fetch requests against GitHub, avoiding anonymous rate limits
+
+inputs:
+  gh_token:
+    description: GitHub token to authenticate with
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
+      run: |
+        gh auth setup-git
+        git config --global http.proactiveAuth auto  # authenticate on the first request, not after a 401, so cloning never counts as an anonymous GitHub request
+        git config --global url."https://github.com/".insteadOf "git@github.com:"  # so SSH submodule URLs are also authenticated via the credential helper above

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
         run: echo "GITHUB_JOB_ID=${{ job.check_run_id }}" >> $GITHUB_ENV
         shell: bash
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - &authenticate-git-clones
+        name: Authenticate git clones
+        uses: ./.github/actions/authenticate-git-clones
+        with:
+          gh_token: ${{ github.token }}
       - &checkout-build-logic
         id: checkout-build-logic
         run: git submodule update --init -- build-logic/common
@@ -92,6 +97,7 @@ jobs:
     steps:
       - *configure_GITHUB_JOB_ID_environment_variable
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - *authenticate-git-clones
       - *checkout-build-logic
       - *setup-mise
       - id: secrets


### PR DESCRIPTION
## Summary
Authenticate the CI submodule fetches for `build-logic/common` so they no longer count against GitHub's anonymous rate limits.

## Details
- Adds a reusable `.github/actions/authenticate-git-clones` composite action (same approach used in `peachee-cloud`): runs `gh auth setup-git` plus `git config --global http.proactiveAuth auto`, and additionally rewrites `git@github.com:` submodule URLs to authenticated HTTPS via `url.insteadOf`.
- Wires it in immediately before the raw `git submodule update --init -- build-logic/common` step, reused via YAML anchor across the `build` and `qa_plugin` jobs. `qa_ruling` already fetches submodules through `actions/checkout`'s own `submodules: true`, which is already authenticated, so it needs no change.
- No behavior change to what gets built or tested — purely CI plumbing.