### PR TITLE
SONARKT-269,SONARKT-798 S1481 Fix FPs for unused variables with unresolved initializers

### DIFF
--- a/its/ruling/src/integrationTest/resources/expected/kotlin/corda/kotlin-S1481.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/corda/kotlin-S1481.json
@@ -4,12 +4,6 @@
 35,
 36
 ],
-"kotlin-corda-project:sources/kotlin/corda/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt": [
-194
-],
-"kotlin-corda-project:sources/kotlin/corda/node/src/test/kotlin/net/corda/node/internal/serialization/RoundTripObservableSerializerTests.kt": [
-98
-],
 "kotlin-corda-project:sources/kotlin/corda/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt": [
 96
 ],
@@ -26,11 +20,5 @@
 ],
 "kotlin-corda-project:sources/kotlin/corda/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/SerializationPropertyOrdering.kt": [
 38
-],
-"kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt": [
-178
-],
-"kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt": [
-332
 ]
 }

--- a/its/ruling/src/integrationTest/resources/expected/kotlin/intellij-rust/kotlin-S1481.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/intellij-rust/kotlin-S1481.json
@@ -1,5 +1,1 @@
-{
-"kotlin-intellij-rust-project:sources/kotlin/intellij-rust/src/test/kotlin/org/rust/lang/core/completion/RsCompletionPriorityTest.kt": [
-40
-]
-}
+{}

--- a/its/ruling/src/integrationTest/resources/expected/kotlin/kotlin/kotlin-S1481.json
+++ b/its/ruling/src/integrationTest/resources/expected/kotlin/kotlin/kotlin-S1481.json
@@ -1,49 +1,6 @@
 {
-"kotlin-kotlin-project:sources/kotlin/kotlin/build-common/test/org/jetbrains/kotlin/incremental/testingUtils/incrementalModificationUtils.kt": [
-95
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/buildSrc/src/main/kotlin/pill/render.kt": [
-30
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/compiler/android-tests/src/org/jetbrains/kotlin/android/tests/CodegenTestsOnAndroidRunner.kt": [
 170
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/InternalCompilerArgument.kt": [
-64
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/daemon/src/org/jetbrains/kotlin/daemon/KotlinCompileDaemon.kt": [
-143
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/platform/JvmDefaultSuperCallChecker.kt": [
-24
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/constants/evaluate/ConstantExpressionEvaluator.kt": [
-618,
-640,
-653
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt": [
-113,
-521
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/compiler/tests-common/tests/org/jetbrains/kotlin/test/MockLibraryUtil.kt": [
-115
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/core/descriptors.runtime/src/kotlin/reflect/jvm/internal/structure/ReflectJavaMember.kt": [
-93,
-94
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/CompletionSession.kt": [
-330
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/idea-jvm/src/org/jetbrains/kotlin/idea/configuration/ModuleSourceRootMap.kt": [
-39
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/BatchTemplateRunner.kt": [
-57
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/conventionNameCalls/ReplaceCallWithBinaryOperatorInspection.kt": [
-56
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/examples/kotlin-jsr223-daemon-local-eval-example/src/test/kotlin/org/jetbrains/kotlin/script/jsr223/KotlinJsr223ScriptEngineIT.kt": [
 145,
@@ -53,85 +10,34 @@
 221,
 224
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/scripting/common/src/kotlin/script/experimental/api/scriptingEnvironment.kt": [
-36
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/stdlib/js/runtime/arrayUtils.kt": [
 54,
 64
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/binary-compatibility-validator/src/main/kotlin/org.jetbrains.kotlin.tools/kotlinMetadataVisibilities.kt": [
-47
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/app/src/main/java/com/example/dagger/kotlin/UseRJavaActivity.kt": [
-7
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidJackProject/Android/src/androidTest/java/org/jetbrains/kotlin/gradle/InternalDummyApplicationTest.kt": [
-28
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/classpathTest/src/main/kotlin/helloWorld.kt": [
-10,
-11,
 12,
 13,
 14
 ],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidProject/libJvm/src/main/kotlin/javaLibUse.kt": [
-6
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformMultipleCommonModules/libJvm/src/main/kotlin/javaLibUse.kt": [
-6
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJvm/src/main/kotlin/javaLibUse.kt": [
-6
-],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectClassPathTest/subproject/src/main/kotlin/helloWorld.kt": [
-10,
-11,
 12,
 13,
 14
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/applyToSubprojects/subproject/src/main/kotlin/helloWorld.kt": [
-10,
-11,
 12,
 13,
 14
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinMultiplatformPlugin.kt": [
-163
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt": [
-104,
-191,
-194,
-199,
-221
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt": [
 525
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-maven-plugin-test/src/it/test-classpath/src/main/kotlin/org/jetbrains/HelloWorld.kt": [
-10,
-11,
 12,
 13,
 14
 ],
 "kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/Ranges.kt": [
 116
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/Templates.kt": [
-212
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt": [
-504
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/plugins/kapt3/kapt3-idea/src/org/jetbrains/kotlin/kapt/idea/KaptProjectResolverExtension.kt": [
-194
-],
-"kotlin-kotlin-project:sources/kotlin/kotlin/ultimate/src/org/jetbrains/kotlin/idea/spring/generate/generateDependenciesUtils.kt": [
-195
 ]
 }

--- a/kotlin-checks-test-sources/src/main/kotlin/checks/UnusedLocalVariableCheckSamplePartialSemantics.kt
+++ b/kotlin-checks-test-sources/src/main/kotlin/checks/UnusedLocalVariableCheckSamplePartialSemantics.kt
@@ -13,3 +13,43 @@ class UnusedLocalVariableCheckSamplePartialSemantics {
         foo.get(1)
     }
 }
+
+/**
+ * Reproduces the K2 false positive observed under partial semantics: a function-valued local has an
+ * error-typed initializer, then its later implicit invocation is not counted as a read.
+ * Plain-valued locals did not reproduce the issue.
+ */
+class FunctionValuedLocalWithUnresolvedInitializer {
+
+    fun functionValuedLocal(body: RequestBody) {
+        val contentLength = RequestBody::contentLength // Compliant, used to be a false positive with partial semantics.
+        contentLength(body)
+    }
+
+    fun delegatedFunctionValuedLocal(body: RequestBody) {
+        val contentLength by lazy { RequestBody::contentLength } // Compliant, used to be a false positive with partial semantics.
+        contentLength(body)
+    }
+
+    fun destructuredFunctionValuedLocal(body: RequestBody) {
+        val (contentLength) = Pair(RequestBody::contentLength, Unit) // Compliant, used to be a false positive with partial semantics.
+        contentLength(body)
+    }
+
+    fun plainValuedLocal(body: RequestBody) {
+        // Despite having an unresolved initializer, the later read of `plainValue` is still recognized by K2.
+        val plainValue = body.contentLength() // Compliant
+        plainValue.inc()
+    }
+
+    fun unusedPlainValueLocalWithUnresolvedInitializer(body: RequestBody) {
+        // Accepted FN: the workaround suppresses unused locals whose initializer has an error type.
+        val unusedValue = body.contentLength()
+    }
+
+    fun genuinelyUnusedVariableNextToUnresolvedCall(body: RequestBody) {
+        val unusedFunction = Int::inc // Noncompliant {{Remove this unused "unusedFunction" local variable.}}
+//          ^^^^^^^^^^^^^^
+        body.contentLength()
+    }
+}

--- a/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnusedLocalVariableCheck.kt
+++ b/sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/UnusedLocalVariableCheck.kt
@@ -17,23 +17,41 @@
 package org.sonarsource.kotlin.checks
 
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
+import org.jetbrains.kotlin.analysis.api.symbols.KaVariableSymbol
+import org.jetbrains.kotlin.analysis.api.types.KaClassType
+import org.jetbrains.kotlin.analysis.api.types.KaErrorType
+import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtVariableDeclaration
 import org.sonar.check.Rule
 import org.sonarsource.kotlin.api.checks.AbstractCheck
 import org.sonarsource.kotlin.api.frontend.KotlinFileContext
+import org.sonarsource.kotlin.api.visiting.withKaSession
 
 @Rule(key = "S1481")
 class UnusedLocalVariableCheck : AbstractCheck() {
 
     override fun visitKtFile(file: KtFile, context: KotlinFileContext) {
         context.kaDiagnostics
-            .filter {
-                it.factoryName == FirErrors.UNUSED_VARIABLE.name
-            }
+            .filter { it.factoryName == FirErrors.UNUSED_VARIABLE.name }
             .map { it.psi as KtNamedDeclaration }
+            .filterNot { it.hasUnresolvedType() }
             .forEach {
                 context.reportIssue(it.nameIdentifier!!, """Remove this unused "${it.name}" local variable.""")
             }
     }
 }
+
+/**
+ * K2's UNUSED_VARIABLE diagnostic is not reliable when semantic errors prevent it from determining
+ * the variable's type.
+ */
+private fun KtNamedDeclaration.hasUnresolvedType(): Boolean = withKaSession {
+    return ((this@hasUnresolvedType as? KtVariableDeclaration)?.symbol as? KaVariableSymbol)
+        ?.returnType
+        ?.containsErrorType() == true
+}
+
+private fun KaType.containsErrorType(): Boolean =
+    this is KaErrorType || (this is KaClassType && typeArguments.any { it.type?.containsErrorType() == true })

--- a/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnusedLocalVariableCheckTest.kt
+++ b/sonar-kotlin-checks/src/test/java/org/sonarsource/kotlin/checks/UnusedLocalVariableCheckTest.kt
@@ -29,6 +29,6 @@ class UnusedLocalVariableCheckTest : CheckTestWithNoSemantics(UnusedLocalVariabl
             this.fileName = "${checkName}SamplePartialSemantics.kt"
             this.classpath = DEFAULT_KOTLIN_CLASSPATH + System.getProperty("java.class.path").split(File.pathSeparatorChar)
             this.deps = emptyList()
-        }.verifyNoIssue()
+        }.verify()
     }
 }


### PR DESCRIPTION
K2 can report function-valued locals as unused when partial semantics
leave their initializer error-typed and their invocation unresolved.
Ignore these unreliable diagnostics, accepting possible false negatives
for genuinely unused locals with unresolved initializers.

This may introduce a non-negligible amount of FNs when analyzing with partial semantics,
but I think it is acceptable. This is not a critical rule and it is better to have FN than FP.

---

I sampled the ruling updates and as can be expected, the simple strategy introduces quite a few FNs because our ruling analysis is with partial semantics.
There are still cases where FPs are indeed fixed, e.g. in

```
kotlin-corda-project:sources/kotlin/corda/testing/test-utils/src/main/kotlin/net/corda/testing/core/Expect.kt
kotlin-corda-project:sources/kotlin/corda/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt
kotlin-kotlin-project:sources/kotlin/kotlin/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
```