### PR TITLE
SONARKT-825 Set SQS ticket edition and team in release workflow

### DIFF
--- a/.github/workflows/AutomateRelease.yml
+++ b/.github/workflows/AutomateRelease.yml
@@ -80,7 +80,7 @@ jobs:
       rule-metadata-pr-labels: "skip-pvf"
       slack-channel: "squad-security-cloud-notifs"
       create-sli-ticket: true
-      sqs-ticket-edition: "Community Build"
+      sqs-ticket-edition: "Community Build & Server"
       sqs-sqc-ticket-team: "f1da89c9-3712-4d15-b194-a4b24406e3e4"
       runner-environment: sonar-xs
       release-process: "https://xtranet-sonarsource.atlassian.net/wiki/x/RADLAQE"

--- a/.github/workflows/AutomateRelease.yml
+++ b/.github/workflows/AutomateRelease.yml
@@ -80,6 +80,8 @@ jobs:
       rule-metadata-pr-labels: "skip-pvf"
       slack-channel: "squad-security-cloud-notifs"
       create-sli-ticket: true
+      sqs-ticket-edition: "Community Build"
+      sqs-sqc-ticket-team: "f1da89c9-3712-4d15-b194-a4b24406e3e4"
       runner-environment: sonar-xs
       release-process: "https://xtranet-sonarsource.atlassian.net/wiki/x/RADLAQE"
       verbose: ${{ inputs.verbose }}


### PR DESCRIPTION
## Summary
- Add `sqs-ticket-edition: "Community Build & Server"` and `sqs-sqc-ticket-team` (UUID `f1da89c9-3712-4d15-b194-a4b24406e3e4`) to AutomateRelease.yml so the SQS/SQC integration tickets carry the correct Jira Edition and Team fields.

## Test plan
- [ ] Confirm workflow YAML is valid (actionlint/CI)