### PR TITLE
SONARKT-821 Renovate should clone `build-logic`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,11 @@
   "schedule": [
     "before 4am on Monday"
   ],
+  // `build-logic/common` is required to configure the Gradle build
+  "cloneSubmodules": true,
+  "cloneSubmodulesFilter": [
+    "build-logic/common"
+  ],
   "enabledManagers": [
     "gradle",
     "gradle-wrapper",


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **Renovate Configuration:**
    - Enabled submodule cloning and filtering for `build-logic/common` in `.github/renovate.json5`

<sub>This will update automatically on new commits.</sub>