### PR TITLE
SONARKT-563 S107 Exclude @Composable functions from the rule

### DIFF
--- a/kotlin-checks-test-sources/src/main/kotlin/checks/TooManyParametersCheckSample.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/TooManyParametersCheckSample.kt
@@ -17,12 +17,16 @@ open class TooManyParametersCheckSample(p1: Int, p2: Int, p3: Int) {
     fun String.extension(p1: Int, p2: Int, p3: Int) = Unit
 
     annotation class GetMapping
+    annotation class Composable
 
     @GetMapping
     fun annotated(p1: Int, p2: Int, p3: Int) = Unit
 
     @checks.TooManyParametersCheckSample.GetMapping
     fun annotated2(p1: Int, p2: Int, p3: Int) = Unit
+
+    @Composable
+    fun composable(p1: Int, p2: Int, p3: Int) = Unit
 
     abstract class OverrideIsCompliant : TooManyParametersCheckSample() {
         override fun sample(p1: Int, p2: Int, p3: Int, p4: Int) = Unit

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooManyParametersCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/TooManyParametersCheck.kt
@@ -47,7 +47,8 @@ class TooManyParametersCheck : AbstractCheck() {
         "PutMapping",
         "DeleteMapping",
         "PatchMapping",
-        "JsonCreator")
+        "JsonCreator",
+        "Composable")
 
     override fun visitNamedFunction(function: KtNamedFunction, kotlinFileContext: KotlinFileContext) {
         if (function.valueParameters.size > max


### PR DESCRIPTION
----
## Summary by Gitar

- **Rule updates:**
    - Excluded `@Composable` functions from `TooManyParametersCheck` in `TooManyParametersCheck.kt`

<sub>This will update automatically on new commits.</sub>